### PR TITLE
Explain blocked families in autoplan because local protection should not remove them silently

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -4912,8 +4912,22 @@ def build_autoplan_strength(user_id, readiness=None, time_budget_min=None, user_
         if not picked or not isinstance(picked, dict):
             continue
 
-        exercise_id = str(picked.get("exercise_id", "")).strip()
+        raw_exercise_id = picked.get("exercise_id")
+        exercise_id = str(raw_exercise_id).strip() if raw_exercise_id not in (None, "") else ""
         if not exercise_id:
+            family_outputs.append({
+                "family_key": family_key,
+                "family_role": fam.get("family_role"),
+                "priority": fam.get("priority"),
+                "exercise_id": None,
+                "exercise_score": None,
+                "family_reason": fam.get("reason", []),
+                "exercise_reason": picked.get("reason", []),
+                "local_state_applied": bool(picked.get("blocked_by_local_state", False)),
+                "blocked_by_local_state": bool(picked.get("blocked_by_local_state", False)),
+                "blocked_regions": picked.get("blocked_regions", []),
+                "blocked_reason": picked.get("blocked_reason")
+            })
             continue
 
         exercise_meta = get_exercise_meta(exercise_id) or {}
@@ -5019,6 +5033,7 @@ def choose_exercise_for_family(user_id, family_key, readiness=None, time_budget_
         available = {}
 
     scored = []
+    family_blocked_regions = set()
 
     for item in candidates:
         ex_id = str(item.get("id", "")).strip()
@@ -5055,6 +5070,8 @@ def choose_exercise_for_family(user_id, family_key, readiness=None, time_budget_
                 caution_regions.append(region)
 
         if blocked_regions:
+            for region in blocked_regions:
+                family_blocked_regions.add(region)
             continue
 
         score = 0.0
@@ -5110,6 +5127,18 @@ def choose_exercise_for_family(user_id, family_key, readiness=None, time_budget_
     scored.sort(key=lambda x: (x.get("score", 0), x.get("exercise_id", "")), reverse=True)
 
     if not scored:
+        if family_blocked_regions:
+            blocked_regions = sorted(family_blocked_regions)
+            return {
+                "family_key": family_key,
+                "exercise_id": None,
+                "score": None,
+                "reason": [],
+                "alternatives": [],
+                "blocked_by_local_state": True,
+                "blocked_regions": blocked_regions,
+                "blocked_reason": f"lokal beskyttelse blokerede familien: {', '.join(blocked_regions)}"
+            }
         return None
 
     top = scored[0]


### PR DESCRIPTION
## Summary

This PR makes autoplan explicitly explain when a family is blocked by local protection instead of silently dropping it.

## Included

- tracks blocked regions across family candidates in `choose_exercise_for_family(...)`
- returns structured block information when all family candidates are blocked by local protection
- preserves blocked families in `families_selected` inside `build_autoplan_strength(...)`
- fixes `None` handling so blocked families do not create fake exercise entries

## Why

The planner already reacted to `local_state`, but blocked families could disappear silently.

That made the behavior safer, but less transparent.

This PR keeps the planner deterministic while making local protection decisions visible and explainable.

## Behavior

If a family cannot produce any viable exercise because all candidates hit a protected region:

- the family remains visible in `families_selected`
- `exercise_id` is `null`
- `blocked_by_local_state` is `true`
- `blocked_regions` lists the affected regions
- `blocked_reason` explains why the family was removed

Blocked families do not create fake entries in the final plan.

## Validation

Verified in live runtime for user 2 with `knee = protect`:

- squat family remained visible in `families_selected`
- squat family reported:
  - `blocked_by_local_state: true`
  - `blocked_regions: ["knee"]`
  - `blocked_reason: "lokal beskyttelse blokerede familien: knee"`
- no fake `"exercise_id": "None"` entry was created

## Notes

This continues the local protection trust layer.

The planner should not only act safely.
It should also explain why it changed the plan.