### PR TITLE
Fix planned rest-day flow because acknowledged rest days must close review

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -668,6 +668,10 @@ def build_checkin_item(user_id, payload, existing_item=None):
     if err:
         return None, err, status
 
+    rest_day_acknowledged, err, status = _parse_optional_bool(payload.get("rest_day_acknowledged"), "rest_day_acknowledged")
+    if err:
+        return None, err, status
+
     menstrual_pain, err, status = _parse_menstrual_pain(payload.get("menstrual_pain"))
     if err:
         return None, err, status
@@ -690,6 +694,7 @@ def build_checkin_item(user_id, payload, existing_item=None):
         "notes": notes,
         "local_signals": local_signals,
         "menstruation_today": menstruation_today,
+        "rest_day_acknowledged": rest_day_acknowledged,
         "menstrual_pain": menstrual_pain,
         "created_at": existing_item.get("created_at") or datetime.now(timezone.utc).isoformat()
     }
@@ -6135,10 +6140,11 @@ def put_checkin(checkin_id):
         log_auth_failure("checkin:put", auth_err)
         return auth_err
 
+    payload = request.get_json(silent=True) or {}
     item, err_payload, status = update_checkin(
         auth_user.get("user_id"),
         checkin_id,
-        request.get_json(silent=True) or {}
+        payload
     )
     if err_payload is not None:
         payload, status = ensure_error_contract(err_payload, status)

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -238,16 +238,29 @@ function isPlannedRestDayPlan(planItem){
   return String(weekItem?.kind || "").trim().toLowerCase() === "rest";
 }
 
