### PR TITLE
Refactor storage access for manual override consumption (Issue 3 – part 2)

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -157,6 +157,10 @@ def delete_user_item(file_key, user_id, item_id):
     return get_storage().delete_user_item(file_key, user_id, item_id)
 
 
+
+def consume_manual_override_workout_storage(user_id, date):
+    return get_storage().consume_manual_override_workout(user_id, date)
+
 def get_iso_weekday_key(date_str):
     date_str = str(date_str or "").strip()
     if not date_str:
@@ -343,26 +347,8 @@ def create_checkin(user_id, payload):
 
 
 def consume_manual_override_workout(user_id, date):
-    items = read_json_file(FILES["workouts"])
-    changed = False
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        if str(item.get("user_id")) != str(user_id):
-            continue
-        if str(item.get("date", "")).strip() != str(date).strip():
-            continue
-        if not bool(item.get("is_manual_override", False)):
-            continue
-        if bool(item.get("is_consumed", False)):
-            continue
-        item["is_consumed"] = True
-        changed = True
+    return consume_manual_override_workout_storage(user_id, date)
 
-    if changed:
-        write_json_file(FILES["workouts"], items)
-
-    return changed
 
 
 def delete_session_result_for_user(user_id, session_result_id):

--- a/app/backend/storage.py
+++ b/app/backend/storage.py
@@ -90,6 +90,31 @@ class JSONStorage:
 
         return deleted
 
+    
+    def consume_manual_override_workout(self, user_id, date):
+        items = self._read_list("workouts")
+        changed = False
+
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("user_id")) != str(user_id):
+                continue
+            if str(item.get("date", "")).strip() != str(date).strip():
+                continue
+            if not bool(item.get("is_manual_override", False)):
+                continue
+            if bool(item.get("is_consumed", False)):
+                continue
+
+            item["is_consumed"] = True
+            changed = True
+
+        if changed:
+            self._write_list("workouts", items)
+
+        return changed
+
     def get_user_settings_for(self, user_id):
         raw = self._read_object("user_settings")
         if not isinstance(raw, dict):
@@ -292,6 +317,27 @@ class SQLiteStorage:
             conn.commit()
 
         return deleted
+
+    
+
+    
+    def consume_manual_override_workout(self, user_id, date):
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT * FROM workouts WHERE user_id = ? AND date = ? AND is_manual_override = 1 AND is_consumed = 0 LIMIT 1",
+                (str(user_id), str(date).strip())
+            ).fetchone()
+
+            if not row:
+                return False
+
+            conn.execute(
+                "UPDATE workouts SET is_consumed = 1 WHERE user_id = ? AND date = ? AND is_manual_override = 1 AND is_consumed = 0",
+                (str(user_id), str(date).strip())
+            )
+            conn.commit()
+
+        return True
 
     def get_user_settings_for(self, user_id):
         with self._conn() as conn:


### PR DESCRIPTION
## Summary
This PR routes manual override workout consumption through the backend storage abstraction.

## Changes
- added `consume_manual_override_workout(user_id, date)` to:
  - JSONStorage
  - SQLiteStorage
- added app-layer wrapper
- refactored `consume_manual_override_workout()` to delegate to storage layer instead of direct file I/O

## Why
Workout state mutation still bypassed the storage abstraction and directly read/mutated/wrote JSON in app-layer code.

This PR moves that mutation into the storage backend so storage behavior is more consistent across backends.

## Scope
This is part 2 of Issue 3.  
Only manual override consumption is refactored in this PR.

## Validation
- python3 -m py_compile app/backend/storage.py
- python3 -m py_compile app/backend/app.py

## Issue
Related to #<issue-3-number>