### PR TITLE
Add today-plan trace history endpoint

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -3358,7 +3358,41 @@ def get_today_plan():
     })
 
 
+@app.get("/api/admin/today-plan-traces")
+def get_today_plan_traces():
+    auth_user, auth_err = require_auth_user()
+    if auth_err:
+        log_auth_failure("admin:today-plan-traces", auth_err)
+        return auth_err
 
+    user_id = auth_user.get("user_id")
+
+    items = list_user_items("today_plan_traces", user_id)
+
+    # defensive check
+    if not isinstance(items, list):
+        return jsonify({
+            "ok": False,
+            "error": "storage_error",
+            "message": "Kunne ikke læse today_plan_traces"
+        }), 500
+
+    # newest first
+    items_sorted = sorted(
+        items,
+        key=lambda x: str(x.get("created_at", "")),
+        reverse=True
+    )
+
+    # hard limit
+    limit = 50
+    items_limited = items_sorted[:limit]
+
+    return jsonify({
+        "ok": True,
+        "items": items_limited,
+        "count": len(items_limited)
+    })
 
 
 @app.post("/api/admin/reset-catalog")


### PR DESCRIPTION
## Summary
Adds an authenticated API endpoint for reading persisted today-plan traces.

## Changes
- added `GET /api/admin/today-plan-traces`
- returns current user's persisted today-plan traces
- sorts traces newest first
- limits response size to 50 items
- logs auth failures through existing structured logging path

## Why
Today-plan decisions are already persisted, but there was no API endpoint to inspect them over time.

This endpoint makes decision history accessible for debugging, review and future pattern-based features.

## Scope
- backend only
- read-only endpoint
- no changes to today-plan decision behavior

## Validation
- `python3 -m py_compile app/backend/app.py`
- verified endpoint exists and reads `today_plan_traces`
- local endpoint test confirmed sorted trace response and count