### PR TITLE
Add ankle_calf local load targets to squat-family bodyweight regressions

### DIFF
--- a/app/data/seed/exercises.json
+++ b/app/data/seed/exercises.json
@@ -53,7 +53,8 @@
     "local_load_targets": [
       "knee",
       "hip",
-      "low_back"
+      "low_back",
+      "ankle_calf"
     ]
   },
   {
@@ -344,7 +345,8 @@
     "notes_en": "Start with bodyweight. Can be increased later.",
     "local_load_targets": [
       "knee",
-      "hip"
+      "hip",
+      "ankle_calf"
     ]
   },
   {
@@ -990,7 +992,8 @@
     "notes_en": "Bodyweight leg exercise, good as a squat substitute.",
     "local_load_targets": [
       "knee",
-      "hip"
+      "hip",
+      "ankle_calf"
     ]
   },
   {
@@ -1030,7 +1033,8 @@
     "notes_en": "Leg exercise focusing on one leg at a time.",
     "local_load_targets": [
       "knee",
-      "hip"
+      "hip",
+      "ankle_calf"
     ]
   },
   {
@@ -1070,7 +1074,8 @@
     "notes_en": "Unilateral leg strength from a chair or bench.",
     "local_load_targets": [
       "knee",
-      "hip"
+      "hip",
+      "ankle_calf"
     ]
   },
   {


### PR DESCRIPTION
## Summary

This PR updates exercise seed metadata for issue #262 so ankle/calf local protection can correctly affect squat-family planning.

## What changed

In `app/data/seed/exercises.json`:

- added `ankle_calf` to `local_load_targets` for:
  - `squat`
  - `lunges`
  - `split_squat`
  - `step_ups`
  - `single_leg_sit_to_stand`

## Why

The existing local-protection planning depends on `local_load_targets` to know when an exercise should be blocked.

These squat-family movements were already marked for:
- `knee`
- `hip`
- and in one case `low_back`

But they did not include `ankle_calf`, which meant ankle/calf protection could miss key squat-pattern bodyweight variants.

That weakened the intended behavior of the existing planning logic:
- ankle-aware blocking could fail
- ankle-aware fallback logic could fail to trigger
- squat-family regressions could remain in the plan when ankle/calf irritation should matter

## Scope

This PR is intentionally limited to:
- seed exercise metadata
- squat-family bodyweight regressions
- one missing local load target dimension

It does not:
- change backend planning logic
- redesign substitution behavior
- alter the exercise contract beyond filling missing metadata

## Validation

Verified the updated entries directly in `app/data/seed/exercises.json` and reviewed the diff to confirm only the intended squat-family entries were changed.

## Related

Closes #262