### PR TITLE
Prefer controlled variation over recent exercise repeats

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -5765,11 +5765,25 @@ def choose_exercise_for_family(user_id, family_key, readiness=None, time_budget_
             reasons.append("er foreslået næste variation")
 
         last_date = last_trained_map.get(ex_id)
+        days_since_last = None
         if last_date:
+            days_since_last = days_since_date(last_date)
+
+        if days_since_last is None:
+            score += 0.35
+            reasons.append("ingen nylig historik")
+        elif days_since_last >= 14:
             score += 0.3
-            reasons.append("har historik")
-        else:
+            reasons.append("ikke trænet for nylig")
+        elif days_since_last >= 7:
             score += 0.1
+            reasons.append("har lidt afstand")
+        elif days_since_last >= 3:
+            score -= 0.15
+            reasons.append("trænet for nylig")
+        else:
+            score -= 0.35
+            reasons.append("meget nyligt trænet")
 
         progression_mode = str(item.get("progression_mode", "")).strip()
         if progression_mode == "double_progression":


### PR DESCRIPTION
Summary

This PR delivers a first controlled-variation pass for issue #108 by adjusting family-based exercise selection to reduce repeated exercise picks when equally valid alternatives exist.

What changed

In "choose_exercise_for_family(...)", exercise scoring now considers how recently a candidate exercise was last trained:

- no recent history gets a small preference
- exercises not trained for a while get a positive preference
- recently trained exercises get reduced preference
- very recently trained exercises get the strongest penalty

The existing "next_variation" preference remains in place, so the system still respects learned progression signals.

Why

Before this change, exercises with history could receive a slight positive bias simply for having been used before.

That made family selection lean too easily toward repetition, even when the catalog now contains more valid alternatives inside the same movement family.

This PR keeps the selection deterministic, but makes it more variation-aware by preferring:

- suggested progression variation
- less recently used alternatives
- reduced repetition of the exact same exercise

Scope

This is intentionally a first controlled-variation step.

It does not yet:

- introduce a full variation engine
- redesign substitution logic
- add randomized exercise rotation
- alter broader family-priority selection

Validation

Ran:

python3 -m py_compile app/backend/app.py

The change is limited to the scoring block in "choose_exercise_for_family(...)".

Related

Closes #108