### PR TITLE
Document cardio integration boundaries in the planning architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,3 +133,57 @@ The currently documented system does not yet claim to fully support:
 - full cardio support
 
 Those belong to later iterations, not to the current documented core.
+
+
+## Cardio integration boundaries
+
+Cardio is integrated at the daily planning layer, not inside the strength progression engine.
+
+The active cardio entry points are:
+
+- `compute_cardio_load_metrics(...)`
+- `choose_cardio_session(...)`
+- `build_autoplan_cardio(...)`
+- `build_cardio_plan(...)`
+
+These helpers use top-level planning context such as:
+
+- readiness
+- fatigue
+- recovery state
+- timing / time budget
+- training-day context
+- recent cardio load
+
+### What cardio is
+
+Cardio is a planning outcome.
+It is selected by the daily planner as a session recommendation.
+
+### What cardio is not
+
+Cardio is not a strength progression mode.
+
+It does not rely on lift-specific progression internals such as:
+
+- recent successful load progression for a given strength exercise
+- progression phases
+- exercise-level strength progression history
+
+### Relationship to restitution
+
+Restitution can override cardio.
+
+This happens when recovery or fatigue logic determines that the safer daily recommendation is restitution instead of another cardio or strength session.
+
+### Relationship to strength planning
+
+Strength and cardio are both outputs of the daily planning layer, but they diverge after session selection:
+
+- strength can continue into exercise-specific progression logic
+- cardio remains a planning-layer recommendation based on top-level session signals and recent cardio load
+
+### Maintenance rule
+
+When refining cardio behavior, prefer changing planning-layer logic and explanation output before expanding strength progression internals.
+

--- a/docs/systemnote.md
+++ b/docs/systemnote.md
@@ -329,3 +329,18 @@ This document should stay aligned with:
 If implementation changes the logic materially, this file should be updated in the same commit.
 
 Do not let the system note become historical fiction with markdown headings.
+
+
+## Cardio boundary note
+
+Cardio is currently chosen through the daily planning flow rather than through the strength progression engine.
+
+In practice this means:
+
+- recent cardio load is evaluated separately
+- cardio kind is selected from planning context
+- restitution can override cardio
+- strength progression remains exercise-specific and separate
+
+This boundary should be preserved unless a later change explicitly redesigns the planning architecture.
+


### PR DESCRIPTION
## Summary

Document the current cardio integration boundaries so the planning model is easier to understand and maintain.

## What this PR clarifies

- cardio is selected at the daily planning layer
- cardio depends on top-level signals such as readiness, recovery, fatigue, timing, training-day context, and recent cardio load
- cardio is not part of the strength progression engine
- restitution can override cardio when recovery/protection logic makes that more appropriate
- strength progression and cardio selection should be maintained as related but distinct layers

## Why

The code already contains cardio integration points, but the boundaries are too implicit.
This makes future maintenance and refinement harder than necessary.

## Scope

Documentation only.

No backend logic changes.
No frontend changes.

## Related

- #44 Refine and document cardio integration boundaries