### PR TITLE
Add secondary utility navigation because overview and settings should stay reachable without cluttering the main training flow

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1527,10 +1527,13 @@ function updateOverviewLayoutForStep(stepId){
   cards.forEach(card => {
     let keepVisible =
       card.id === "forecastHero" ||
-      card.id === "overviewStatusCard";
+      card.id === "overviewStatusCard" ||
+      card.id === "profileEquipmentCard";
 
     if (stepId === "overview" && dailyUiState === "needs_checkin"){
-      keepVisible = card.id === "forecastHero";
+      keepVisible =
+        card.id === "forecastHero" ||
+        card.id === "profileEquipmentCard";
     }
 
     card.classList.toggle(
@@ -3417,6 +3420,35 @@ function getWizardSections(){
   };
 }
 
+function renderUtilityNav(){
+  const root = document.getElementById("utilityNav");
+  if (!root) return;
+
+  const items = [
+    { id: "overview", label: getWizardStepLabel({ labelKey: "wizard.overview" }) },
+    { id: "profile", label: tr("overview.profile_equipment") },
+    { id: "manual", label: getWizardStepLabel({ labelKey: "wizard.manual" }) },
+    { id: "history", label: getWizardStepLabel({ labelKey: "wizard.history" }) },
+  ];
+
+  root.innerHTML = items.map(item => `
+      <button type="button" data-utility-step="${esc(item.id)}">
+        ${esc(item.label)}
+      </button>
+    `).join("");
+
+  root.querySelectorAll("[data-utility-step]").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const target = String(btn.getAttribute("data-utility-step") || "").trim();
+      if (target === "profile"){
+        setEquipmentEditorOpen(true);
+        return;
+      }
+      showWizardStep(target);
+    });
+  });
+}
+
 function renderWizardNav(){
   const root = document.getElementById("wizardNav");
   if (!root) return;
@@ -3518,6 +3550,7 @@ function showWizardStep(stepId){
   updateReviewHeadingForStep(stepId);
   updateOverviewLayoutForStep(stepId);
   renderWizardNav();
+  renderUtilityNav();
   requestAnimationFrame(() => {
     const groups = getWizardSections();
     const firstNode = (groups[stepId] || []).find(Boolean);

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -178,6 +178,26 @@
       outline:2px solid var(--accent);
       transform:translateY(-1px);
     }
+    .utility-nav{
+      display:flex;
+      gap:8px;
+      flex-wrap:wrap;
+      margin:0 0 14px;
+      align-items:center;
+    }
+    .utility-nav button{
+      width:auto;
+      padding:7px 11px;
+      border-radius:999px;
+      opacity:.88;
+      background:#141414;
+      border:1px solid #2c2c2c;
+      transition:opacity .15s ease, border-color .15s ease, background .15s ease;
+    }
+    .utility-nav button:hover{
+      opacity:1;
+      border-color:var(--accent);
+    }
     .wizard-step-hidden{
       display:none !important;
     }
@@ -333,6 +353,7 @@
     </div>
     <p data-i18n="app.tagline">Styrke, løb og restitution. Lokal-first, forklarbar og uden cloud-afhængighed.</p>
     <div id="wizardNav" class="wizard-nav"></div>
+    <div id="utilityNav" class="utility-nav"></div>
 
     <div class="grid" id="overviewSection">
       <section class="card" id="forecastHero" style="grid-column:1/-1">


### PR DESCRIPTION
## Summary

This PR adds a secondary utility navigation layer so overview and settings remain easy to reach without overloading the primary training flow.

## Why

The simplified UI correctly emphasized the daily flow, but it also hid important secondary areas too aggressively.

That made users lose access or orientation around:

- overview
- profile and settings
- manual workout
- history

The app remained technically functional, but the navigation model felt too closed.

## Included

- keeps the existing primary wizard navigation focused on:
  - check-in
  - today's plan
  - after training
- adds a compact secondary utility navigation for:
  - overview
  - profile/settings
  - manual workout
  - history
- reuses the existing settings modal for profile/settings
- keeps `profileEquipmentCard` visible in overview, including `needs_checkin` state

## Result

The app now has:

- a clear primary daily flow
- a compact secondary access layer for non-primary but important areas

This preserves the simplified UI without making key areas hard to find.

## Notes

This is a navigation refinement, not a large shell rewrite.
It intentionally reuses existing functionality and avoids adding new state or modal systems.