### PR TITLE
Added edge-case validation for phase-based strength progression

### DIFF
--- a/tests/test_progression_continuity_window.py
+++ b/tests/test_progression_continuity_window.py
@@ -84,6 +84,41 @@ def test_excludes_sessions_older_than_recent_window():
     assert [item["date"] for item in history] == ["2026-03-12", "2026-03-01"], history
 
 
+
+def test_gap_equal_to_threshold_keeps_continuity():
+    session_results = [
+        make_strength_session("2026-02-26", "2026-02-26T06:00:00+00:00", load=96),
+        make_strength_session("2026-03-12", "2026-03-12T06:00:00+00:00", load=100),
+    ]
+
+    history = backend_app.get_relevant_strength_history(
+        session_results,
+        "bench_press",
+        max_items=6,
+        recent_days=42,
+        continuity_gap_days=14,
+    )
+
+    assert [item["date"] for item in history] == ["2026-03-12", "2026-02-26"], history
+
+
+def test_gap_above_threshold_breaks_continuity():
+    session_results = [
+        make_strength_session("2026-02-25", "2026-02-25T06:00:00+00:00", load=96),
+        make_strength_session("2026-03-12", "2026-03-12T06:00:00+00:00", load=100),
+    ]
+
+    history = backend_app.get_relevant_strength_history(
+        session_results,
+        "bench_press",
+        max_items=6,
+        recent_days=42,
+        continuity_gap_days=14,
+    )
+
+    assert [item["date"] for item in history] == ["2026-03-12"], history
+
+
 if __name__ == "__main__":
     test_keeps_recent_continuous_block()
     test_stops_at_large_gap_and_excludes_older_block()

--- a/tests/test_progression_phase_scenarios.py
+++ b/tests/test_progression_phase_scenarios.py
@@ -121,6 +121,38 @@ def test_recalibration_blocks_progression_after_long_pause():
     assert out["progression_reason"] == "rekalibrering efter pause", out
 
 
+
+def test_trend_at_minimum_threshold_without_repeated_success_holds():
+    session_results = [
+        make_strength_session("2026-03-10", "2026-03-10T06:00:00+00:00", "bench_press", 7, 96),
+        make_strength_session("2026-03-13", "2026-03-13T06:00:00+00:00", "bench_press", 8, 98),
+        make_strength_session("2026-03-17", "2026-03-17T06:00:00+00:00", "bench_press", 8, 100),
+    ]
+
+    out = run_strength_progression_scenario(session_results=session_results)
+
+    assert out["progression_phase"] == "trend", out
+    assert out["relevant_session_count"] == 3, out
+    assert out["trend_successful_sessions"] == 2, out
+    assert out["trend_repeated_success"] is True, out
+    assert out["progression_decision"] == "increase", out
+
+
+def test_trend_blocks_progression_when_load_drop_exists_in_window():
+    session_results = [
+        make_strength_session("2026-03-10", "2026-03-10T06:00:00+00:00", "bench_press", 8, 96),
+        make_strength_session("2026-03-13", "2026-03-13T06:00:00+00:00", "bench_press", 8, 98, load_drop=True),
+        make_strength_session("2026-03-17", "2026-03-17T06:00:00+00:00", "bench_press", 8, 100),
+    ]
+
+    out = run_strength_progression_scenario(session_results=session_results)
+
+    assert out["progression_phase"] == "trend", out
+    assert out["trend_load_drop_sessions"] == 1, out
+    assert out["trend_repeated_success"] is True, out
+    assert out["progression_decision"] == "hold", out
+
+
 if __name__ == "__main__":
     test_calibration_requires_repeated_success()
     test_trend_allows_progression_after_repeated_success()


### PR DESCRIPTION
Covered:
- trend behavior at minimum session threshold
- blocking behavior for load drop in trend window
- continuity boundary at gap threshold (14 vs 15 days)
- recent-window exclusion behavior

The phase model and continuity logic are now validated across both normal and boundary conditions.