### PR TITLE
Add deterministic exercise import pipeline

### DIFF
--- a/scripts/audit_exercise_model.py
+++ b/scripts/audit_exercise_model.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
 
-DATA_PATH = Path("app/data/seed/exercises.json")
+DEFAULT_DATA_PATH = Path("app/data/seed/exercises.json")
 
 REQUIRED_FIELDS = {
     "id",
@@ -60,11 +61,17 @@ def warn(msg: str) -> None:
 
 
 def main() -> None:
-    if not DATA_PATH.exists():
-        fail(f"Missing file: {DATA_PATH}")
+    parser = argparse.ArgumentParser(description="Validate exercise JSON against the SovereignStrength exercise model contract.")
+    parser.add_argument("--input", default=str(DEFAULT_DATA_PATH), help="Path to exercise JSON file")
+    args = parser.parse_args()
+
+    data_path = Path(args.input)
+
+    if not data_path.exists():
+        fail(f"Missing file: {data_path}")
 
     try:
-        items = json.loads(DATA_PATH.read_text(encoding="utf-8"))
+        items = json.loads(data_path.read_text(encoding="utf-8"))
     except Exception as exc:
         fail(f"Could not parse JSON: {exc}")
 
@@ -132,6 +139,7 @@ def main() -> None:
             fail(f"{item_id}: progression_ladder must be a list when present")
 
     print(f"OK: validated {len(items)} exercise entries against the exercise model contract")
+    print(f"Source: {data_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/import_exercises.py
+++ b/scripts/import_exercises.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = REPO_ROOT / "tmp" / "imported_exercises.json"
+
+REQUIRED_OUTPUT_FIELDS = {
+    "id",
+    "name",
+    "name_en",
+    "category",
+    "category_en",
+    "default_unit",
+    "difficulty_tier",
+    "equipment_type",
+    "input_kind",
+    "load_increment",
+    "load_optional",
+    "local_load_targets",
+    "movement_pattern",
+    "notes",
+    "notes_en",
+    "progression_mode",
+    "progression_step",
+    "progression_style",
+    "recommended_step",
+    "set_options",
+    "start_weight",
+    "supports_bodyweight",
+    "supports_load",
+}
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}")
+    sys.exit(1)
+
+def slugify(value: str) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    text = re.sub(r"_+", "_", text).strip("_")
+    return text or "unknown_exercise"
+
+def as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+def map_record(raw: dict[str, Any]) -> dict[str, Any]:
+    name = str(raw.get("name") or raw.get("title") or "").strip()
+    name_en = str(raw.get("name_en") or raw.get("english_name") or name).strip()
+    category = str(raw.get("category") or "general").strip()
+    category_en = str(raw.get("category_en") or category).strip()
+    equipment_type = str(raw.get("equipment_type") or raw.get("equipment") or "bodyweight").strip()
+    movement_pattern = str(raw.get("movement_pattern") or raw.get("movement") or "general").strip()
+
+    input_kind = str(raw.get("input_kind") or "reps").strip()
+    default_unit = str(raw.get("default_unit") or ("sec" if input_kind in ("time", "cardio_time") else "reps")).strip()
+
+    supports_load = bool(raw.get("supports_load", equipment_type not in ("bodyweight", "none")))
+    supports_bodyweight = bool(raw.get("supports_bodyweight", equipment_type == "bodyweight"))
+    load_optional = bool(raw.get("load_optional", supports_bodyweight))
+
+    item = {
+        "id": slugify(str(raw.get("id") or name or name_en)),
+        "name": name or name_en or "Unknown exercise",
+        "name_en": name_en or name or "Unknown exercise",
+        "category": category or "general",
+        "category_en": category_en or category or "general",
+        "default_unit": default_unit,
+        "difficulty_tier": int(raw.get("difficulty_tier", 1) or 1),
+        "equipment_type": equipment_type or "bodyweight",
+        "input_kind": input_kind,
+        "load_increment": float(raw.get("load_increment", 0) or 0),
+        "load_optional": load_optional,
+        "local_load_targets": as_list(raw.get("local_load_targets") or ["general"]),
+        "movement_pattern": movement_pattern or "general",
+        "notes": str(raw.get("notes") or "").strip(),
+        "notes_en": str(raw.get("notes_en") or raw.get("notes") or "").strip(),
+        "progression_mode": str(raw.get("progression_mode") or "reps_only").strip(),
+        "progression_step": float(raw.get("progression_step", 0) or 0),
+        "progression_style": str(raw.get("progression_style") or "standard").strip(),
+        "recommended_step": float(raw.get("recommended_step", 0) or 0),
+        "set_options": as_list(raw.get("set_options") or [1, 2, 3]),
+        "start_weight": float(raw.get("start_weight", 0) or 0),
+        "supports_bodyweight": supports_bodyweight,
+        "supports_load": supports_load,
+    }
+
+    optional_map = {
+        "rep_options": raw.get("rep_options"),
+        "time_options": raw.get("time_options"),
+        "load_options": raw.get("load_options"),
+        "image_folder": raw.get("image_folder"),
+        "external_images": raw.get("external_images"),
+        "progression_channels": raw.get("progression_channels"),
+        "progression_ladder": raw.get("progression_ladder"),
+        "rep_display_hint": raw.get("rep_display_hint"),
+    }
+
+    for key, value in optional_map.items():
+        if value not in (None, "", []):
+            item[key] = value
+
+    missing = sorted(field for field in REQUIRED_OUTPUT_FIELDS if field not in item)
+    if missing:
+        fail(f"{item['id']}: mapped record missing required output fields: {', '.join(missing)}")
+
+    return item
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Transform external exercise JSON into SovereignStrength contract format.")
+    parser.add_argument("--input", required=True, help="Path to external JSON input")
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT), help="Path to write transformed JSON")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    if not input_path.exists():
+        fail(f"Input file not found: {input_path}")
+
+    try:
+        raw = json.loads(input_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        fail(f"Could not parse input JSON: {exc}")
+
+    if not isinstance(raw, list):
+        fail("Input JSON must be a top-level list of exercise objects")
+
+    mapped: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    for idx, entry in enumerate(raw, start=1):
+        if not isinstance(entry, dict):
+            fail(f"Input entry #{idx} is not an object")
+
+        item = map_record(entry)
+
+        if item["id"] in seen_ids:
+            fail(f"Duplicate mapped id: {item['id']}")
+        seen_ids.add(item["id"])
+        mapped.append(item)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(mapped, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    print(f"OK: transformed {len(mapped)} exercises")
+    print(f"Output: {output_path}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary

This PR completes issue #116 by adding a deterministic exercise import pipeline for external exercise catalogs.

What this adds

- "scripts/import_exercises.py"
  
  - reads an external JSON list of exercise records
  - maps records into the SovereignStrength exercise contract
  - normalizes exercise ids
  - applies conservative defaults for missing metadata
  - writes transformed output to a separate file
  - fails on invalid input shape or duplicate mapped ids

- "scripts/audit_exercise_model.py"
  
  - now supports "--input"
  - can validate both the main seed dataset and imported output files
  - reports the validated source path

Why

Issue #116 is about controlled catalog expansion, not manual JSON dumping.

With #115 already defining the exercise model contract, this PR adds the next foundation piece:

- deterministic transformation
- repeatable validation
- explicit compatibility with the documented schema

This makes later catalog integration safer and more maintainable.

Scope

This PR is intentionally limited to:

- import pipeline structure
- schema mapping
- validation compatibility

It does not yet:

- merge imported records into the active seed catalog
- import a full external catalog into production
- implement selection logic or variation behavior
- redesign frontend catalog browsing

Validation

Tested with a small external sample:

python3 scripts/import_exercises.py --input tmp/external_exercises_sample.json --output tmp/imported_exercises.json
python3 scripts/audit_exercise_model.py --input tmp/imported_exercises.json

Observed result:

OK: transformed 2 exercises
OK: validated 2 exercise entries against the exercise model contract

Related

Closes #116