### PR TITLE
Replace silent storage fallbacks with visible error handling

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -194,6 +194,13 @@ def list_user_items(file_key, user_id, sort_keys=("created_at", "date")):
 def append_user_item(file_key, item):
     return get_storage().append_item(file_key, item)
 
+def get_storage_last_error():
+    storage = get_storage()
+    getter = getattr(storage, "get_last_error", None)
+    if callable(getter):
+        return getter()
+    return None
+
 def get_latest_user_item(file_key, user_id, sort_keys=("created_at", "date")):
     return get_storage().get_latest_user_item(file_key, user_id, sort_keys=sort_keys)
 
@@ -2566,6 +2573,14 @@ def get_today_plan():
     if auth_err:
         return auth_err
     checkins = list_user_items("checkins", auth_user.get("user_id"))
+    checkins_error = get_storage_last_error()
+    if checkins_error and checkins_error.get("file_key") == "checkins":
+        return jsonify({
+            "ok": False,
+            "error": "storage_error",
+            "source": "checkins",
+        })
+
     workouts = list_workouts_for_user(auth_user.get("user_id"))
     programs = read_json_file(FILES["programs"])
     exercises = read_json_file(FILES["exercises"])

--- a/app/backend/storage.py
+++ b/app/backend/storage.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 class JSONStorage:
     def __init__(self, data_dir):
         self.data_dir = Path(data_dir)
+        self._last_error = None
 
     def _path(self, file_key):
         return self.data_dir / f"{file_key}.json"
@@ -32,18 +33,35 @@ class JSONStorage:
         finally:
             lock_file.close()
 
+    def _set_last_error(self, file_key, operation, message):
+        self._last_error = {
+            "file_key": file_key,
+            "operation": operation,
+            "message": message,
+        }
+
+    def _clear_last_error(self):
+        self._last_error = None
+
+    def get_last_error(self):
+        return dict(self._last_error) if isinstance(self._last_error, dict) else None
+
     def _read_list(self, file_key):
         path = self._path(file_key)
         if not path.exists():
+            self._clear_last_error()
             return []
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             if isinstance(data, list):
+                self._clear_last_error()
                 return data
             logger.error("JSONStorage expected list in %s but got %s", path, type(data).__name__)
+            self._set_last_error(file_key, "read_list", f"expected list but got {type(data).__name__}")
             return []
         except Exception:
             logger.exception("JSONStorage failed to read list from %s", path)
+            self._set_last_error(file_key, "read_list", "exception while reading list")
             return []
 
     def _write_list(self, file_key, data):
@@ -53,15 +71,19 @@ class JSONStorage:
     def _read_object(self, file_key):
         path = self._path(file_key)
         if not path.exists():
+            self._clear_last_error()
             return {}
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             if isinstance(data, dict):
+                self._clear_last_error()
                 return data
             logger.error("JSONStorage expected dict in %s but got %s", path, type(data).__name__)
+            self._set_last_error(file_key, "read_object", f"expected dict but got {type(data).__name__}")
             return {}
         except Exception:
             logger.exception("JSONStorage failed to read object from %s", path)
+            self._set_last_error(file_key, "read_object", "exception while reading object")
             return {}
 
     def _write_object(self, file_key, data):


### PR DESCRIPTION
## Summary
Adds visible storage error tracking in JSON storage and surfaces checkin read failures in `/api/today-plan`.

## Changes
- added last-error tracking in `JSONStorage`:
  - `self._last_error`
  - `_set_last_error(...)`
  - `_clear_last_error()`
  - `get_last_error()`
- `_read_list(...)` and `_read_object(...)` now:
  - clear last error on success / missing-file empty state
  - store last error on type mismatch or read/parse failure
- added `get_storage_last_error()` app-layer helper
- `/api/today-plan` now returns a visible storage error when `checkins` failed to load:
  - `{ "ok": false, "error": "storage_error", "source": "checkins" }`

## Why
Previously, a corrupted or unreadable `checkins` file could silently look like a legitimate empty state (`no_checkin`).

This change is the first controlled step toward propagating critical storage failures without broadly changing backend behavior.

## Scope
- JSON storage observability only
- one endpoint propagation target: `/api/today-plan`
- one storage source: `checkins`
- no HTTP status redesign yet

## Validation
- `python3 -m py_compile app/backend/storage.py`
- `python3 -m py_compile app/backend/app.py`
- verified `today-plan` checks `get_storage_last_error()` after loading checkins
- verified storage read paths still preserve existing fallback contract for non-propagated callers

## Notes
This is a controlled, non-breaking first step in replacing silent storage fallbacks with visible error handling.

Closes #7