### PR TITLE
Prefer hip-dominant squat fallbacks for ankle protection

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2457,6 +2457,11 @@ def build_strength_plan(programs, exercises, latest_strength, time_budget_min, f
         "romanian_deadlift": ["glute_bridge", "single_leg_glute_bridge", "hamstring_walkouts", "hip_hinge_bw"],
     }
 
+    ankle_calf_protect = False
+    ankle_info = local_state.get("ankle_calf", {}) if isinstance(local_state, dict) else {}
+    if isinstance(ankle_info, dict):
+        ankle_calf_protect = str(ankle_info.get("state", "")).strip() == "protect"
+
     filtered_exercises = []
     excluded_due_to_equipment = []
     substitutions_used = []
@@ -2488,6 +2493,14 @@ def build_strength_plan(programs, exercises, latest_strength, time_budget_min, f
             continue
 
         substitute_candidates = substitution_map.get(exercise_id, [])
+        if exercise_id == "squat" and local_blocked and ankle_calf_protect:
+            substitute_candidates = [
+                "glute_bridge",
+                "hamstring_walkouts",
+                "hip_hinge_bw",
+                "split_squat",
+                "step_ups",
+            ]
         if isinstance(substitute_candidates, str):
             substitute_candidates = [substitute_candidates]
 


### PR DESCRIPTION
Summary

This PR improves lower-body substitution quality for issue #258 by preferring hip-dominant fallback options when a squat exercise is locally blocked by ankle/calf protection.

What changed

In "build_strength_plan(...)", when:

- the planned exercise is "squat"
- the exercise is locally blocked
- and "ankle_calf" is in "protect"

the planner now uses a more ankle-aware substitute priority list:

- "glute_bridge"
- "hamstring_walkouts"
- "hip_hinge_bw"
- "split_squat"
- "step_ups"

instead of relying only on the default squat substitution ordering.

Why

The first local-protection substitution layer already allows the planner to avoid unsafe exercises and attempt a substitute.

However, for ankle/calf protection cases, the default squat fallback candidates were still too dominated by knee/unilateral squat-style options.

That could lead to:

- lower-body work disappearing too easily
- weaker preservation of session structure
- substitutions that were still not especially well matched to ankle-sensitive cases

This PR introduces a small deterministic refinement:
when squat is blocked specifically by ankle/calf protection, prefer lower-body options with lower ankle demand first.

Scope

This PR intentionally focuses on:

- "squat"
- "ankle_calf" local "protect"
- strength-plan fallback ordering only

It does not yet:

- generalize the rule to all lower-body patterns
- add new exercise entries
- introduce a full regression engine
- redesign broader local-risk session shaping

Outcome

When squat is blocked by ankle/calf protection, the planner is now more likely to preserve lower-body work through hip-dominant fallback options before trying more ankle-demanding lower-body alternatives.

This keeps the behavior:

- deterministic
- explainable
- conservative
- better aligned with local protection intent

Validation

Ran:

python3 -m py_compile app/backend/app.py

The diff is limited to "build_strength_plan(...)".

Related

Closes #258