### PR TITLE
Fix/126 today plan cleanup

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1583,14 +1583,16 @@ function formatProgressFlag(flag){
 }
 
 function formatProgressionDecision(value){
-  const x = String(value || "").trim();
+  const x = String(value || "").trim().toLowerCase();
+  if (!x) return "";
   if (x === "increase") return tr("progression.increase_next_time");
   if (x === "increase_reps") return tr("progression.increase_next_time");
   if (x === "hold") return tr("progression.hold_today");
   if (x === "use_start_weight") return tr("progression.start_weight");
   if (x === "no_progression") return tr("progression.no_auto_progression");
   if (x === "manual_override") return tr("plan.motor.manual_override");
-  return x || "";
+  if (x === "autoplan_cardio_initial") return tr("decision.autoplan_cardio_initial");
+  return tr("decision.generic");
 }
 
 
@@ -1600,7 +1602,10 @@ function formatProgressionReason(value){
   if (!x) return "";
   if (x === "Manuel plan valgt som dagens træning") return tr("plan.reason.manual_plan_selected_today");
   if (x === "Manual plan selected as today's training") return tr("plan.reason.manual_plan_selected_today");
-  return x;
+  if (x === "autoplan selected a cardio session based on readiness, recovery, and recent cardio load") {
+    return tr("plan.reason.cardio_autoplan_selected_today");
+  }
+  return tr("plan.reason.generic_today_choice");
 }
 
 function formatPlanReason(value){

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -384,6 +384,7 @@
   "plan.reason.manual_plan_selected_today": "Manuel plan valgt som dagens træning",
   "plan.reason.manual_override_today": "Manuel plan overstyrer dagens autoplan.",
   "plan.reason.generic_today_choice": "Planen er valgt ud fra din status i dag.",
+  "plan.reason.cardio_autoplan_selected_today": "Rolig løbetur valgt ud fra din status, restitution og den seneste cardio-belastning.",
   "session_type.other": "Andet",
   "workout.achieved_placeholder": "fx 8",
   "common.items_count": "{count} elementer",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -372,6 +372,7 @@
   "plan.reason.manual_plan_selected_today": "Manual plan selected as today's training",
   "plan.reason.manual_override_today": "Manual plan overrides today's autoplan.",
   "plan.reason.generic_today_choice": "Today's plan was selected based on your current status.",
+  "plan.reason.cardio_autoplan_selected_today": "An easy run was selected based on your status, recovery, and recent cardio load.",
   "session_type.other": "Other",
   "workout.achieved_placeholder": "e.g. 8",
   "common.items_count": "{count} items",


### PR DESCRIPTION
## Today plan cleanup – entry-level finalization

This completes the cleanup of the today-plan UI by removing the last internal labels from the entry card.

### What changed
- replaced raw `autoplan_cardio_initial` label with user-facing text
- replaced raw cardio reason text with localized explanation
- ensured all fallbacks use stable, human-readable labels

### Result
The today-plan view now reads as guidance rather than internal system output.

No backend changes. Frontend only.