### PR TITLE
Refine trend blocking logic

### DIFF
--- a/app/backend/progression_engine.py
+++ b/app/backend/progression_engine.py
@@ -416,15 +416,24 @@ def summarize_strength_trend(relevant_history, window_size=3):
     successful_sessions = sum(1 for x in session_summaries if x["successful_session"])
     failure_sessions = sum(1 for x in session_summaries if x["hit_failure"])
     load_drop_sessions = sum(1 for x in session_summaries if x["load_drop_detected"])
+    negative_signal_sessions = failure_sessions + load_drop_sessions
+
+    latest_summary = session_summaries[0] if session_summaries else {}
+    latest_blocking_signal = bool(
+        latest_summary.get("hit_failure", False) or
+        latest_summary.get("load_drop_detected", False)
+    )
 
     repeated_success = successful_sessions >= 2
-    blocking_signal_present = failure_sessions > 0 or load_drop_sessions > 0
+    blocking_signal_present = latest_blocking_signal or negative_signal_sessions >= 2
 
     return {
         "window_size": len(window),
         "successful_sessions": successful_sessions,
         "failure_sessions": failure_sessions,
         "load_drop_sessions": load_drop_sessions,
+        "negative_signal_sessions": negative_signal_sessions,
+        "latest_blocking_signal": latest_blocking_signal,
         "repeated_success": repeated_success,
         "blocking_signal_present": blocking_signal_present,
         "session_summaries": session_summaries,


### PR DESCRIPTION
## Summary
Refines trend-window blocking behavior so progression is not blocked by a single older bad session.

## Changes
- added `negative_signal_sessions`
- added `latest_blocking_signal`
- changed `blocking_signal_present` to block only when:
  - the latest session contains a blocking signal, or
  - there are at least 2 negative signals in the 3-session window

## Why
The previous logic blocked progression whenever any failure or load-drop appeared in the trend window.

That was too rigid and could erase an otherwise stable trend because of one older off-session.

## Scope
- backend only
- progression engine only
- intended behavior change within trend evaluation

## Validation
- `python3 -m py_compile app/backend/progression_engine.py`
- sanity tests confirmed:
  - one older bad session no longer blocks progression
  - a bad latest session still blocks progression
  - two negative signals in the trend window still block progression