### PR TITLE
Fix manual override consumption because session-result can crash

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -296,6 +296,11 @@ def get_user_settings_for(user_id):
 def save_user_settings_for(user_id, settings):
     return get_storage().save_user_settings_for(user_id, settings)
 
+
+def consume_manual_override_workout(user_id, date):
+    return get_storage().consume_manual_override_workout(user_id, date)
+
+
 def list_workouts_for_user(user_id):
     return list_user_items("workouts", user_id)
 


### PR DESCRIPTION
## Summary

Fix the session-result crash caused by missing manual override consumption wiring.

## What this PR changes

- restore the missing `consume_manual_override_workout(...)` wrapper in `app/backend/app.py`

## Why

`POST /api/session-result` could crash with:

`NameError: name 'consume_manual_override_workout' is not defined`

The storage-layer consume method already exists, but the app-layer wrapper was missing.

## Scope

Backend only.

## Related

- #163 Fix session-result crash because consume_manual_override_workout is not defined