### PR TITLE
Add a first-run soft landing before the normal daily flow

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -278,6 +278,13 @@ function getTodayCheckin(checkins, latestCheckin, planItem){
   return null;
 }
 
+function isFirstRunUser(planItem, latestCheckin, sessionResults){
+  const hasPlan = !!(planItem && typeof planItem === "object");
+  const hasLatestCheckin = !!(latestCheckin && typeof latestCheckin === "object" && String(latestCheckin.date || "").trim());
+  const hasSessions = Array.isArray(sessionResults) && sessionResults.length > 0;
+  return !hasPlan && !hasLatestCheckin && !hasSessions;
+}
+
 function deriveDailyUiState(planItem, latestCheckin, sessionResults){
   const today = new Date().toISOString().slice(0,10);
   const latestDate = String(latestCheckin?.date || "").slice(0,10);
@@ -287,6 +294,7 @@ function deriveDailyUiState(planItem, latestCheckin, sessionResults){
   const acknowledgedRestDay = Boolean(getAcknowledgedRestDayCheckin(latestCheckin, planItem));
   const plannedRestToday = isPlannedRestDayPlan(planItem);
 
+  if (isFirstRunUser(planItem, latestCheckin, sessionResults)) return "first_run_onboarding";
   if (!hasCheckinToday) return "no_checkin_yet";
   if (completedToday) return "completed_session_today";
   if (acknowledgedRestDay) return "completed_rest_day_today";
@@ -297,6 +305,7 @@ function deriveDailyUiState(planItem, latestCheckin, sessionResults){
 
 function getDefaultWizardStepForDailyState(planItem, latestCheckin, sessionResults){
   const dailyState = deriveDailyUiState(planItem, latestCheckin, sessionResults);
+  if (dailyState === "first_run_onboarding") return "overview";
   if (dailyState === "no_checkin_yet") return "checkin";
   if (dailyState === "planned_rest_today") return "plan";
   if (dailyState === "plan_ready") return "plan";
@@ -1798,6 +1807,44 @@ function renderOverviewStatus(planItem, latestCheckin, workouts){
     } else {
       overviewWorkoutLine.textContent = tr("overview.no_history_yet");
     }
+  }
+
+  renderFirstRunOnboardingCard({
+    planItem: planItem || null,
+    latestCheckin: latestCheckin || null,
+    sessionResults: STATE.sessionResults || []
+  });
+}
+
+function renderFirstRunOnboardingCard({ planItem, latestCheckin, sessionResults } = {}){
+  const card = document.getElementById("firstRunOnboardingCard");
+  const openSetupBtn = document.getElementById("openInitialSetupBtn");
+  const continueBtn = document.getElementById("continueToCheckinBtn");
+  if (!card) return;
+
+  const firstRun = isFirstRunUser(planItem || null, latestCheckin || null, sessionResults || []);
+  card.classList.toggle("wizard-step-hidden", !firstRun);
+  card.style.display = firstRun ? "" : "none";
+
+  if (openSetupBtn && !openSetupBtn.dataset.boundOnboarding){
+    openSetupBtn.dataset.boundOnboarding = "true";
+    openSetupBtn.addEventListener("click", () => {
+      showWizardStep("overview");
+      requestAnimationFrame(() => {
+        setEquipmentEditorOpen(true);
+      });
+    });
+  }
+
+  if (continueBtn && !continueBtn.dataset.boundOnboarding){
+    continueBtn.dataset.boundOnboarding = "true";
+    continueBtn.addEventListener("click", () => {
+      showWizardStep("checkin");
+      const checkinSection = document.getElementById("checkinSection");
+      if (checkinSection && typeof checkinSection.scrollIntoView === "function"){
+        checkinSection.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    });
   }
 }
 
@@ -4560,6 +4607,7 @@ function renderWizardNav(){
   const dailyUiState = deriveDailyUiState(STATE.currentTodayPlan || null, STATE.latestCheckin || null, STATE.sessionResults || []);
 
   const clickableByState = {
+    first_run_onboarding: new Set(["checkin"]),
     no_checkin_yet: new Set(["checkin"]),
     plan_ready: new Set(["checkin", "plan"]),
     planned_rest_today: new Set(["checkin", "plan"]),

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -545,5 +545,15 @@
   "today_plan.rest_day_acknowledging": "Registrerer hviledag...",
   "today_plan.rest_day_acknowledged_saved": "Hviledag registreret.",
   "today_plan.rest_day_logged_title": "Hviledag registreret",
-  "today_plan.rest_day_logged_text": "Dagens planlagte hviledag er registreret."
+  "today_plan.rest_day_logged_text": "Dagens planlagte hviledag er registreret.",
+  "onboarding": {
+    "first_run": {
+      "title": "Velkommen til SovereignStrength",
+      "intro": "Appen hjælper dig med at vælge dagens træning ud fra check-in, udstyr og dine præferencer.",
+      "flow": "Flow: overblik → check-in → dagens plan → efter træning.",
+      "setup_reason": "Jo bedre profil og udstyr er sat op, jo mere brugbar bliver din første anbefaling.",
+      "soft_landing": "Start roligt: kig overblikket igennem, sæt profil og udstyr op, og tag derefter din første check-in.",
+      "continue_checkin": "Fortsæt til check-in"
+    }
+  }
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -534,5 +534,15 @@
   "today_plan.rest_day_acknowledging": "Logging rest day...",
   "today_plan.rest_day_acknowledged_saved": "Rest day logged.",
   "today_plan.rest_day_logged_title": "Rest day logged",
-  "today_plan.rest_day_logged_text": "Today's planned rest day has been logged."
+  "today_plan.rest_day_logged_text": "Today's planned rest day has been logged.",
+  "onboarding": {
+    "first_run": {
+      "title": "Welcome to SovereignStrength",
+      "intro": "The app helps you choose today's training based on check-in, equipment, and your preferences.",
+      "flow": "Flow: overview → check-in → today's plan → after training.",
+      "setup_reason": "The better your profile and equipment are set up, the more useful your first recommendation becomes.",
+      "soft_landing": "Start gently: review the overview, set up profile and equipment, and then take your first check-in.",
+      "continue_checkin": "Continue to check-in"
+    }
+  }
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -368,6 +368,20 @@
           <button type="button" id="forecastPrimaryBtn" class="primary-cta" data-i18n="overview.go_to_checkin">Gå til check-in</button>
         </div>
       </section>
+      <section class="card wizard-step-hidden" id="firstRunOnboardingCard" style="grid-column:1/-1; display:none">
+        <h2 data-i18n="onboarding.first_run.title">Velkommen til SovereignStrength</h2>
+        <p class="small" data-i18n="onboarding.first_run.intro">Appen hjælper dig med at vælge dagens træning ud fra check-in, udstyr og dine præferencer.</p>
+        <div class="overview-status">
+          <div class="stat-line" data-i18n="onboarding.first_run.flow">Flow: overblik → check-in → dagens plan → efter træning.</div>
+          <div class="stat-line" data-i18n="onboarding.first_run.setup_reason">Jo bedre profil og udstyr er sat op, jo mere brugbar bliver din første anbefaling.</div>
+          <div class="stat-line" data-i18n="onboarding.first_run.soft_landing">Start roligt: kig overblikket igennem, sæt profil og udstyr op, og tag derefter din første check-in.</div>
+        </div>
+        <div class="btn-row" style="margin-top:12px">
+          <button type="button" id="openInitialSetupBtn" data-i18n="button.edit_profile_equipment">Redigér profil og udstyr</button>
+          <button type="button" id="continueToCheckinBtn" class="primary-cta" data-i18n="onboarding.first_run.continue_checkin">Fortsæt til check-in</button>
+        </div>
+      </section>
+
       <section class="card" id="overviewStatusCard" style="grid-column:1/-1">
         <h2 data-i18n="overview.status_right_now">Status lige nu</h2>
         <div class="overview-status">


### PR DESCRIPTION
## Summary

This PR implements a first iteration of issue #242 by giving new users a soft landing in overview instead of dropping them directly into the daily check-in on first app launch.

## What changed

In the frontend:

- added `first_run_onboarding` as a daily UI state
- changed first-run default landing from direct check-in to `overview`
- added a first-run onboarding card in overview
- added two clear onboarding actions:
  - edit profile and equipment
  - continue to check-in
- added Danish and English onboarding copy for the new overview card

## Why

New users were previously pushed straight into daily input before the app had explained itself or encouraged initial setup.

That created an onboarding problem:
- the first experience felt abrupt
- users were asked for input before understanding the flow
- profile and equipment setup could easily be skipped
- the app could feel demanding before it felt helpful

This change makes the first experience softer and more supportive without redesigning the full wizard flow.

## Scope

This PR is intentionally limited to a small first iteration:

- first-run users land on overview
- overview shows a dedicated onboarding card
- users are guided toward setup or their first check-in

It does not yet:
- add a full multi-step onboarding wizard
- redesign the full first recommendation flow
- fully implement all setup guidance from #243

## Validation

Ran:

```bash
node --check app/frontend/app.js