### PR TITLE
Use local_state in exercise selection because protect regions must block unsafe family candidates

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -4955,7 +4955,8 @@ def build_autoplan_strength(user_id, readiness=None, time_budget_min=None, user_
             "exercise_id": exercise_id,
             "exercise_score": picked.get("score", 0),
             "family_reason": fam.get("reason", []),
-            "exercise_reason": picked.get("reason", [])
+            "exercise_reason": picked.get("reason", []),
+            "local_state_applied": any("lokal caution" in str(x) for x in (picked.get("reason", []) or []))
         })
 
     return {
@@ -4972,10 +4973,13 @@ def choose_exercise_for_family(user_id, family_key, readiness=None, time_budget_
     state = get_live_adaptation_state_for(user_id)
     identity_graph = state.get("exercise_identity_graph", {}) if isinstance(state, dict) else {}
     learning_signals = state.get("learning_signals", {}) if isinstance(state, dict) else {}
+    local_state = state.get("local_state", {}) if isinstance(state, dict) else {}
     if not isinstance(identity_graph, dict):
         identity_graph = {}
     if not isinstance(learning_signals, dict):
         learning_signals = {}
+    if not isinstance(local_state, dict):
+        local_state = {}
 
     exercises = read_json_file(FILES["exercises"])
     candidates = get_exercises_for_family(family_key, exercises=exercises, identity_graph=identity_graph)
@@ -5012,6 +5016,22 @@ def choose_exercise_for_family(user_id, family_key, readiness=None, time_budget_
         learned = str(learning.get("learned_recommendation", "")).strip()
         next_variation = str(learning.get("next_variation", "")).strip()
 
+        local_targets = get_local_load_targets_for_exercise(ex_id, exercises=exercises)
+        blocked_regions = []
+        caution_regions = []
+        for region in local_targets:
+            info = local_state.get(region, {}) if isinstance(local_state, dict) else {}
+            if not isinstance(info, dict):
+                continue
+            region_state = str(info.get("state", "")).strip()
+            if region_state == "protect":
+                blocked_regions.append(region)
+            elif region_state == "caution":
+                caution_regions.append(region)
+
+        if blocked_regions:
+            continue
+
         score = 0.0
         reasons = []
 
@@ -5041,6 +5061,10 @@ def choose_exercise_for_family(user_id, family_key, readiness=None, time_budget_
         progression_mode = str(item.get("progression_mode", "")).strip()
         if progression_mode == "double_progression":
             score += 0.15
+
+        if caution_regions:
+            score -= 0.6 * len(caution_regions)
+            reasons.append(f"lokal caution i: {', '.join(caution_regions[:3])}")
 
         input_kind = str(item.get("input_kind", "")).strip()
         if readiness is not None:

--- a/app/backend/storage.py
+++ b/app/backend/storage.py
@@ -121,7 +121,11 @@ class JSONStorage:
 
     def list_user_items(self, file_key, user_id, sort_keys=("created_at", "date")):
         items = self._read_list(file_key)
-        items = [x for x in items if isinstance(x, dict) and x.get("user_id", 1) == user_id]
+        user_id = str(user_id).strip()
+        items = [
+            x for x in items
+            if isinstance(x, dict) and str(x.get("user_id", "")).strip() == user_id
+        ]
         return self._sort_desc(items, *sort_keys)
 
     def append_item(self, file_key, item):


### PR DESCRIPTION
## Summary

This PR makes autoplan exercise selection react to rolling `local_state`.

## Included

- reads `local_state` inside `choose_exercise_for_family(...)`
- blocks candidates whose `local_load_targets` hit a region in `protect`
- down-ranks candidates whose `local_load_targets` hit a region in `caution`
- fixes JSON storage user filtering so user-scoped checkins and local state read correctly
- exposes a small `local_state_applied` flag in autoplan family output

## Why

The local protection foundation can now:

- collect local signals
- map exercises to local load targets
- derive rolling `local_state`

But the planner previously ignored that state during exercise selection.

This PR adds the first actual planner reaction layer.

## Behavior

- `protect` removes unsafe candidates from selection
- `caution` reduces candidate score rather than fully blocking
- behavior stays deterministic and compact

## Validation

- verified in live runtime that a `knee = protect` state blocks squat-family selection
- `choose_exercise_for_family("squat")` returned `null`
- autoplan omitted the squat family under local protection
- verified and fixed JSON storage filtering so user-specific checkins are actually visible to runtime state derivation

## Notes

This is the first planner reaction layer, not the final one.

Follow-up work should likely add:

- clearer family-level fallback behavior
- local-aware substitution preference
- local-aware cardio choice