### PR TITLE
Refresh adaptation state in today-plan because local_state must update in the main planning flow

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2891,6 +2891,9 @@ def get_today_plan():
     if auth_err:
         log_auth_failure("today-plan", auth_err)
         return auth_err
+
+    update_adaptation_state(auth_user.get("user_id"))
+
     checkins = list_user_items("checkins", auth_user.get("user_id"))
     checkins_error = get_storage_last_error()
     if checkins_error and checkins_error.get("file_key") == "checkins":


### PR DESCRIPTION
## Summary

This PR makes `/api/today-plan` refresh adaptation state before building the plan.

## Why

`local_state` was added as part of the local protection foundation, but it was not being refreshed in the main today-plan flow.

That meant the planner could fetch today's plan without updating the rolling adaptation state that now includes `local_state`.

## Included

- calls `update_adaptation_state(auth_user.get("user_id"))` inside `get_today_plan()`
- removes temporary debugging/sentinel instrumentation used during runtime verification
- keeps the runtime fix small and focused

## Why this matters

Without this refresh in the main planning route, the system could serve today's plan while still relying on stale adaptation state.

That breaks the intended chain between:

- local check-in signals
- local load-target mappings
- rolling `local_state`
- later planner reactions

## Validation

- `python3 -m py