### PR TITLE
Enforce i18n for decision trace UI

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2410,12 +2410,32 @@ function renderTodayPlan(item){
   const motorSummary = tr("plan.motor_summary", { value: planMotorLabel });
   const familiesSummary = familiesSelectedText ? tr("plan.selected_families", { value: familiesSelectedText }) : "";
 
+  const decisionTrace = item?.decision_trace && typeof item.decision_trace === "object" ? item.decision_trace : null;
+  const decisionBits = [];
+  if (decisionTrace?.rule_applied) {
+    decisionBits.push(tr("decision_trace.rule", { value: decisionTrace.rule_applied }));
+  }
+  if (decisionTrace?.readiness_bucket) {
+    decisionBits.push(tr("decision_trace.readiness_bucket", { value: decisionTrace.readiness_bucket }));
+  }
+  if (decisionTrace?.fatigue_bucket) {
+    decisionBits.push(tr("decision_trace.fatigue_bucket", { value: decisionTrace.fatigue_bucket }));
+  }
+  if (decisionTrace?.timing) {
+    decisionBits.push(tr("decision_trace.timing", { value: decisionTrace.timing }));
+  }
+  if (decisionTrace?.override) {
+    decisionBits.push(tr("decision_trace.override", { value: decisionTrace.override }));
+  }
+  const decisionTraceSummary = decisionBits.length ? decisionBits.join(" · ") : "";
+
   setText(
     "todayPlanSummary",
     [
       baseSummary,
       recoveryDaySummary,
       motorSummary,
+      decisionTraceSummary,
       familiesSummary,
       trainingDaySummary,
       trainingAllowedSummary,


### PR DESCRIPTION
## Summary
Replaces hardcoded decision-trace labels in the today-plan UI with i18n keys.

## Changes
- uses `tr(...)` for decision-trace labels in `renderTodayPlan(...)`
- renders localized labels for:
  - rule
  - readiness bucket
  - fatigue bucket
  - timing
  - override
- reuses existing i18n keys in `da.json` and `en.json`

## Why
Decision-trace data was already available in the response, but user-facing labels must follow the same i18n rules as the rest of the UI.

This keeps language switching consistent and avoids hardcoded frontend text.

## Scope
- frontend only
- today-plan summary rendering only
- no behavior changes to backend or planning logic

## Validation
- `node --check app.js`
- verified decision-trace rendering uses `tr(...)` keys