### PR TITLE
Refactor weekly status loading to use storage abstraction (Issue 3 – part 3)

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -3052,11 +3052,7 @@ def build_weekly_training_status(user_id, checkin_date, training_day_prefs, week
     status["allowed_days_total"] = allowed_days_total
     status["allowed_days_remaining"] = allowed_days_remaining
 
-    try:
-        session_results = read_json_file(FILES["session_results"])
-    except Exception:
-        session_results = []
-
+    session_results = list_session_results_for_user(user_id)
     if not isinstance(session_results, list):
         session_results = []
 


### PR DESCRIPTION
## Summary
This PR routes weekly status session-result loading through the backend storage abstraction.

## Changes
- replaced direct `read_json_file(FILES["session_results"])` usage in `build_weekly_training_status()`
- now uses `list_session_results_for_user(user_id)` instead

## Why
Weekly status is based on user-specific session data and should not bypass the storage abstraction.

This change improves:
- consistency across storage modes
- backend maintainability
- alignment with the storage-layer refactor in Issue 3

## Scope
This is part 3 of Issue 3.  
Only weekly status loading is refactored in this PR.

## Validation
- `python3 -m py_compile app/backend/app.py`
- verified weekly status now uses storage wrapper
- verified diff is limited to one targeted replacement

## Issue
Related to #<issue-3-number>