### PR TITLE
Validate today-plan query parameters

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2839,6 +2839,16 @@ def validate_today_plan_item(item):
 
 @app.get("/api/today-plan")
 def get_today_plan():
+    query_args = request.args or {}
+    allowed_query_params = set()
+    unexpected_query_params = sorted([key for key in query_args.keys() if key not in allowed_query_params])
+    if unexpected_query_params:
+        return jsonify(make_error_payload(
+            "invalid_query_params",
+            "ukendte query parametre",
+            fields=unexpected_query_params,
+        )), 400
+
     auth_user, auth_err = require_auth_user()
     if auth_err:
         log_auth_failure("today-plan", auth_err)


### PR DESCRIPTION
## Summary
Adds explicit query-parameter validation for the today-plan endpoint.

## Changes
- `GET /api/today-plan` now rejects unexpected query parameters
- returns a structured 400 error with:
  - `error: invalid_query_params`
  - `message: ukendte query parametre`
  - `fields: [...]`

## Why
The endpoint currently accepts no query parameters.
Silently ignoring unsupported params makes the API contract ambiguous and harder to debug.

This change makes the contract explicit and fail-fast.

## Scope
- backend only
- no behavior changes for valid today-plan requests
- only affects requests with unexpected query params

## Validation
- `python3 -m py_compile app/backend/app.py`
- direct endpoint test confirmed unexpected query params return structured 400 response