### PR TITLE
Refactor today-plan checkin loading to use storage abstraction

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2371,8 +2371,7 @@ def get_today_plan():
     auth_user, auth_err = require_auth_user()
     if auth_err:
         return auth_err
-    checkins = read_json_file(FILES["checkins"])
-    checkins = filter_items_for_user(checkins, auth_user.get("user_id"))
+    checkins = list_user_items("checkins", auth_user.get("user_id"))
     workouts = list_workouts_for_user(auth_user.get("user_id"))
     programs = read_json_file(FILES["programs"])
     exercises = read_json_file(FILES["exercises"])


### PR DESCRIPTION
## Summary
This PR routes `checkins` loading in `get_today_plan()` through the backend storage abstraction.

## Changes
- replaced direct `read_json_file(FILES["checkins"])` usage
- removed manual `filter_items_for_user(...)` step
- now uses `list_user_items("checkins", auth_user.get("user_id"))`

## Why
`checkins` in `get_today_plan()` are user-specific and should not bypass the storage abstraction.

This improves:
- consistency across storage modes
- readability in the planning flow
- alignment with the ongoing storage cleanup

## Scope
This is a small targeted storage-refactor step.  
Only `checkins` loading in `get_today_plan()` is changed.

## Validation
- `python3 -m py_compile app/backend/app.py`
- verified today-plan now uses storage wrapper for checkins
- verified diff is limited to one targeted replacement

## Issue
Related to #3 