### PR TITLE
Add lightweight i18n guardrails for frontend text regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,16 @@ This repository should be the authoritative source for:
 ## License
 
 See [LICENSE](LICENSE).
+
+## UI text and i18n guardrails
+
+Visible frontend text should resolve through the i18n layer wherever practical.
+
+Guardrails:
+- avoid shipping hardcoded user-facing strings in render paths when a translation key should exist
+- avoid mixed-language UI output in the same screen
+- review suspicious `innerHTML`, `setText(...)`, and `textContent` changes carefully
+- run `python3 scripts/audit_i18n_guardrails.py` before merging frontend text/rendering changes
+
+This is a lightweight guardrail, not a heavy framework rule.
+

--- a/scripts/audit_i18n_guardrails.py
+++ b/scripts/audit_i18n_guardrails.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FILES = [
+    ROOT / "app/frontend/app.js",
+    ROOT / "app/frontend/index.html",
+]
+
+SUSPICIOUS_PATTERNS = [
+    (r'setText\([^)]*,\s*"[^"]*[A-Za-zÆØÅæøå][^"]*"\s*(?:\+|\))', "Hardcoded string in setText(...)"),
+    (r'textContent\s*=\s*"[^"]*[A-Za-zÆØÅæøå][^"]*"', "Hardcoded textContent assignment"),
+    (r'innerHTML\s*=\s*`[\s\S]*?[A-Za-zÆØÅæøå]{3,}[\s\S]*?`', "Template literal with visible hardcoded text"),
+    (r'placeholder="[^"]*[A-Za-zÆØÅæøå][^"]*"', "Hardcoded placeholder in HTML"),
+    (r'data-i18n="[^"]+"\>[^<]*[A-Za-zÆØÅæøå]{3,}[^<]*\<', "HTML contains both data-i18n and visible fallback text"),
+    (r'\?\s*`?$', 'Literal "?" fallback in visible rendering'),
+]
+
+ALLOW_SUBSTRINGS = [
+    'document.title = tr("app.title")',
+    'toggleSystemInfo.textContent = tr("button.hide")',
+    'data-i18n=',
+    'data-i18n-placeholder=',
+]
+
+def should_skip(line: str) -> bool:
+    return any(token in line for token in ALLOW_SUBSTRINGS)
+
+def audit_file(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    findings: list[str] = []
+    lines = text.splitlines()
+
+    for idx, line in enumerate(lines, start=1):
+        if should_skip(line):
+            continue
+        for pattern, label in SUSPICIOUS_PATTERNS:
+            if re.search(pattern, line):
+                findings.append(f"{path.relative_to(ROOT)}:{idx}: {label}: {line.strip()}")
+                break
+
+    return findings
+
+def main() -> int:
+    all_findings: list[str] = []
+
+    for path in FILES:
+        if not path.exists():
+            print(f"Missing file: {path}", file=sys.stderr)
+            return 2
+        all_findings.extend(audit_file(path))
+
+    if all_findings:
+        print("i18n guardrail audit found suspicious UI strings:\n")
+        for item in all_findings:
+            print(item)
+        print("\nReview these manually before merge.")
+        return 1
+
+    print("i18n guardrail audit passed: no obvious suspicious UI strings found.")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a lightweight first guardrail against repeated frontend text regressions such as hardcoded UI strings, mixed-language output, and missing i18n handling leaking into visible screens.

## What this PR changes

### 1. README rule
Adds a small explicit rule in the repository documentation:

- visible frontend text should go through the i18n layer where practical
- suspicious render-path text changes should be reviewed carefully
- the i18n audit script should be run before merging frontend text/rendering changes

### 2. Audit script
Adds `scripts/audit_i18n_guardrails.py`, a lightweight scan for suspicious frontend text patterns in:

- `app/frontend/app.js`
- `app/frontend/index.html`

The script intentionally stays simple.
It is meant to catch obvious problems early, not to become a heavy lint framework.

## Why this helps

Recent fixes have repeatedly surfaced the same class of regressions:
- raw text in render paths
- mixed Danish/English output
- missing translation handling
- visible fallback/debug-style strings leaking into the UI

This PR adds a practical prevention layer so those problems are easier to spot before merge.

## Scope

Docs + tooling only.

No backend changes.
No planner logic changes.
No UI behavior changes yet.

## Notes

The audit currently produces both real findings and some false positives.
That is acceptable for Phase 1.

The goal is to create a lightweight review guardrail first, then refine it incrementally.