### PR TITLE
Enforce i18n for forecast cardio descriptions

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -968,22 +968,22 @@ function buildForecastLeadText(planItem){
     }
     if (firstExercise.includes("interval")){
       return targetReps
-        ? `Intervaller · ${targetReps}`
-        : "Intervaller · kort, hårdt pas med pauser";
+        ? tr("forecast.intervals_with_target", { value: targetReps })
+        : tr("forecast.intervals_default");
     }
     if (firstExercise.includes("tempo")){
       return targetReps
-        ? `Tempopas · ${targetReps}`
-        : "Tempopas · kontrolleret hård løbebelastning";
+        ? tr("forecast.tempo_with_target", { value: targetReps })
+        : tr("forecast.tempo_default");
     }
     if (firstExercise.includes("base")){
       return targetReps
-        ? `Basepas · ${targetReps}`
-        : "Basepas · roligt løb i snakketempo";
+        ? tr("forecast.base_with_target", { value: targetReps })
+        : tr("forecast.base_default");
     }
     return targetReps
-      ? `Løb · ${targetReps}`
-      : "Løb · planlagt cardiopas";
+        ? tr("forecast.run_with_target", { value: targetReps })
+        : tr("forecast.run_default");
   }
 
   if (sessionType === "restitution"){

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -453,5 +453,13 @@
   "exercise.none_yet": "Ingen øvelser endnu.",
   "recovery.none_yet": "Ingen recovery-logs endnu.",
   "overview.readiness_label": "Parathed",
-  "plan.none": "Ingen plan"
+  "plan.none": "Ingen plan",
+  "forecast.intervals_with_target": "Intervaller · {value}",
+  "forecast.intervals_default": "Intervaller · kort, hårdt pas med pauser",
+  "forecast.tempo_with_target": "Tempopas · {value}",
+  "forecast.tempo_default": "Tempopas · kontrolleret hård løbebelastning",
+  "forecast.base_with_target": "Basepas · {value}",
+  "forecast.base_default": "Basepas · roligt løb i snakketempo",
+  "forecast.run_with_target": "Løb · {value}",
+  "forecast.run_default": "Løb · planlagt cardiopas"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -441,5 +441,13 @@
   "exercise.none_yet": "No exercises yet.",
   "recovery.none_yet": "No recovery logs yet.",
   "overview.readiness_label": "Readiness",
-  "plan.none": "No plan"
+  "plan.none": "No plan",
+  "forecast.intervals_with_target": "Intervals · {value}",
+  "forecast.intervals_default": "Intervals · short, hard effort with breaks",
+  "forecast.tempo_with_target": "Tempo session · {value}",
+  "forecast.tempo_default": "Tempo session · controlled hard running effort",
+  "forecast.base_with_target": "Base session · {value}",
+  "forecast.base_default": "Base session · easy conversational running",
+  "forecast.run_with_target": "Run · {value}",
+  "forecast.run_default": "Run · planned cardio session"
 }


### PR DESCRIPTION
## Summary
Removes hardcoded forecast cardio description strings and routes them through i18n.

## Changes
- added i18n keys for:
  - interval forecast text
  - tempo forecast text
  - base forecast text
  - generic run forecast text
- replaced hardcoded forecast strings in `app/frontend/app.js`
- updated both `da.json` and `en.json`

## Why
Forecast descriptions are user-facing UI text and should follow the active language setting consistently.

This continues the i18n cleanup in small, reviewable batches.

## Scope
- frontend only
- no intended behavior changes

## Validation
- `node --check app/frontend/app.js`
- verified targeted hardcoded forecast strings no longer appear in `app.js`