### PR TITLE
Add continuity window and gap-based filtering to strength progression history

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -18,6 +18,7 @@ from progression_engine import (
     parse_top_rep,
     parse_seconds_value,
     analyze_session_result_for_progression,
+    get_relevant_strength_history,
     decide_progression_from_context,
 )
 

--- a/app/backend/progression_engine.py
+++ b/app/backend/progression_engine.py
@@ -249,7 +249,103 @@ def parse_session_sort_datetime(session):
     return None
 
 
-def get_relevant_strength_history(session_results, exercise_id, max_items=6):
+
+def normalize_dt_for_compare(dt):
+    if dt is None:
+        return None
+    try:
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt
+    except Exception:
+        return None
+
+
+def days_between_datetimes(newer, older):
+    newer_dt = normalize_dt_for_compare(newer)
+    older_dt = normalize_dt_for_compare(older)
+    if newer_dt is None or older_dt is None:
+        return None
+    try:
+        return max(0, (newer_dt - older_dt).days)
+    except Exception:
+        return None
+
+
+def get_relevant_strength_history(session_results, exercise_id, max_items=6, recent_days=42, continuity_gap_days=14):
+    history = []
+    exercise_id = str(exercise_id or "").strip()
+    newest_relevant_dt = None
+    previous_kept_dt = None
+
+    if not exercise_id:
+        return history
+
+    for session in reversed(session_results or []):
+        if not isinstance(session, dict):
+            continue
+
+        session_type = str(session.get("session_type", "")).strip().lower()
+        if session_type != "strength":
+            continue
+
+        results = session.get("results", [])
+        if not isinstance(results, list) or not results:
+            continue
+
+        matched_result = None
+        for result in reversed(results):
+            if not isinstance(result, dict):
+                continue
+            if str(result.get("exercise_id", "")).strip() == exercise_id:
+                matched_result = result
+                break
+
+        if not matched_result:
+            continue
+
+        analysis = analyze_session_result_for_progression(matched_result)
+        has_usable_data = bool(
+            analysis.get("first_set_load") is not None or
+            analysis.get("first_set_reps") is not None or
+            analysis.get("hit_failure", False) or
+            analysis.get("has_sets", False)
+        )
+        if not has_usable_data:
+            continue
+
+        sort_dt = parse_session_sort_datetime(session)
+        if sort_dt is None:
+            continue
+
+        if newest_relevant_dt is None:
+            newest_relevant_dt = sort_dt
+
+        age_from_newest_days = days_between_datetimes(newest_relevant_dt, sort_dt)
+        if age_from_newest_days is not None and age_from_newest_days > recent_days:
+            continue
+
+        if previous_kept_dt is not None:
+            gap_days = days_between_datetimes(previous_kept_dt, sort_dt)
+            if gap_days is not None and gap_days > continuity_gap_days:
+                break
+
+        history.append({
+            "session": session,
+            "result": matched_result,
+            "analysis": analysis,
+            "date": str(session.get("date", "")).strip(),
+            "created_at": str(session.get("created_at", "")).strip(),
+            "sort_dt": sort_dt,
+        })
+
+        previous_kept_dt = sort_dt
+
+        if len(history) >= max_items:
+            break
+
+    return history
+
     history = []
     exercise_id = str(exercise_id or "").strip()
 

--- a/tests/test_progression_continuity_window.py
+++ b/tests/test_progression_continuity_window.py
@@ -1,0 +1,91 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "app" / "backend"))
+
+import app as backend_app
+
+
+def make_strength_session(date, created_at, exercise_id="bench_press", reps=8, load=100, *, hit_failure=False):
+    return {
+        "date": date,
+        "created_at": created_at,
+        "session_type": "strength",
+        "results": [
+            {
+                "exercise_id": exercise_id,
+                "target_reps": "6-8",
+                "achieved_reps": str(reps),
+                "hit_failure": hit_failure,
+                "sets": [
+                    {"reps": str(reps), "load": f"{load} kg"},
+                    {"reps": str(reps), "load": f"{load} kg"},
+                ],
+            }
+        ],
+    }
+
+
+def test_keeps_recent_continuous_block():
+    session_results = [
+        make_strength_session("2026-03-01", "2026-03-01T06:00:00+00:00", load=96),
+        make_strength_session("2026-03-08", "2026-03-08T06:00:00+00:00", load=98),
+        make_strength_session("2026-03-12", "2026-03-12T06:00:00+00:00", load=100),
+    ]
+
+    history = backend_app.get_relevant_strength_history(
+        session_results,
+        "bench_press",
+        max_items=6,
+        recent_days=42,
+        continuity_gap_days=14,
+    )
+
+    assert len(history) == 3, history
+    assert [item["date"] for item in history] == ["2026-03-12", "2026-03-08", "2026-03-01"], history
+
+
+def test_stops_at_large_gap_and_excludes_older_block():
+    session_results = [
+        make_strength_session("2026-02-10", "2026-02-10T06:00:00+00:00", load=94),
+        make_strength_session("2026-03-01", "2026-03-01T06:00:00+00:00", load=96),
+        make_strength_session("2026-03-08", "2026-03-08T06:00:00+00:00", load=98),
+        make_strength_session("2026-03-12", "2026-03-12T06:00:00+00:00", load=100),
+    ]
+
+    history = backend_app.get_relevant_strength_history(
+        session_results,
+        "bench_press",
+        max_items=6,
+        recent_days=42,
+        continuity_gap_days=14,
+    )
+
+    assert len(history) == 3, history
+    assert [item["date"] for item in history] == ["2026-03-12", "2026-03-08", "2026-03-01"], history
+
+
+def test_excludes_sessions_older_than_recent_window():
+    session_results = [
+        make_strength_session("2026-01-20", "2026-01-20T06:00:00+00:00", load=94),
+        make_strength_session("2026-02-05", "2026-02-05T06:00:00+00:00", load=96),
+        make_strength_session("2026-03-01", "2026-03-01T06:00:00+00:00", load=98),
+        make_strength_session("2026-03-12", "2026-03-12T06:00:00+00:00", load=100),
+    ]
+
+    history = backend_app.get_relevant_strength_history(
+        session_results,
+        "bench_press",
+        max_items=6,
+        recent_days=30,
+        continuity_gap_days=14,
+    )
+
+    assert [item["date"] for item in history] == ["2026-03-12", "2026-03-01"], history
+
+
+if __name__ == "__main__":
+    test_keeps_recent_continuous_block()
+    test_stops_at_large_gap_and_excludes_older_block()
+    test_excludes_sessions_older_than_recent_window()
+    print("All progression continuity window tests passed")


### PR DESCRIPTION
Description
Introduce continuity-aware filtering for strength progression history.
The progression engine now builds history based on the latest continuous block of relevant sessions instead of simply selecting the most recent items.
Key rules:
recent window: only include sessions within 42 days of the newest relevant session
continuity gap: stop history if gap between sessions exceeds 14 days
history is limited to the latest continuous block per exercise
This prevents outdated or disconnected sessions from influencing progression decisions.
Added deterministic tests covering:
continuous session sequences
gap-based history break
exclusion of outdated sessions
The implementation remains:
deterministic (no weighting or scoring)
local to progression logic (no global state changes)
compatible with existing phase-based progression (#87)
This improves reliability of phase detection and multi-session trend evaluation.