### PR TITLE
Add conservative upper-body local fallbacks

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2454,6 +2454,8 @@ def build_strength_plan(programs, exercises, latest_strength, time_budget_min, f
         "bench_press": ["push_ups", "incline_push_ups", "diamond_push_ups"],
         "overhead_press": ["pike_push_ups", "push_ups", "incline_push_ups"],
         "barbell_row": ["dumbbell_row", "reverse_snow_angels", "superman_hold"],
+        "incline_push_ups": ["dead_bug"],
+        "dumbbell_row": ["dead_bug"],
         "romanian_deadlift": ["glute_bridge", "single_leg_glute_bridge", "hamstring_walkouts", "hip_hinge_bw"],
     }
 


### PR DESCRIPTION
Summary

This PR improves strength-plan fallback behavior for issue #263 by adding conservative fallback options when locally protected upper-body exercises would otherwise disappear from the plan without replacement.

What changed

In "build_strength_plan(...)", the substitution map now includes:

- "incline_push_ups" → "dead_bug"
- "dumbbell_row" → "dead_bug"

This means that when these exercises are locally blocked during plan building, the planner can preserve session structure with a conservative fallback instead of simply deleting the affected slot.

Why

Manual testing showed that shoulder, elbow, and wrist local protection could remove upper-body exercises without inserting a replacement.

Observed examples:

- shoulder irritation: incline push-ups and dumbbell row disappeared without replacement
- elbow irritation: incline push-ups and dumbbell row disappeared without replacement
- wrist irritation: incline push-ups disappeared without replacement

That behavior made the session structurally thinner and reduced training intent without any explicit adaptation.

This PR introduces a small deterministic first pass so the planner can preserve more of the session instead of silently shortening it.

Scope

This PR intentionally focuses on:

- "incline_push_ups"
- "dumbbell_row"
- conservative fallback behavior only
- deterministic planning in "build_strength_plan(...)"

It does not yet:

- add a broader upper-body regression engine
- deduplicate fallback choices if multiple blocked exercises resolve to the same safe fallback
- redesign push/pull family handling
- add pseudo-clinical logic

Outcome

When locally protected upper-body exercises would otherwise disappear, the planner now has a conservative fallback path that helps preserve session structure more reliably than before.

This keeps the change:

- small
- deterministic
- explainable
- conservative

Validation

Ran:

python3 -m py_compile app/backend/app.py

The diff is limited to "app/backend/app.py".

Related

Closes #263