### PR TITLE
Trigger strength substitutions on local protection

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2465,13 +2465,25 @@ def build_strength_plan(programs, exercises, latest_strength, time_budget_min, f
         exercise_id = ex.get("exercise_id", "")
         meta = exercise_map.get(exercise_id, {}) or {}
         equipment_type = str(meta.get("equipment_type", "")).strip()
+        local_targets = get_local_load_targets_for_exercise(exercise_id, exercises=exercises)
+        blocked_regions = []
 
-        if not equipment_type:
+        for region in local_targets:
+            info = local_state.get(region, {}) if isinstance(local_state, dict) else {}
+            if not isinstance(info, dict):
+                continue
+            region_state = str(info.get("state", "")).strip()
+            if region_state == "protect":
+                blocked_regions.append(region)
+
+        local_blocked = bool(blocked_regions)
+
+        if not equipment_type and not local_blocked:
             filtered_exercises.append(ex)
             continue
 
-        allowed = bool(available_equipment.get(equipment_type, True))
-        if allowed:
+        allowed = bool(available_equipment.get(equipment_type, True)) if equipment_type else True
+        if allowed and not local_blocked:
             filtered_exercises.append(ex)
             continue
 
@@ -2496,12 +2508,14 @@ def build_strength_plan(programs, exercises, latest_strength, time_budget_min, f
             substitutions_used.append({
                 "from_exercise_id": exercise_id,
                 "to_exercise_id": chosen_substitute_id,
-                "missing_equipment_type": equipment_type
+                "missing_equipment_type": None if allowed else equipment_type,
+                "local_protection_regions": sorted(set(blocked_regions)),
             })
         else:
             excluded_due_to_equipment.append({
                 "exercise_id": exercise_id,
-                "equipment_type": equipment_type
+                "equipment_type": equipment_type,
+                "local_protection_regions": sorted(set(blocked_regions)),
             })
 
     selected_exercises = filtered_exercises


### PR DESCRIPTION
Summary

This PR delivers a first implementation step for issue #171 by allowing local protection state to trigger deterministic strength-exercise substitutions, not only equipment-based substitutions.

What changed

In "build_strength_plan(...)", planned strength exercises are now checked for local "protect" regions based on their "local_load_targets".

If the originally selected exercise is locally blocked, the planner now:

- tries to select a substitute from the existing "substitution_map"
- uses the existing "choose_best_substitute(...)" logic
- preserves training intent where possible instead of only excluding the exercise

The substitution output now also includes:

- "local_protection_regions"

and "missing_equipment_type" is only set when equipment is actually part of the substitution reason.

Why

The app already had:

- exercise-level local target metadata
- local protection state
- equipment-based substitution logic
- deterministic substitute ranking

But strength substitutions were only triggered when equipment was missing.

That meant the engine could recognize a locally blocked region without using the already available substitution path to preserve the session with a safer alternative.

This PR closes that gap for a first safe backend pass.

Scope

This PR intentionally focuses on:

- strength planning
- local "protect" state
- existing substitution infrastructure

It does not yet:

- add caution-based regressions
- extend cardio substitution logic
- redesign session-level local override behavior
- introduce a new substitution engine

Outcome

When a planned strength exercise is locally blocked, the planner can now try a safer deterministic substitute instead of only relying on equipment-based substitution behavior.

This improves local protection without replacing the existing planning structure.

Validation

Ran:

python3 -m py_compile app/backend/app.py

The diff is limited to "build_strength_plan(...)".

Related

Closes #171