### PR TITLE
Refactor today-plan session result loading to use storage abstraction

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2477,8 +2477,7 @@ def get_today_plan():
     if latest_strength:
         days_since_last_strength = days_between_iso_dates(checkin_date, latest_strength.get("date", ""))
 
-    session_results = read_json_file(FILES["session_results"])
-    session_results = filter_items_for_user(session_results, auth_user.get("user_id"))
+    session_results = list_session_results_for_user(auth_user.get("user_id"))
     recommendations = read_json_file(FILES["recommendations"])
     previous_recommendation = recommendations[-1] if recommendations else None
 


### PR DESCRIPTION
## Summary
This PR routes `session_results` loading in `get_today_plan()` through the backend storage abstraction.

## Changes
- replaced direct `read_json_file(FILES["session_results"])` usage
- removed manual `filter_items_for_user(...)` step
- now uses `list_session_results_for_user(auth_user.get("user_id"))`

## Why
`session_results` in `get_today_plan()` are user-specific and should not bypass the storage abstraction.

This improves:
- consistency across storage modes
- readability in the planning flow
- alignment with the ongoing storage cleanup

## Scope
This is a small targeted storage-refactor step.  
Only `session_results` loading in `get_today_plan()` is changed.

## Validation
- `python3 -m py_compile app/backend/app.py`
- verified today-plan now uses storage wrapper for session results
- verified diff is limited to one targeted replacement

## Issue
Related to #3 