### PR TITLE
Enforce i18n for decision trace UI

### DIFF
--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -416,5 +416,10 @@
   "profile.weekly_target_6": "6 pas",
   "button.reset_catalog_from_seed": "Reset øvelser og programmer",
   "status.resetting_catalog": "Nulstiller øvelser og programmer fra seed...",
-  "status.catalog_reset_done": "Øvelser og programmer blev nulstillet fra seed."
+  "status.catalog_reset_done": "Øvelser og programmer blev nulstillet fra seed.",
+  "decision_trace.rule": "Regel: {value}",
+  "decision_trace.readiness_bucket": "Parathed: {value}",
+  "decision_trace.fatigue_bucket": "Belastning: {value}",
+  "decision_trace.timing": "Timing: {value}",
+  "decision_trace.override": "Override: {value}"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -404,5 +404,10 @@
   "profile.weekly_target_6": "6 sessions",
   "button.reset_catalog_from_seed": "Reset exercises and programs",
   "status.resetting_catalog": "Resetting exercises and programs from seed...",
-  "status.catalog_reset_done": "Exercises and programs were reset from seed."
+  "status.catalog_reset_done": "Exercises and programs were reset from seed.",
+  "decision_trace.rule": "Rule: {value}",
+  "decision_trace.readiness_bucket": "Readiness: {value}",
+  "decision_trace.fatigue_bucket": "Fatigue: {value}",
+  "decision_trace.timing": "Timing: {value}",
+  "decision_trace.override": "Override: {value}"
 }


### PR DESCRIPTION
## Summary
Removes hardcoded decision trace labels and replaces them with i18n keys.

## Changes
- added decision trace labels to language files
- replaced inline hardcoded strings in today-plan rendering
- preserved existing UI behavior while making labels translatable

## Why
Hardcoded labels break language consistency and undermine the existing i18n structure.

## Scope
- frontend only
- no behavior changes

## Validation
- `node --check app/frontend/app.js`
- verified hardcoded decision-trace labels were removed