### PR TITLE
Import curated first wave of bodyweight exercises

### DIFF
--- a/app/data/seed/exercises.json
+++ b/app/data/seed/exercises.json
@@ -397,7 +397,7 @@
     ],
     "image_folder": "Plank",
     "external_images": [
-      "/images/plank/0.jpg"
+      "/assets/exercise-db/Plank/1.jpg"
     ],
     "name_en": "Plank",
     "category_en": "core",

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -3071,7 +3071,22 @@ function formatVariationName(value){
 function getExerciseImages(exerciseId){
   const meta = getExerciseMeta(exerciseId);
   const images = Array.isArray(meta?.external_images) ? meta.external_images : [];
-  return images.filter(Boolean);
+  const imageFolder = String(meta?.image_folder || "").trim();
+  return images
+    .filter(Boolean)
+    .map(src => {
+      const value = String(src || "").trim();
+      if (!value) return "";
+      if (value.startsWith("/images/")){
+        const filename = value.split("/").pop();
+        if (imageFolder && filename){
+          return `/assets/exercise-db/${imageFolder}/${filename}`;
+        }
+      }
+      if (value.startsWith("/")) return value;
+      return `/assets/exercise-db/${value}`;
+    })
+    .filter(Boolean);
 }
 
 function openExerciseViewer(exerciseId){


### PR DESCRIPTION
Summary

This PR completes a first controlled pass on issue #107 by importing a curated first wave of bodyweight exercises into the SovereignStrength seed catalog and fixing exercise image resolution for both imported and legacy exercise entries.

What this adds

Catalog expansion

- 20 new bodyweight exercise entries added to "app/data/seed/exercises.json"
- preserved source image references via:
  - "image_folder"
  - "external_images"
- normalized exercise metadata for SovereignStrength use, including:
  - "equipment_type = bodyweight"
  - "supports_bodyweight = true"
  - "supports_load = false"
  - curated "movement_pattern"
  - curated "local_load_targets"

Image handling fix

- updated frontend image resolution logic in "app/frontend/app.js"
- relative image paths now resolve to "/assets/exercise-db/..."
- legacy "/images/..." references are translated to the correct asset location using "image_folder"
- corrected the seed reference for "plank" to use the correct image frame

Why

Issue #107 is about expanding the exercise catalog in a structured way, not bulk-dumping raw external data into the seed file.

This PR intentionally uses a curated first-wave subset from "free-exercise-db" and normalizes the imported entries so they are more compatible with:

- planning
- review behavior
- future progression work
- future controlled variation work

In practice, catalog import also exposed an image path mismatch between older and newer exercise entries, so this PR includes the minimal frontend/data fixes needed to make exercise images actually render correctly.

Scope

This PR is intentionally limited to a first curated bodyweight wave plus the image-resolution fixes required to support exercise presentation.

It does not yet:

- import the full external catalog
- solve all metadata enrichment gaps
- implement variation logic
- redesign exercise browsing UI

Validation

Ran:

python3 scripts/audit_exercise_model.py

Observed result:

OK: validated 54 exercise entries against the exercise model contract
Source: app/data/seed/exercises.json

Also verified live behavior:

- imported exercise images render
- legacy "plank" image renders correctly after reference correction
- relative and legacy image paths both resolve correctly in the exercise viewer

Related

Closes #107