### PR TITLE
Stop Strength boot when auth fails

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -3488,7 +3488,8 @@ async function boot(){
 
 (async () => {
   try{
-    await ensureAuthOrRedirect();
+    const authUser = await ensureAuthOrRedirect();
+    if (!authUser) return;
     await boot();
   }catch(err){
     setText("status", "Fejl før opstart: " + (err?.message || String(err)));


### PR DESCRIPTION
Summary
Stop SovereignStrength from continuing into full app boot when auth has already failed.
Problem
The frontend startup flow previously did this:
await ensureAuthOrRedirect(); await boot();
But ensureAuthOrRedirect() redirects and returns null when the user is not authenticated.
That allowed the app to continue into boot() even after auth failure, which then triggered boot-time API requests that returned 401.
Because the boot flow uses strict API calls and a large refresh sequence, the result was a half-loaded UI with unresolved placeholder states such as profile, training types, equipment, and account loading.
Fix
Change startup to:
const authUser = await ensureAuthOrRedirect(); if (!authUser) return; await boot();
Why this works
This makes auth failure a real gate instead of a cosmetic redirect.
If the user is not authenticated, the app no longer continues into full boot and no longer falls into ambiguous placeholder UI caused by unauthorized boot requests.
Scope
This PR is intentionally minimal.
It does not redesign auth. It does not change boot data APIs. It only prevents unauthorized startup from continuing into app boot.
Related
Fix Strength boot state when auth/api data does not resolve correctly (#124)