### PR TITLE
Add passive deload recommendation for repeated trend failures

### DIFF
--- a/app/backend/progression_engine.py
+++ b/app/backend/progression_engine.py
@@ -346,59 +346,6 @@ def get_relevant_strength_history(session_results, exercise_id, max_items=6, rec
 
     return history
 
-    history = []
-    exercise_id = str(exercise_id or "").strip()
-
-    if not exercise_id:
-        return history
-
-    for session in reversed(session_results or []):
-        if not isinstance(session, dict):
-            continue
-
-        session_type = str(session.get("session_type", "")).strip().lower()
-        if session_type != "strength":
-            continue
-
-        results = session.get("results", [])
-        if not isinstance(results, list) or not results:
-            continue
-
-        matched_result = None
-        for result in reversed(results):
-            if not isinstance(result, dict):
-                continue
-            if str(result.get("exercise_id", "")).strip() == exercise_id:
-                matched_result = result
-                break
-
-        if not matched_result:
-            continue
-
-        analysis = analyze_session_result_for_progression(matched_result)
-        has_usable_data = bool(
-            analysis.get("first_set_load") is not None or
-            analysis.get("first_set_reps") is not None or
-            analysis.get("hit_failure", False) or
-            analysis.get("has_sets", False)
-        )
-        if not has_usable_data:
-            continue
-
-        history.append({
-            "session": session,
-            "result": matched_result,
-            "analysis": analysis,
-            "date": str(session.get("date", "")).strip(),
-            "created_at": str(session.get("created_at", "")).strip(),
-            "sort_dt": parse_session_sort_datetime(session),
-        })
-
-        if len(history) >= max_items:
-            break
-
-    return history
-
 
 def detect_progression_phase(relevant_history, pause_days=21, min_trend_sessions=3):
     count = len(relevant_history or [])
@@ -481,6 +428,46 @@ def summarize_strength_trend(relevant_history, window_size=3):
         "repeated_success": repeated_success,
         "blocking_signal_present": blocking_signal_present,
         "session_summaries": session_summaries,
+    }
+
+
+
+def evaluate_deload_need(phase, trend_ctx, fatigue_score):
+    if phase != "trend":
+        return {
+            "deload_recommended": False,
+            "deload_reason": None,
+            "deload_scope": None,
+        }
+
+    failures = int(trend_ctx.get("failure_sessions", 0) or 0)
+    load_drops = int(trend_ctx.get("load_drop_sessions", 0) or 0)
+
+    if failures >= 2:
+        return {
+            "deload_recommended": True,
+            "deload_reason": "gentagne failures",
+            "deload_scope": "exercise",
+        }
+
+    if load_drops >= 2:
+        return {
+            "deload_recommended": True,
+            "deload_reason": "gentagne load-drops",
+            "deload_scope": "exercise",
+        }
+
+    if (failures + load_drops) >= 2 and fatigue_score >= 2:
+        return {
+            "deload_recommended": True,
+            "deload_reason": "kombineret træthed og ustabil performance",
+            "deload_scope": "exercise",
+        }
+
+    return {
+        "deload_recommended": False,
+        "deload_reason": None,
+        "deload_scope": None,
     }
 
 
@@ -670,6 +657,12 @@ def decide_progression_from_context(exercise_id, ctx):
             decision = "hold"
             progression_reason = "progression holdes"
 
+        deload_ctx = evaluate_deload_need(
+            phase,
+            trend_ctx,
+            fatigue_score,
+        )
+
         return {
             "ok": True,
             "exercise": exercise_id,
@@ -699,6 +692,9 @@ def decide_progression_from_context(exercise_id, ctx):
             "trend_failure_sessions": trend_ctx.get("failure_sessions"),
             "trend_load_drop_sessions": trend_ctx.get("load_drop_sessions"),
             "trend_repeated_success": trend_ctx.get("repeated_success"),
+            "deload_recommended": deload_ctx.get("deload_recommended"),
+            "deload_reason": deload_ctx.get("deload_reason"),
+            "deload_scope": deload_ctx.get("deload_scope"),
         }
 
     if last_entry is None:

--- a/tests/test_progression_phase_scenarios.py
+++ b/tests/test_progression_phase_scenarios.py
@@ -153,6 +153,24 @@ def test_trend_blocks_progression_when_load_drop_exists_in_window():
     assert out["progression_decision"] == "hold", out
 
 
+
+def test_trend_recommends_deload_after_repeated_failures():
+    session_results = [
+        make_strength_session("2026-03-10", "2026-03-10T06:00:00+00:00", "bench_press", 8, 96, hit_failure=True),
+        make_strength_session("2026-03-13", "2026-03-13T06:00:00+00:00", "bench_press", 8, 98, hit_failure=True),
+        make_strength_session("2026-03-17", "2026-03-17T06:00:00+00:00", "bench_press", 8, 100),
+    ]
+
+    out = run_strength_progression_scenario(session_results=session_results)
+
+    assert out["progression_phase"] == "trend", out
+    assert out["trend_failure_sessions"] == 2, out
+    assert out["deload_recommended"] is True, out
+    assert out["deload_reason"] == "gentagne failures", out
+    assert out["deload_scope"] == "exercise", out
+    assert out["progression_decision"] == "hold", out
+
+
 if __name__ == "__main__":
     test_calibration_requires_repeated_success()
     test_trend_allows_progression_after_repeated_success()


### PR DESCRIPTION
Implemented v1 deload trigger design as passive progression output.

Added:
- deterministic deload recommendation helper
- deload fields in strength progression output
- test coverage for repeated failures in trend phase

Current behavior:
- deload is recommended but does not yet alter progression or planning behavior
- output remains deterministic and exercise-scoped