### PR TITLE
Add optional menstruation-aware check-in signals because relevant pain states should influence daily planning

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -599,6 +599,31 @@ def compute_readiness_score(sleep_score, energy_score, soreness_score):
     readiness_score = max(1, min(5, readiness_score))
     return readiness_score
 
+def _parse_optional_bool(value, field):
+    if value in (None, "", "null"):
+        return None, None, None
+    if isinstance(value, bool):
+        return value, None, None
+    s = str(value).strip().lower()
+    if s in ("true", "1", "yes", "ja"):
+        return True, None, None
+    if s in ("false", "0", "no", "nej"):
+        return False, None, None
+    return None, make_error_payload("invalid_boolean", f"{field} skal være true/false", field=field), 400
+
+def _parse_menstrual_pain(value):
+    if value in (None, "", "null"):
+        return "none", None, None
+    allowed = {"none", "light", "moderate", "severe"}
+    s = str(value).strip().lower()
+    if s in allowed:
+        return s, None, None
+    return None, make_error_payload(
+        "invalid_menstrual_pain",
+        "menstrual_pain skal være none, light, moderate eller severe",
+        field="menstrual_pain",
+    ), 400
+
 def create_checkin(user_id, payload):
     if not isinstance(payload, dict):
         return None, make_error_payload("invalid_payload", "ugyldig payload"), 400
@@ -631,6 +656,14 @@ def create_checkin(user_id, payload):
     if err:
         return None, err, status
 
+    menstruation_today, err, status = _parse_optional_bool(payload.get("menstruation_today"), "menstruation_today")
+    if err:
+        return None, err, status
+
+    menstrual_pain, err, status = _parse_menstrual_pain(payload.get("menstrual_pain"))
+    if err:
+        return None, err, status
+
     readiness_score = compute_readiness_score(
         sleep_score=sleep_score,
         energy_score=energy_score,
@@ -648,6 +681,8 @@ def create_checkin(user_id, payload):
         "readiness_score": readiness_score,
         "notes": notes,
         "local_signals": local_signals,
+        "menstruation_today": menstruation_today,
+        "menstrual_pain": menstrual_pain,
         "created_at": datetime.now(timezone.utc).isoformat()
     }
     item, count = append_user_item("checkins", item)
@@ -2562,6 +2597,23 @@ def append_today_plan_trace(user_id, trace):
         logger.exception("today_plan_trace_write_failed")
 
 
