### PR TITLE
Persist today-plan decision traces

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2714,6 +2714,23 @@ def log_today_plan_decision(auth_user, checkin_date, session_type, template_id, 
     )
 
 
+def append_today_plan_trace(user_id, trace):
+    if not isinstance(trace, dict):
+        return
+
+    item = {
+        "id": str(uuid.uuid4()),
+        "user_id": user_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        **trace,
+    }
+
+    try:
+        append_user_item("today_plan_traces", item)
+    except Exception:
+        logger.exception("today_plan_trace_write_failed")
+
+
 def validate_today_plan_item(item):
     if not isinstance(item, dict):
         return {
@@ -3272,6 +3289,19 @@ def get_today_plan():
     }
 
     item = validate_today_plan_item(item)
+
+    append_today_plan_trace(
+        auth_user.get("user_id"),
+        {
+            "date": checkin_date,
+            "session_type": item.get("session_type"),
+            "template_id": item.get("template_id"),
+            "plan_variant": item.get("plan_variant"),
+            "reason": item.get("reason"),
+            "readiness_score": item.get("readiness_score"),
+            "fatigue_score": item.get("fatigue_score"),
+        }
+    )
 
     return jsonify({
         "ok": True,


### PR DESCRIPTION
## Summary
Adds minimal persisted decision traces for `today-plan`.

## Changes
- added `append_today_plan_trace(...)`
- stores a compact append-only trace for each normal `today-plan` response
- trace includes:
  - `date`
  - `user_id`
  - `session_type`
  - `template_id`
  - `plan_variant`
  - `reason`
  - `readiness_score`
  - `fatigue_score`
- logs trace write failure without breaking normal response flow

## Why
Logs and debug endpoints help inspect current behavior, but they do not provide a lightweight persisted history of plan decisions.

This change makes it easier to inspect how decision behavior changes over time without adding a new storage system or changing the API response.

## Scope
- backend only
- append-only trace storage
- no changes to existing `today-plan` response shape

## Validation
- `python3 -m py_compile app/backend/app.py`
- direct local test verified `today_plan_traces` append is called with expected fields