### PR TITLE
Reduce overview competition so the daily flow dominates first sight

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1482,9 +1482,7 @@ function updateOverviewLayoutForStep(stepId){
   cards.forEach(card => {
     let keepVisible =
       card.id === "forecastHero" ||
-      card.id === "overviewStatusCard" ||
-      card.id === "profileEquipmentCard" ||
-      card.id === "weekPlanCard";
+      card.id === "overviewStatusCard";
 
     if (stepId === "overview" && dailyUiState === "needs_checkin"){
       keepVisible = card.id === "forecastHero";


### PR DESCRIPTION
## Summary

Reduce first-screen competition in the overview so the daily flow becomes more visually dominant.

## Problem

The app has improved a lot in the core daily flow, but the overview still exposes too many peer-level cards at first sight.

This makes the product feel more like a dashboard of available modules than a guided daily training tool.

In particular, cards such as profile/equipment and other secondary overview blocks compete visually with the actual day-driving elements:
- expected today
- current status
- next action

## What this PR changes

### Overview visibility
- keep only the most important cards visible in the overview step:
  - `forecastHero`
  - `overviewStatusCard`

### Reduce first-screen competition
- stop treating profile/equipment and other secondary cards as equal-priority first-sight content in the overview step

## Why this helps

This shifts the app's first impression toward:
- what should I do today
instead of:
- what sections exist in the system

The goal is not to remove secondary functionality.
The goal is to make the daily flow feel primary.

## Scope

Frontend only.

No backend changes.
No changes to planner logic.
No feature removal.

## Related

- #101 Reduce primary navigation and move secondary features into menus