### PR TITLE
Refactor today-plan context cleanup because orchestration should not rebuild shared state after manual override (Issue 5 part 3)

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2538,10 +2538,6 @@ def get_today_plan():
             readiness_score=readiness_score,
             manual_override=manual_override,
         )
-    time_budget_min = int(latest_checkin.get("time_budget_min", 45) or 45)
-    checkin_date = latest_checkin.get("date", "")
-    user_settings = get_user_settings_for(auth_user.get("user_id"))
-    training_day_ctx = get_training_day_context(user_settings, checkin_date)
 
     latest_strength = find_latest_strength_workout(workouts)
     days_since_last_strength = None


### PR DESCRIPTION
## Summary
Remove redundant shared-context reconstruction in `get_today_plan()` after the manual override path.

## Changes
- removed duplicated reassignment of:
  - `time_budget_min`
  - `checkin_date`
  - `user_settings`
  - `training_day_ctx`
- continue using values already derived from shared today-plan context

## Why
`get_today_plan()` already builds shared context earlier in the flow.
Rebuilding the same values after the manual override early-return path created unnecessary duplication and future drift risk.

## Scope
Part 3 of "Refactor today-plan into structured orchestration flow".
Only redundant context reconstruction is removed.

## Validation
- `python3 -m py_compile app/backend/app.py`
- verified flow now proceeds directly from manual-override branch to next planning step
- verified no planning logic changes

## Notes
Pure structural cleanup. No decision logic changes.