+function getAcknowledgedRestDayCheckin(latestCheckin, planItem){
+  const item = latestCheckin && typeof latestCheckin === "object" ? latestCheckin : null;
+  if (!item) return null;
+
+  const today = new Date().toISOString().slice(0,10);
+  const itemDate = String(item.date || "").slice(0,10);
+  if (itemDate !== today) return null;
+  if (item.rest_day_acknowledged !== true) return null;
+
+  return item;
+}
+
 function deriveDailyUiState(planItem, latestCheckin, sessionResults){
   const today = new Date().toISOString().slice(0,10);
   const latestDate = String(latestCheckin?.date || "").slice(0,10);
   const hasCheckinToday = latestDate === today;
   const hasPlan = !!(planItem && typeof planItem === "object");
   const completedToday = hasCompletedSessionToday(sessionResults);
+  const acknowledgedRestDay = Boolean(getAcknowledgedRestDayCheckin(latestCheckin, planItem));
   const plannedRestToday = isPlannedRestDayPlan(planItem);
 
   if (!hasCheckinToday) return "no_checkin_yet";
-  if (completedToday) return "completed_today";
+  if (completedToday || acknowledgedRestDay) return "completed_today";
   if (plannedRestToday) return "planned_rest_today";
   if (hasPlan) return "plan_ready";
   return "overview";
@@ -2583,9 +2596,11 @@ function renderSessionReview(item){
   const root = document.getElementById("sessionReviewList");
   const form = document.getElementById("sessionResultForm");
   const completedTodayItem = !STATE.editingSessionResultId ? getCompletedSessionToday(STATE.sessionResults || []) : null;
+  const acknowledgedRestDayItem = !STATE.editingSessionResultId ? getAcknowledgedRestDayCheckin(STATE.latestCheckin || null, STATE.currentTodayPlan || null) : null;
+  const isClosedDay = Boolean(completedTodayItem || acknowledgedRestDayItem);
 
   if (form){
-    if (completedTodayItem){
+    if (isClosedDay){
       form.classList.add("wizard-step-hidden");
       form.querySelectorAll("input, select, textarea").forEach(el => {
         el.disabled = true;
@@ -2625,6 +2640,14 @@ function renderSessionReview(item){
     toggleCardioReviewFields(null);
     setText("sessionResultStatus", "");
     renderSessionResultSummary(storedSummary);
+    return;
+  }
+
+  if (acknowledgedRestDayItem){
+    root.innerHTML = `<li><div class="small">${esc(tr("today_plan.rest_day_acknowledged_saved"))}</div></li>`;
+    toggleCardioReviewFields(null);
+    setText("sessionResultStatus", "");
+    renderRestDayAcknowledgedSummary(acknowledgedRestDayItem, STATE.currentTodayPlan || null);
     return;
   }
 
@@ -2730,6 +2753,28 @@ function renderReviewSummary(item){
 
 
 
+
+function renderRestDayAcknowledgedSummary(checkinItem, planItem){
+  const root = document.getElementById("reviewPlanSummary");
+  if (!root) return;
+
+  const item = checkinItem && typeof checkinItem === "object" ? checkinItem : {};
+  const bits = [];
+
+  if (item.readiness_score != null){
+    bits.push(`${tr("overview.readiness")}: ${esc(String(item.readiness_score))}`);
+  }
+  if (item.time_budget_min){
+    bits.push(tr("overview.time_today_short", { minutes: item.time_budget_min }));
+  }
+
+  root.innerHTML = `
+    <div style="font-weight:700; margin-bottom:10px; color:#4ade80">✔ ${esc(tr("today_plan.rest_day_logged_title"))}</div>
+    <div class="small" style="margin-bottom:8px">${esc(tr("today_plan.rest_day_logged_text"))}</div>
+    ${bits.length ? `<div class="small" style="margin-bottom:8px">${bits.map(x => esc(x)).join(" · ")}</div>` : ""}
+    ${buildNextPlannedSessionHtml(planItem || null)}
+  `;
+}
 
 function renderSessionResultSummary(summary){
   const root = document.getElementById("reviewPlanSummary");
@@ -3302,7 +3347,7 @@ function renderTodayPlan(item){
   const heroActions = isPlannedRestDay
     ? `
     <div style="margin-top:12px; display:flex; gap:10px; flex-wrap:wrap">
-      <button type="button" id="startRecoveryBtn">${esc(tr("plan.light_movement_today"))}</button>
+      <button type="button" id="acknowledgeRestDayBtn">${esc(tr("today_plan.acknowledge_rest_day"))}</button>
       <button type="button" class="secondary" id="openManualTrainingBtn">${esc(tr("wizard.manual"))}</button>
     </div>
     `
@@ -3369,9 +3414,7 @@ function renderTodayPlan(item){
   document.getElementById("startWorkoutBtn")?.addEventListener("click", () => {
     showWizardStep("review");
   });
-  document.getElementById("startRecoveryBtn")?.addEventListener("click", () => {
-    showWizardStep("review");
-  });
+  document.getElementById("acknowledgeRestDayBtn")?.addEventListener("click", handleRestDayAcknowledge);
   document.getElementById("openManualTrainingBtn")?.addEventListener("click", () => {
     showWizardStep("manual");
   });
@@ -3947,6 +3990,60 @@ function updateMenstruationCheckinVisibility(){
   const block = document.getElementById("menstruationCheckinFields");
   if (block){
     block.classList.toggle("wizard-step-hidden", !enabled);
+  }
+}
+
+
+async function handleRestDayAcknowledge(){
+  const latestCheckin = STATE.latestCheckin && typeof STATE.latestCheckin === "object" ? STATE.latestCheckin : null;
+  const plan = STATE.currentTodayPlan && typeof STATE.currentTodayPlan === "object" ? STATE.currentTodayPlan : null;
+  const statusEl = document.getElementById("sessionResultStatus");
+
+  const checkinId = String(latestCheckin?.id || "").trim();
+  const checkinDate = String(latestCheckin?.date || plan?.date || plan?.recommended_for || "").trim();
+
+  if (!checkinId || !checkinDate){
+    setText("sessionResultStatus", tr("today_plan.rest_day_checkin_required"));
+    statusEl?.classList.remove("ok");
+    statusEl?.classList.add("warn");
+    return;
+  }
+
+  const payload = {
+    date: checkinDate,
+    sleep_score: Number(latestCheckin.sleep_score || 0),
+    energy_score: Number(latestCheckin.energy_score || 0),
+    soreness_score: Number(latestCheckin.soreness_score || 0),
+    time_budget_min: Number(latestCheckin.time_budget_min || 45),
+    notes: String(latestCheckin.notes || "").trim(),
+    local_signals: Array.isArray(latestCheckin.local_signals) ? latestCheckin.local_signals : [],
+    menstruation_today: latestCheckin.menstruation_today ?? null,
+    menstrual_pain: String(latestCheckin.menstrual_pain || "none"),
+    rest_day_acknowledged: true
+  };
+
+  try{
+    setText("sessionResultStatus", tr("today_plan.rest_day_acknowledging"));
+    statusEl?.classList.remove("warn");
+
+    const res = await apiJsonRequest("PUT", `/api/checkins/${encodeURIComponent(checkinId)}`, payload);
+
+    const acknowledgedCheckin = res?.item && typeof res.item === "object"
+      ? { ...res.item, rest_day_acknowledged: true }
+      : { ...latestCheckin, ...payload, rest_day_acknowledged: true };
+
+    STATE.latestCheckin = acknowledgedCheckin;
+
+    statusEl?.classList.add("ok");
+    setText("sessionResultStatus", tr("today_plan.rest_day_acknowledged_saved"));
+    await refreshAll();
+    STATE.latestCheckin = { ...(STATE.latestCheckin || {}), ...acknowledgedCheckin, rest_day_acknowledged: true };
+    renderSessionReview(STATE.currentTodayPlan || null);
+    showWizardStep("review");
+  }catch(err){
+    setText("sessionResultStatus", tr("status.error_prefix") + (err?.message || String(err)));
+    statusEl?.classList.remove("ok");
+    statusEl?.classList.add("warn");
   }
 }
 
@@ -5156,7 +5253,7 @@ function buildNextPlannedSessionHtml(planItem){
   const nextTraining = info.nextTraining;
 
   const tomorrowLine = tomorrow && tomorrow.kind === "rest"
-    ? `<div class="small" style="margin-bottom:6px">${esc(tr("review.tomorrow_label"))}: ${esc(tr("weekplan.label.rest"))} · ${esc(tomorrow.dateLabel || "")}</div>`
+    ? `<div class="small" style="margin-bottom:6px">${esc(tr("review.tomorrow_rest_label"))} · ${esc(tomorrow.dateLabel || "")}</div>`
     : "";
 
   return `

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -269,6 +269,7 @@
   "review.next_progression_label": "Progression næste gang",
   "review.next_planned_session_label": "Næste planlagte træning",
   "review.tomorrow_label": "I morgen",
+  "review.tomorrow_rest_label": "I morgen er planlagt hviledag",
   "review.session_saved_button": "Session gemt",
   "status.startup_error_prefix": "Fejl før opstart: ",
   "checkin.sleep_score_label": "Søvn (1-5)",
@@ -538,5 +539,11 @@
   "progression.increase_reps_next_time": "Øg reps næste gang",
   "progression.hold_load_today": "Hold {load} i dag",
   "progression.hold_current_load_today": "Hold nuværende belastning i dag",
-  "status.ready_to_save_equipment": "Redigér profil og udstyr, og gem når du er klar."
+  "status.ready_to_save_equipment": "Redigér profil og udstyr, og gem når du er klar.",
+  "today_plan.acknowledge_rest_day": "Registrer hviledag",
+  "today_plan.rest_day_checkin_required": "Du skal have et check-in i dag, før du kan registrere hviledag.",
+  "today_plan.rest_day_acknowledging": "Registrerer hviledag...",
+  "today_plan.rest_day_acknowledged_saved": "Hviledag registreret.",
+  "today_plan.rest_day_logged_title": "Hviledag registreret",
+  "today_plan.rest_day_logged_text": "Dagens planlagte hviledag er registreret."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -258,6 +258,7 @@
   "review.next_progression_label": "Next progression",
   "review.next_planned_session_label": "Next planned session",
   "review.tomorrow_label": "Tomorrow",
+  "review.tomorrow_rest_label": "Tomorrow is a planned rest day",
   "review.session_saved_button": "Session saved",
   "status.startup_error_prefix": "Startup error: ",
   "checkin.sleep_score_label": "Sleep (1-5)",
@@ -527,5 +528,11 @@
   "progression.increase_reps_next_time": "Increase reps next time",
   "progression.hold_load_today": "Hold {load} today",
   "progression.hold_current_load_today": "Hold the current load today",
-  "status.ready_to_save_equipment": "Edit profile and equipment, then save when you're ready."
+  "status.ready_to_save_equipment": "Edit profile and equipment, then save when you're ready.",
+  "today_plan.acknowledge_rest_day": "Log rest day",
+  "today_plan.rest_day_checkin_required": "You need a check-in for today before you can log a rest day.",
+  "today_plan.rest_day_acknowledging": "Logging rest day...",
+  "today_plan.rest_day_acknowledged_saved": "Rest day logged.",
+  "today_plan.rest_day_logged_title": "Rest day logged",
+  "today_plan.rest_day_logged_text": "Today's planned rest day has been logged."
 }


### PR DESCRIPTION
## Summary
- add explicit planned rest-day acknowledgement instead of routing rest-day CTA into workout review
- treat acknowledged rest days as closed days in the daily UI flow
- show a completed-style rest-day summary with forward-looking next-session guidance
- localize remaining rest-day forward-planning labels in Danish and English

## What changed
- added `rest_day_acknowledged` to the check-in model
- replaced the planned rest-day CTA with a dedicated **Log rest day / Registrer hviledag** action
- added frontend handling for acknowledged rest days so they count as a closed daily state
- hide the session-result form when the day is closed by either:
  - a completed session, or
  - an acknowledged planned rest day
- added a dedicated acknowledged-rest summary in review/status
- preserved local acknowledged rest-day UI state after refresh so the screen closes correctly immediately
- changed the forward-looking rest-day label from generic `Tomorrow: Rest` style wording to a more human readable rest-day sentence

## User impact
On a planned rest day, the user can now:
- explicitly log the rest day
- avoid being pushed into a fake workout-review flow
- see the day as completed/closed
- still see the next planned training guidance afterward

This removes the earlier contradiction where the app said it was a rest day but still asked the user to fill out training results.

## Validation
- `python3 -m py_compile app/backend/app.py`
- `node --check app/frontend/app.js`
- `python3 -m json.tool app/frontend/i18n/da.json >/dev/null`
- `python3 -m json.tool app/frontend/i18n/en.json >/dev/null`
- manual live test:
  - planned rest day can be acknowledged
  - review form no longer remains open after rest-day acknowledgement
  - completed-style status with next planned training is shown

## Notes
The backend model now accepts `rest_day_acknowledged` on check-ins.
The frontend currently preserves acknowledged rest-day state immediately after the successful PUT response so the UI closes deterministically for the user.

Closes #194