### PR TITLE
Deduplicate conservative upper-body fallbacks

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2529,16 +2529,33 @@ def build_strength_plan(programs, exercises, latest_strength, time_budget_min, f
         )
 
         if chosen_substitute_id:
-            substituted = dict(ex)
-            substituted["exercise_id"] = chosen_substitute_id
-            substituted["_substituted_from"] = exercise_id
-            filtered_exercises.append(substituted)
-            substitutions_used.append({
-                "from_exercise_id": exercise_id,
-                "to_exercise_id": chosen_substitute_id,
-                "missing_equipment_type": None if allowed else equipment_type,
-                "local_protection_regions": sorted(set(blocked_regions)),
-            })
+            existing_ids = {
+                str(item.get("exercise_id", "")).strip()
+                for item in filtered_exercises
+                if isinstance(item, dict)
+            }
+            duplicate_conservative_fallback = (
+                chosen_substitute_id in {"dead_bug"}
+                and chosen_substitute_id in existing_ids
+            )
+
+            if duplicate_conservative_fallback:
+                excluded_due_to_equipment.append({
+                    "exercise_id": exercise_id,
+                    "equipment_type": equipment_type,
+                    "local_protection_regions": sorted(set(blocked_regions)),
+                })
+            else:
+                substituted = dict(ex)
+                substituted["exercise_id"] = chosen_substitute_id
+                substituted["_substituted_from"] = exercise_id
+                filtered_exercises.append(substituted)
+                substitutions_used.append({
+                    "from_exercise_id": exercise_id,
+                    "to_exercise_id": chosen_substitute_id,
+                    "missing_equipment_type": None if allowed else equipment_type,
+                    "local_protection_regions": sorted(set(blocked_regions)),
+                })
         else:
             excluded_due_to_equipment.append({
                 "exercise_id": exercise_id,


### PR DESCRIPTION
Summary

This PR improves upper-body fallback quality for issue #267 by preventing repeated conservative fallback substitutions when multiple upper-body exercises are locally blocked in the same plan.

What changed

In "build_strength_plan(...)", when a substitute is selected, the planner now checks whether that substitute is already present in the filtered plan.

For conservative fallback handling, this PR currently deduplicates:

- "dead_bug"

If "dead_bug" has already been inserted or is already present in the plan, a later blocked exercise will no longer add another identical conservative fallback entry.

Why

The first upper-body local fallback pass fixed the problem where blocked exercises simply disappeared.

However, manual testing then showed a new issue:

- shoulder irritation: both "incline_push_ups" and "dumbbell_row" could be replaced by "dead_bug"
- elbow irritation: both "incline_push_ups" and "dumbbell_row" could be replaced by "dead_bug"

That preserved slot count, but produced an obviously poor result:

- repeated identical fallback entries
- weaker session quality
- less meaningful training structure
- a plan that looked mechanically patched rather than conservatively adapted

Scope

This PR intentionally focuses on:

- conservative fallback deduplication
- current upper-body fallback behavior
- deterministic plan shaping only

It does not yet:

- introduce a broader fallback ranking engine
- redesign substitution behavior across all exercise families
- add pseudo-clinical logic
- solve all duplicate scenarios for every substitute

Outcome

When multiple upper-body exercises are locally blocked in the same plan, the planner now avoids inserting repeated copies of the same conservative fallback.

This keeps the behavior:

- deterministic
- conservative
- cleaner than before
- better aligned with explainable adaptation

Validation

Ran:

python3 -m py_compile app/backend/app.py

The diff is limited to "app/backend/app.py".

Related

Closes #267