### PR TITLE
Humanize “Dagens plan” reason text and remove raw planner fallback

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1607,7 +1607,7 @@ function formatPlanReason(value){
   if (!x) return "";
   if (x === "Manuel plan overstyrer dagens autoplan.") return tr("plan.reason.manual_override_today");
   if (x === "Manual plan overrides today's autoplan.") return tr("plan.reason.manual_override_today");
-  return x;
+  return tr("plan.reason.generic_today_choice");
 }
 
 function formatFatigueText(value){

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -383,6 +383,7 @@
   "plan.action.follow_plan_today": "Følg planen i dag",
   "plan.reason.manual_plan_selected_today": "Manuel plan valgt som dagens træning",
   "plan.reason.manual_override_today": "Manuel plan overstyrer dagens autoplan.",
+  "plan.reason.generic_today_choice": "Planen er valgt ud fra din status i dag.",
   "session_type.other": "Andet",
   "workout.achieved_placeholder": "fx 8",
   "common.items_count": "{count} elementer",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -371,6 +371,7 @@
   "plan.action.follow_plan_today": "Follow the plan today",
   "plan.reason.manual_plan_selected_today": "Manual plan selected as today's training",
   "plan.reason.manual_override_today": "Manual plan overrides today's autoplan.",
+  "plan.reason.generic_today_choice": "Today's plan was selected based on your current status.",
   "session_type.other": "Other",
   "workout.achieved_placeholder": "e.g. 8",
   "common.items_count": "{count} items",


### PR DESCRIPTION
## Summary

Improve the “Dagens plan” experience by replacing raw planner fallback text with a short, user-facing explanation.

## Problem

Even after the first cleanup, `formatPlanReason()` still fell back to returning raw reason strings directly from the planner/backend layer.

That meant the UI could still expose internal or awkward phrasing instead of a short explanation suitable for the user-facing daily plan surface.

## What this PR changes

### Frontend
- update `formatPlanReason()` so unknown/unmapped reason values no longer return raw text directly
- replace the raw fallback with a neutral user-facing explanation:
  - `plan.reason.generic_today_choice`

### i18n
Add the new key in both languages:
- `app/frontend/i18n/da.json`
- `app/frontend/i18n/en.json`

## Why this helps

The daily plan screen should explain today’s choice in human language, not leak planner text when no exact mapping exists.

This keeps the screen calmer and more consistent, especially while the planner logic is still evolving.

## Scope

This is a small follow-up improvement on issue #126.
It does not redesign the screen further.
It only replaces the raw fallback reason path with a stable user-facing explanation.

## Related

- #126 Clean up “Dagens plan” screen because it is cluttered, repetitive, and leaks internal planning labels