### PR TITLE
Enrich canonical bodyweight entries from imported equivalents

### DIFF
--- a/app/data/seed/exercises.json
+++ b/app/data/seed/exercises.json
@@ -551,7 +551,7 @@
     "default_unit": "reps",
     "progression_step": 0,
     "start_weight": 0,
-    "notes": "Bodyweight push alternative to bench press/shoulder press when equipment is unavailable.",
+    "notes": "Klassisk kropsvægts-pres med fokus på overkrop og kropsspænding.",
     "progression_mode": "reps_only",
     "recommended_step": 0,
     "load_increment": 0,
@@ -595,16 +595,26 @@
     ],
     "image_folder": "Pushups",
     "external_images": [
-      "/assets/exercise-db/Pushups/0.jpg",
-      "/assets/exercise-db/Pushups/1.jpg"
+      "Pushups/0.jpg",
+      "Pushups/1.jpg"
     ],
     "name_en": "Push-ups",
     "category_en": "push",
-    "notes_en": "Bodyweight press as a substitute for bench press/overhead press when equipment is limited.",
+    "notes_en": "Classic bodyweight press focused on upper-body strength and full-body tension.",
     "local_load_targets": [
       "shoulder",
       "elbow",
       "wrist"
+    ],
+    "form_cues": [
+      "Hold kroppen i én linje",
+      "Sænk brystet roligt mod gulvet",
+      "Pres op uden at miste spænding"
+    ],
+    "form_cues_en": [
+      "Keep the body in one line",
+      "Lower the chest under control toward the floor",
+      "Press up without losing tension"
     ]
   },
   {
@@ -666,7 +676,7 @@
     "default_unit": "reps",
     "progression_step": 0,
     "start_weight": 0,
-    "notes": "Bodyweight posterior-chain exercise as a fallback when no barbell is available.",
+    "notes": "Bro-øvelse for baller og hofteekstension med ryggen i rolig kontrol.",
     "progression_mode": "reps_only",
     "recommended_step": 0,
     "load_increment": 0,
@@ -694,10 +704,25 @@
     ],
     "name_en": "Glute bridge",
     "category_en": "posterior chain",
-    "notes_en": "Bodyweight posterior-chain exercise as a fallback when no barbell is available.",
+    "notes_en": "Bridge exercise for glutes and hip extension with controlled spinal position.",
     "local_load_targets": [
       "hip",
       "low_back"
+    ],
+    "external_images": [
+      "Butt_Lift_Bridge/0.jpg",
+      "Butt_Lift_Bridge/1.jpg"
+    ],
+    "image_folder": "Butt_Lift_Bridge",
+    "form_cues": [
+      "Spænd balderne i toppen",
+      "Løft hofterne uden at overstrække lænden",
+      "Sænk roligt tilbage igen"
+    ],
+    "form_cues_en": [
+      "Squeeze the glutes at the top",
+      "Lift the hips without overextending the lower back",
+      "Lower back down under control"
     ]
   },
   {
@@ -707,7 +732,7 @@
     "default_unit": "reps",
     "progression_step": 0,
     "start_weight": 0,
-    "notes": "Easier push variant with elevated hands.",
+    "notes": "Push-up med hænderne hævet for at gøre bevægelsen lettere og mere kontrolleret.",
     "progression_mode": "reps_only",
     "recommended_step": 0,
     "load_increment": 0,
@@ -735,11 +760,26 @@
     ],
     "name_en": "Incline push-ups",
     "category_en": "push",
-    "notes_en": "Easier push variation with elevated hands.",
+    "notes_en": "Push-up with elevated hands to make the movement easier and more controlled.",
     "local_load_targets": [
       "shoulder",
       "elbow",
       "wrist"
+    ],
+    "external_images": [
+      "Incline_Push-Up/0.jpg",
+      "Incline_Push-Up/1.jpg"
+    ],
+    "image_folder": "Incline_Push-Up",
+    "form_cues": [
+      "Hold kroppen i en lige linje",
+      "Sænk brystet roligt mod underlaget",
+      "Pres op uden at lade hofterne hænge"
+    ],
+    "form_cues_en": [
+      "Keep the body in a straight line",
+      "Lower the chest under control toward the support",
+      "Press up without letting the hips sag"
     ]
   },
   {
@@ -1203,7 +1243,7 @@
     "default_unit": "sec",
     "progression_step": 0,
     "start_weight": 0,
-    "notes": "Anti-lateral flexion for the core.",
+    "notes": "Sideplanke for lateral core-stabilitet og skulderkontrol.",
     "progression_mode": "reps_only",
     "recommended_step": 0,
     "load_increment": 0,
@@ -1233,10 +1273,25 @@
     ],
     "name_en": "Side plank",
     "category_en": "core",
-    "notes_en": "Anti-lateral flexion for the core.",
+    "notes_en": "Side plank for lateral core stability and shoulder control.",
     "local_load_targets": [
       "shoulder",
       "low_back"
+    ],
+    "external_images": [
+      "Side_Bridge/0.jpg",
+      "Side_Bridge/1.jpg"
+    ],
+    "image_folder": "Side_Bridge",
+    "form_cues": [
+      "Hold kroppen lang og lige",
+      "Løft hoften aktivt væk fra gulvet",
+      "Hold skulderen stabil over albuen"
+    ],
+    "form_cues_en": [
+      "Keep the body long and straight",
+      "Actively lift the hip away from the floor",
+      "Keep the shoulder stable over the elbow"
     ]
   },
   {


### PR DESCRIPTION
Summary

This PR delivers a first safe cleanup pass for issue #255 by improving the existing canonical legacy bodyweight entries using metadata from the newer imported/enriched equivalents.

What changed

Updated the following legacy bodyweight entries with stronger notes, image references, and form cues copied from the newer imported equivalents:

- "push_ups" ← "pushups"
- "incline_push_ups" ← "incline_push_up"
- "glute_bridge" ← "butt_lift_bridge"
- "side_plank" ← "side_bridge"

The legacy ids remain unchanged, but their metadata quality is now much closer to the newer imported entries.

Why

These legacy ids are still actively referenced in important parts of the system, including:

- re-entry strength planning
- substitution maps
- bodyweight load factor maps
- progression ladders
- seed programs

Because of that, replacing ids directly would create a larger migration problem than this issue needs to solve right now.

This PR instead takes a safer first step:

- keep the currently wired canonical ids
- improve their metadata quality
- make exercise viewing more consistent for entries the system still actively uses

Scope

This PR is intentionally limited to metadata normalization of currently referenced legacy bodyweight entries.

It does not yet:

- replace ids across backend logic and programs
- delete imported overlap entries
- introduce an alias system
- fully deduplicate the full exercise catalog

Outcome

The catalog becomes more consistent where it matters most right now:

- planning still uses the same stable ids
- exercise viewer quality improves for those legacy entries
- overlap between legacy and imported entries becomes less visible to the user

Validation

Ran:

python3 scripts/audit_exercise_model.py

Observed result:

OK: validated 54 exercise entries against the exercise model contract
Source: app/data/seed/exercises.json

Related

Closes #255