### PR TITLE
Refactor today-plan workout loading to use storage abstraction

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2373,8 +2373,7 @@ def get_today_plan():
         return auth_err
     checkins = read_json_file(FILES["checkins"])
     checkins = filter_items_for_user(checkins, auth_user.get("user_id"))
-    workouts = read_json_file(FILES["workouts"])
-    workouts = filter_items_for_user(workouts, auth_user.get("user_id"))
+    workouts = list_workouts_for_user(auth_user.get("user_id"))
     programs = read_json_file(FILES["programs"])
     exercises = read_json_file(FILES["exercises"])
 


### PR DESCRIPTION
## Summary
This PR routes `workouts` loading in `get_today_plan()` through the backend storage abstraction.

## Changes
- replaced direct `read_json_file(FILES["workouts"])` usage
- removed manual `filter_items_for_user(...)` step
- now uses `list_workouts_for_user(auth_user.get("user_id"))`

## Why
`workouts` in `get_today_plan()` are user-specific and should not bypass the storage abstraction.

This improves:
- consistency across storage modes
- readability in the planning flow
- alignment with the ongoing storage cleanup

## Scope
This is a small targeted storage-refactor step.  
Only `workouts` loading in `get_today_plan()` is changed.

## Validation
- `python3 -m py_compile app/backend/app.py`
- verified today-plan now uses storage wrapper for workouts
- verified diff is limited to one targeted replacement

## Issue
Related to #3 