### PR TITLE
Refine explicit daily UI states and completed-day overview flow

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1618,7 +1618,9 @@ function getForecastTypeLabel(planItem){
 function renderForecastHero(planItem, latestCheckin){
   setText("forecastDate", planItem?.recommended_for || latestCheckin?.date || "");
 
-  const completedToday = hasCompletedSessionToday(STATE.sessionResults || []);
+  const dailyUiState = deriveDailyUiState(planItem || null, latestCheckin || null, STATE.sessionResults || []);
+  const completedToday = dailyUiState === "completed_session_today";
+  const completedRestDayToday = dailyUiState === "completed_rest_day_today";
   const plannedRestToday = isPlannedRestDayPlan(planItem);
 
   if (!planItem){
@@ -1633,15 +1635,22 @@ function renderForecastHero(planItem, latestCheckin){
     return;
   }
 
-  if (completedToday){
+  if (completedToday || completedRestDayToday){
     setText("forecastType", "Færdig i dag");
-    setText("forecastSummary", "Dagens session er gemt.");
+    setText(
+      "forecastSummary",
+      completedRestDayToday ? tr("today_plan.rest_day_acknowledged_saved") : "Dagens session er gemt."
+    );
 
     const bits = [];
-    if (planItem.session_type) bits.push(formatSessionType(planItem.session_type));
-    if (planItem.time_budget_min) bits.push(tr("forecast.time_label", { minutes: planItem.time_budget_min }));
-    if (planItem.recovery_state && typeof planItem.recovery_state === "object"){
-      bits.push(tr("forecast.recovery_label", { value: `${formatRecoveryState(planItem.recovery_state.recovery_state || "")}${planItem.recovery_state.recovery_score != null ? ` (${planItem.recovery_state.recovery_score})` : ""}` }));
+    if (completedRestDayToday) {
+      bits.push(tr("today_plan.rest_day_logged_title"));
+    } else {
+      if (planItem?.session_type) bits.push(formatSessionType(planItem.session_type));
+      if (planItem?.time_budget_min) bits.push(tr("forecast.time_label", { minutes: planItem.time_budget_min }));
+      if (planItem?.recovery_state && typeof planItem.recovery_state === "object"){
+        bits.push(tr("forecast.recovery_label", { value: `${formatRecoveryState(planItem.recovery_state.recovery_state || "")}${planItem.recovery_state.recovery_score != null ? ` (${planItem.recovery_state.recovery_score})` : ""}` }));
+      }
     }
 
     const nextGuidanceMessage = String(planItem?.next_guidance?.message || "").trim();
@@ -1654,7 +1663,7 @@ function renderForecastHero(planItem, latestCheckin){
     const btn = document.getElementById("forecastPrimaryBtn");
     if (btn){
       btn.textContent = "Se status";
-      btn.onclick = () => showWizardStep("review");
+      btn.onclick = () => showWizardStep(completedRestDayToday ? "overview" : "review");
     }
     return;
   }


### PR DESCRIPTION
## What
- splits completed daily UI state into completed session vs completed rest day
- aligns overview layout logic with actual daily state names
- updates forecast hero so completed training days and completed rest days are shown differently
- keeps completed rest days in a clearer day-closed overview state

## Why
Issue #111 is about making the primary daily flow more explicit and less contradictory.

Previously:
- the frontend still used a dead state name in overview layout logic
- completed training and completed rest days were treated as the same frontend state
- the forecast/overview layer remained too session-centric even when the user had actually completed the day by acknowledging a planned rest day

## Result
The frontend daily state model is now more explicit, and the completed-day overview better matches what the user actually did that day.