+def get_menstruation_planning_signal(latest_checkin):
+    if not isinstance(latest_checkin, dict):
+        return None
+
+    menstrual_pain = str(latest_checkin.get("menstrual_pain", "none") or "none").strip().lower()
+    menstruation_today = latest_checkin.get("menstruation_today")
+
+    if menstrual_pain in ("moderate", "severe"):
+        return {
+            "active": True,
+            "menstrual_pain": menstrual_pain,
+            "menstruation_today": menstruation_today,
+            "reason": f"rapporterede menstruationssmerter ({menstrual_pain})"
+        }
+
+    return None
+
 def build_today_plan_priority_decision(
     auth_user,
     readiness_score,
@@ -2571,6 +2623,7 @@ def build_today_plan_priority_decision(
     time_budget_min,
     training_day_ctx,
     weekly_status,
+    latest_checkin=None,
 ):
     local_override = build_local_risk_planning_override(
         auth_user.get("user_id") if isinstance(auth_user, dict) else None,
@@ -2582,6 +2635,24 @@ def build_today_plan_priority_decision(
     if isinstance(local_override, dict):
         local_override["weekly_status"] = weekly_status
         return local_override
+
+    menstruation_signal = get_menstruation_planning_signal(latest_checkin)
+    if isinstance(menstruation_signal, dict):
+        return {
+            "session_type": "restitution",
+            "template_id": "restitution_easy",
+            "plan_entries": build_restitution_plan(time_budget_min),
+            "plan_variant": "menstruation_support_override",
+            "reason": f"{menstruation_signal.get('reason')} · restitution prioriteres",
+            "autoplan_meta": {
+                "template_mode": "menstruation_support_v0_1",
+                "families_selected": [],
+                "menstruation_support_applied": True,
+                "menstrual_pain": menstruation_signal.get("menstrual_pain"),
+                "menstruation_today": menstruation_signal.get("menstruation_today"),
+            },
+            "weekly_status": weekly_status,
+        }
 
     if readiness_score <= 3:
         return {
@@ -3119,6 +3190,7 @@ def get_today_plan():
         time_budget_min=time_budget_min,
         training_day_ctx=training_day_ctx,
         weekly_status=weekly_status,
+        latest_checkin=latest_checkin,
     )
 
     if isinstance(priority_decision_ctx, dict):

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1212,6 +1212,7 @@ function renderProfileEquipmentCard(){
   const trainingTypes = preferences.training_types && typeof preferences.training_types === "object"
     ? preferences.training_types
     : {};
+  const menstruationSupportEnabled = preferences.menstruation_support_enabled === true;
   const trainingDays = preferences.training_days && typeof preferences.training_days === "object"
     ? preferences.training_days
     : {};
@@ -1337,6 +1338,7 @@ function populateEquipmentEditor(){
   const trainingTypes = preferences.training_types && typeof preferences.training_types === "object"
     ? preferences.training_types
     : {};
+  const menstruationSupportEnabled = preferences.menstruation_support_enabled === true;
   const trainingDays = preferences.training_days && typeof preferences.training_days === "object"
     ? preferences.training_days
     : {};
@@ -1365,6 +1367,7 @@ function populateEquipmentEditor(){
   setChecked("pref_strength_weights", trainingTypes.strength_weights !== false);
   setChecked("pref_bodyweight", trainingTypes.bodyweight !== false);
   setChecked("pref_mobility", trainingTypes.mobility !== false);
+  setChecked("pref_menstruation_support_enabled", menstruationSupportEnabled);
 
   setChecked("day_mon", trainingDays.mon !== false);
   setChecked("day_tue", trainingDays.tue !== false);
@@ -1427,6 +1430,7 @@ async function handleEquipmentSettingsSubmit(ev){
         bodyweight: readChecked("pref_bodyweight"),
         mobility: readChecked("pref_mobility"),
       },
+      menstruation_support_enabled: readChecked("pref_menstruation_support_enabled"),
       training_days: {
         mon: readChecked("day_mon"),
         tue: readChecked("day_tue"),
@@ -1455,6 +1459,7 @@ async function handleEquipmentSettingsSubmit(ev){
     const res = await apiPost("/api/user-settings", payload);
     STATE.userSettings = res?.item && typeof res.item === "object" ? res.item : payload;
     await refreshAll();
+    updateMenstruationCheckinVisibility();
     setEquipmentEditorOpen(false);
     if (statusEl) statusEl.textContent = tr("status.equipment_saved");
   }catch(err){
@@ -3086,11 +3091,26 @@ async function handleWorkoutSubmit(ev){
   }
 }
 
+function updateMenstruationCheckinVisibility(){
+  const prefs = STATE.userSettings && typeof STATE.userSettings === "object" && STATE.userSettings.preferences && typeof STATE.userSettings.preferences === "object"
+    ? STATE.userSettings.preferences
+    : {};
+  const enabled = prefs.menstruation_support_enabled === true;
+  const block = document.getElementById("menstruationCheckinFields");
+  if (block){
+    block.classList.toggle("wizard-step-hidden", !enabled);
+  }
+}
+
 async function handleRecoverySubmit(ev){
   ev.preventDefault();
 
   const form = ev.currentTarget;
   const statusEl = document.getElementById("recoveryFormStatus");
+
+  const menstruationEnabled = STATE.userSettings && typeof STATE.userSettings === "object" && STATE.userSettings.preferences && typeof STATE.userSettings.preferences === "object"
+    ? STATE.userSettings.preferences.menstruation_support_enabled === true
+    : false;
 
   const payload = {
     date: form.recovery_date.value,
@@ -3099,7 +3119,9 @@ async function handleRecoverySubmit(ev){
     soreness_score: Number(form.soreness_score.value),
     time_budget_min: Number(form.time_budget_min.value || 45),
     notes: form.recovery_notes.value.trim(),
-    local_signals: collectLocalCheckinSignals(form)
+    local_signals: collectLocalCheckinSignals(form),
+    menstruation_today: menstruationEnabled ? Boolean(form.menstruation_today?.checked) : null,
+    menstrual_pain: menstruationEnabled ? String(form.menstrual_pain?.value || "none") : "none"
   };
 
   try{
@@ -3114,10 +3136,13 @@ async function handleRecoverySubmit(ev){
     form.energy_score.value = "3";
     form.soreness_score.value = "2";
     form.time_budget_min.value = "45";
+    if (form.menstruation_today) form.menstruation_today.checked = false;
+    if (form.menstrual_pain) form.menstrual_pain.value = "none";
     ["knee", "low_back", "shoulder", "elbow", "hip", "ankle_calf", "wrist"].forEach((region) => {
       if (form[`local_signal_${region}`]) form[`local_signal_${region}`].value = "";
     });
     await refreshAll();
+    updateMenstruationCheckinVisibility();
     advanceWizardAfterCheckin();
   }catch(err){
     setText("recoveryFormStatus", tr("status.error_prefix") + (err?.message || String(err)));
@@ -3823,6 +3848,7 @@ function initCheckinScoreButtons(){
   enhanceCheckinScoreField("sleep_score");
   enhanceCheckinScoreField("energy_score");
   enhanceCheckinScoreField("soreness_score");
+  updateMenstruationCheckinVisibility();
 }
 
 

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -404,6 +404,7 @@
             <label class="training-option"><input id="pref_strength_weights" type="checkbox"><span data-i18n="settings.strength_weights">Styrke med vægte</span></label>
             <label class="training-option"><input id="pref_bodyweight" type="checkbox"><span data-i18n="training_type.bodyweight">Kropsvægtøvelser</span></label>
             <label class="training-option"><input id="pref_mobility" type="checkbox"><span data-i18n="settings.mobility_recovery">Mobility and recovery</span></label>
+            <label class="training-option"><input id="pref_menstruation_support_enabled" type="checkbox"><span>Vis valgfri menstruationsfelter i check-in</span></label>
 
             <div style="margin:16px 0 6px; font-weight:700" data-i18n="profile.training_days_title">Jeg kan typisk træne på</div>
             <div class="small" style="margin-bottom:8px" data-i18n="profile.training_days_help">Dage du ikke vælger her, bliver altid hviledage.</div>
@@ -857,6 +858,22 @@
             <option value="60">60 min</option>
           </select>
         </label>
+
+        <div id="menstruationCheckinFields" class="wizard-step-hidden">
+          <label>
+            <span>Menstruation i dag</span>
+            <input id="menstruation_today" name="menstruation_today" type="checkbox">
+          </label>
+          <label>
+            <span>Menstruationssmerter</span>
+            <select id="menstrual_pain" name="menstrual_pain">
+              <option value="none">Ingen</option>
+              <option value="light">Lette</option>
+              <option value="moderate">Moderate</option>
+              <option value="severe">Svære</option>
+            </select>
+          </label>
+        </div>
 
         <label>
           <span data-i18n="checkin.notes">Noter</span>


### PR DESCRIPTION
## Summary

This PR adds a first optional menstruation-aware planning signal.

## Included

- adds optional check-in fields for:
  - `menstruation_today`
  - `menstrual_pain`
- validates and stores the new fields in backend check-ins
- adds a first planning override for `moderate` or `severe` menstrual pain
- returns restitution with explicit explanation when menstruation-related pain should dominate the daily plan
- adds frontend support for:
  - `preferences.menstruation_support_enabled`
  - conditional menstruation-related check-in fields

## Why

The previous check-in model was too neutral in the bad way.

It relied on generic signals like sleep, energy, soreness, and time, but could not distinguish between:

- general low readiness
- reduced capacity or higher protection need related to menstruation-related pain

This PR adds a compact optional signal so the planner can behave less naively when relevant.

## Behavior

When menstruation support is enabled and the latest check-in reports:

- `menstrual_pain = moderate` or
- `menstrual_pain = severe`

the planner can return:

- `session_type = restitution`
- `plan_variant = menstruation_support_override`
- an explicit reason describing the menstruation-related pain signal

## Validation

Validated directly in live backend runtime:

- check-in stored:
  - `menstruation_today = true`
  - `menstrual_pain = moderate`
- `build_today_plan_priority_decision(...)` returned:
  - `session_type = restitution`
  - `plan_variant = menstruation_support_override`
  - reason:
    - `rapporterede menstruationssmerter (moderate) · restitution prioriteres`
  - `autoplan_meta.menstruation_support_applied = true`

## Notes

This is a first version.

It does not attempt to:
- infer cycle phases
- track cycles
- diagnose anything
- build a full hormonal model

It adds a compact optional signal that can improve planning quality for users who want it.

## Follow-up

The current simplified UI no longer exposes profile/settings in a normal user path, so the new frontend settings toggle is wired but not yet reachable through the main interaction flow.

A follow-up should reintroduce an intuitive settings entrypoint so optional check-in support features can be enabled without manual backend edits.