### PR TITLE
Refactor storage access for session result deletion (Issue 3 – part 1)

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -153,6 +153,8 @@ def append_user_item(file_key, item):
 def get_latest_user_item(file_key, user_id, sort_keys=("created_at", "date")):
     return get_storage().get_latest_user_item(file_key, user_id, sort_keys=sort_keys)
 
+def delete_user_item(file_key, user_id, item_id):
+    return get_storage().delete_user_item(file_key, user_id, item_id)
 
 
 def get_iso_weekday_key(date_str):
@@ -364,28 +366,7 @@ def consume_manual_override_workout(user_id, date):
 
 
 def delete_session_result_for_user(user_id, session_result_id):
-    items = read_json_file(FILES["session_results"])
-    out = []
-    deleted = None
-
-    for item in items:
-        if not isinstance(item, dict):
-            out.append(item)
-            continue
-
-        same_user = str(item.get("user_id")) == str(user_id)
-        same_id = str(item.get("id", "")).strip() == str(session_result_id).strip()
-
-        if same_user and same_id and deleted is None:
-            deleted = item
-            continue
-
-        out.append(item)
-
-    if deleted is not None:
-        write_json_file(FILES["session_results"], out)
-
-    return deleted
+    return delete_user_item("session_results", user_id, session_result_id)
 
 def list_session_results_for_user(user_id):
     return list_user_items("session_results", user_id)

--- a/app/backend/storage.py
+++ b/app/backend/storage.py
@@ -66,6 +66,30 @@ class JSONStorage:
         items = self.list_user_items(file_key, user_id, sort_keys=sort_keys)
         return items[0] if items else None
 
+    def delete_user_item(self, file_key, user_id, item_id):
+        items = self._read_list(file_key)
+        out = []
+        deleted = None
+
+        for item in items:
+            if not isinstance(item, dict):
+                out.append(item)
+                continue
+
+            same_user = str(item.get("user_id")) == str(user_id)
+            same_id = str(item.get("id", "")).strip() == str(item_id).strip()
+
+            if same_user and same_id and deleted is None:
+                deleted = item
+                continue
+
+            out.append(item)
+
+        if deleted is not None:
+            self._write_list(file_key, out)
+
+        return deleted
+
     def get_user_settings_for(self, user_id):
         raw = self._read_object("user_settings")
         if not isinstance(raw, dict):
@@ -242,6 +266,32 @@ class SQLiteStorage:
     def get_latest_user_item(self, file_key, user_id, sort_keys=("created_at", "date")):
         items = self.list_user_items(file_key, user_id, sort_keys=sort_keys)
         return items[0] if items else None
+
+    def delete_user_item(self, file_key, user_id, item_id):
+        table_map = {
+            "workouts": "workouts",
+            "checkins": "checkins",
+            "session_results": "session_results",
+        }
+        table = table_map[file_key]
+
+        with self._conn() as conn:
+            row = conn.execute(
+                f"SELECT * FROM {table} WHERE user_id = ? AND id = ?",
+                (str(user_id), str(item_id))
+            ).fetchone()
+
+            if not row:
+                return None
+
+            deleted = self._normalize_row(file_key, row)
+            conn.execute(
+                f"DELETE FROM {table} WHERE user_id = ? AND id = ?",
+                (str(user_id), str(item_id))
+            )
+            conn.commit()
+
+        return deleted
 
     def get_user_settings_for(self, user_id):
         with self._conn() as conn:


### PR DESCRIPTION
## Summary
This PR introduces a storage-layer delete operation and routes session result deletion through the storage abstraction.

## Changes
- added `delete_user_item(file_key, user_id, item_id)` to:
  - JSONStorage
  - SQLiteStorage
- added wrapper in app layer
- refactored `delete_session_result_for_user()` to use storage layer instead of direct file I/O

## Why
Backend logic previously bypassed the storage abstraction and operated directly on JSON files.

This creates:
- inconsistent data access patterns
- difficulty switching storage backends
- duplicated logic

This PR introduces a minimal, safe step toward unified storage access.

## Scope
This is **part 1 of Issue 3**.  
Only session result deletion is refactored in this PR.

## Validation
- `python3 -m py_compile app/backend/storage.py`
- `python3 -m py_compile app/backend/app.py`
- verified delete flow works through storage layer
- diff limited to storage + one call site

## Issue
Related to #3