### PR TITLE
Fix dead backend branches because they created unreachable logic and locals()-based ambiguity

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -1139,13 +1139,6 @@ def get_live_adaptation_state_for(user_id):
         return state if isinstance(state, dict) else {}
     except Exception:
         return {}
-        users = raw.get("users", {})
-        if not isinstance(users, dict):
-            return {}
-        state = users.get(user_id, {})
-        return state if isinstance(state, dict) else {}
-    except Exception:
-        return {}
 
 def _decision_label(decision):
     decision = str(decision or "").strip()
@@ -2935,8 +2928,8 @@ def get_today_plan():
         "fatigue_score": fatigue_score,
         "recovery_state": recovery_state,
         "template_id": template_id,
-        "template_mode": autoplan_meta.get("template_mode") if isinstance(locals().get("autoplan_meta"), dict) else None,
-        "families_selected": autoplan_meta.get("families_selected", []) if isinstance(locals().get("autoplan_meta"), dict) else [],
+        "template_mode": autoplan_meta.get("template_mode") if isinstance(autoplan_meta, dict) else None,
+        "families_selected": autoplan_meta.get("families_selected", []) if isinstance(autoplan_meta, dict) else [],
         "training_day_context": training_day_ctx if isinstance(training_day_ctx, dict) else {},
         "reason": reason,
         "days_since_last_strength": days_since_last_strength,


### PR DESCRIPTION
## Summary
This PR removes unreachable backend logic and replaces `locals()`-based conditional access with explicit checks.

## Changes
- removed unreachable code in `get_live_adaptation_state_for()`
- removed duplicate unreachable `except` path
- replaced `locals().get("autoplan_meta")` checks with explicit `isinstance(autoplan_meta, dict)` checks

## Why
This improves backend determinism and reduces ambiguity in core planning-related code without changing intended behavior.

## Validation
- `python3 -m py_compile app/backend/app.py`
- verified `get_live_adaptation_state_for()` contains a single reachable exception path
- verified `locals()` usage removed from the touched payload block

## Issue
Closes #1