### PR TITLE
Add guided initial setup cues before the first recommendation

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1816,15 +1816,105 @@ function renderOverviewStatus(planItem, latestCheckin, workouts){
   });
 }
 
+function buildInitialSetupChecklist(userSettings){
+  const settings = userSettings && typeof userSettings === "object" ? userSettings : {};
+  const profile = settings.profile && typeof settings.profile === "object" ? settings.profile : {};
+  const preferences = settings.preferences && typeof settings.preferences === "object" ? settings.preferences : {};
+  const trainingTypes = preferences.training_types && typeof preferences.training_types === "object" ? preferences.training_types : {};
+  const trainingDays = preferences.training_days && typeof preferences.training_days === "object" ? preferences.training_days : {};
+  const availableEquipment = settings.available_equipment && typeof settings.available_equipment === "object" ? settings.available_equipment : {};
+
+  const hasHeight = profile.height_cm != null && String(profile.height_cm).trim() !== "";
+  const hasBodyweight = profile.bodyweight_kg != null && String(profile.bodyweight_kg).trim() !== "";
+  const hasTrainingType = Object.values(trainingTypes).some(Boolean);
+  const hasTrainingDays = Object.values(trainingDays).some(Boolean);
+  const hasEquipment = Object.values(availableEquipment).some(Boolean);
+  const menstruationConfigured = preferences.menstruation_support_enabled === true || preferences.menstruation_support_enabled === false;
+
+  const items = [
+    {
+      key: "profile",
+      done: hasHeight && hasBodyweight,
+      optional: false,
+      label: tr("onboarding.first_run.checklist.profile"),
+      help: tr("onboarding.first_run.checklist.profile_help")
+    },
+    {
+      key: "training_types",
+      done: hasTrainingType,
+      optional: false,
+      label: tr("onboarding.first_run.checklist.training_types"),
+      help: tr("onboarding.first_run.checklist.training_types_help")
+    },
+    {
+      key: "equipment",
+      done: hasEquipment,
+      optional: false,
+      label: tr("onboarding.first_run.checklist.equipment"),
+      help: tr("onboarding.first_run.checklist.equipment_help")
+    },
+    {
+      key: "planning",
+      done: hasTrainingDays,
+      optional: false,
+      label: tr("onboarding.first_run.checklist.planning"),
+      help: tr("onboarding.first_run.checklist.planning_help")
+    },
+    {
+      key: "physiology",
+      done: menstruationConfigured,
+      optional: true,
+      label: tr("onboarding.first_run.checklist.physiology"),
+      help: tr("onboarding.first_run.checklist.physiology_help")
+    }
+  ];
+
+  const requiredDone = items.filter(x => !x.optional && x.done).length;
+  const requiredTotal = items.filter(x => !x.optional).length;
+  const readyForRecommendation = requiredDone >= requiredTotal;
+
+  return {
+    items,
+    requiredDone,
+    requiredTotal,
+    readyForRecommendation
+  };
+}
+
 function renderFirstRunOnboardingCard({ planItem, latestCheckin, sessionResults } = {}){
   const card = document.getElementById("firstRunOnboardingCard");
   const openSetupBtn = document.getElementById("openInitialSetupBtn");
   const continueBtn = document.getElementById("continueToCheckinBtn");
+  const setupStatus = document.getElementById("firstRunSetupStatus");
+  const checklist = document.getElementById("firstRunChecklist");
   if (!card) return;
 
   const firstRun = isFirstRunUser(planItem || null, latestCheckin || null, sessionResults || []);
   card.classList.toggle("wizard-step-hidden", !firstRun);
   card.style.display = firstRun ? "" : "none";
+
+  const checklistState = buildInitialSetupChecklist(STATE.userSettings || {});
+  if (setupStatus){
+    setupStatus.textContent = checklistState.readyForRecommendation
+      ? tr("onboarding.first_run.ready")
+      : tr("onboarding.first_run.missing_setup", { done: checklistState.requiredDone, total: checklistState.requiredTotal });
+  }
+
+  if (checklist){
+    checklist.innerHTML = checklistState.items.map(item => {
+      const stateLabel = item.done
+        ? tr("onboarding.first_run.status_done")
+        : (item.optional
+          ? tr("onboarding.first_run.status_optional")
+          : tr("onboarding.first_run.status_missing"));
+      return `
+        <div class="stat-line">
+          <strong>${esc(stateLabel)}</strong> · ${esc(item.label)}<br>
+          <span class="small">${esc(item.help)}</span>
+        </div>
+      `;
+    }).join("");
+  }
 
   if (openSetupBtn && !openSetupBtn.dataset.boundOnboarding){
     openSetupBtn.dataset.boundOnboarding = "true";

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -553,7 +553,24 @@
       "flow": "Flow: overblik → check-in → dagens plan → efter træning.",
       "setup_reason": "Jo bedre profil og udstyr er sat op, jo mere brugbar bliver din første anbefaling.",
       "soft_landing": "Start roligt: kig overblikket igennem, sæt profil og udstyr op, og tag derefter din første check-in.",
-      "continue_checkin": "Fortsæt til check-in"
+      "continue_checkin": "Fortsæt til check-in",
+      "ready": "Klar til første anbefaling.",
+      "missing_setup": "Minimum setup: {done}/{total} kerneområder klar.",
+      "status_done": "Klar",
+      "status_missing": "Mangler",
+      "status_optional": "Valgfrit",
+      "checklist": {
+        "profile": "Basisprofil",
+        "profile_help": "Tilføj højde og vægt for mere brugbare anbefalinger.",
+        "training_types": "Træningstyper",
+        "training_types_help": "Vælg om du vil bruge løb, styrke, kropsvægt og/eller mobilitet.",
+        "equipment": "Udstyr",
+        "equipment_help": "Markér hvilket udstyr du faktisk har adgang til.",
+        "planning": "Planlægningspræferencer",
+        "planning_help": "Vælg træningsdage, så appen lettere kan forme første plan.",
+        "physiology": "Fysiologi-hensyn",
+        "physiology_help": "Menstruationsrelaterede hensyn er valgfri og kan sættes op senere."
+      }
     }
   }
-}
+}\n

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -542,7 +542,24 @@
       "flow": "Flow: overview → check-in → today's plan → after training.",
       "setup_reason": "The better your profile and equipment are set up, the more useful your first recommendation becomes.",
       "soft_landing": "Start gently: review the overview, set up profile and equipment, and then take your first check-in.",
-      "continue_checkin": "Continue to check-in"
+      "continue_checkin": "Continue to check-in",
+      "ready": "Ready for a first recommendation.",
+      "missing_setup": "Minimum setup: {done}/{total} core areas ready.",
+      "status_done": "Ready",
+      "status_missing": "Missing",
+      "status_optional": "Optional",
+      "checklist": {
+        "profile": "Basic profile",
+        "profile_help": "Add height and bodyweight for more useful recommendations.",
+        "training_types": "Training types",
+        "training_types_help": "Choose whether you want running, strength, bodyweight, and/or mobility.",
+        "equipment": "Equipment",
+        "equipment_help": "Mark which equipment you actually have access to.",
+        "planning": "Planning preferences",
+        "planning_help": "Choose training days so the app can shape the first plan more intelligently.",
+        "physiology": "Physiology-aware options",
+        "physiology_help": "Menstruation-related considerations are optional and can be configured later."
+      }
     }
   }
-}
+}\n

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -376,6 +376,8 @@
           <div class="stat-line" data-i18n="onboarding.first_run.setup_reason">Jo bedre profil og udstyr er sat op, jo mere brugbar bliver din første anbefaling.</div>
           <div class="stat-line" data-i18n="onboarding.first_run.soft_landing">Start roligt: kig overblikket igennem, sæt profil og udstyr op, og tag derefter din første check-in.</div>
         </div>
+        <div class="small" id="firstRunSetupStatus" style="margin-top:10px"></div>
+        <div class="overview-status" id="firstRunChecklist" style="margin-top:10px"></div>
         <div class="btn-row" style="margin-top:12px">
           <button type="button" id="openInitialSetupBtn" data-i18n="button.edit_profile_equipment">Redigér profil og udstyr</button>
           <button type="button" id="continueToCheckinBtn" class="primary-cta" data-i18n="onboarding.first_run.continue_checkin">Fortsæt til check-in</button>


### PR DESCRIPTION
## Summary

This PR implements a first iteration of issue #243 by adding guided initial setup cues to the new-user onboarding card before the first recommendation.

## What changed

In the frontend:

- added a minimum setup checklist for first-run users
- added a setup readiness summary to the onboarding card
- distinguished between:
  - core setup areas
  - optional physiology-aware settings
- expanded onboarding copy in both Danish and English

## Setup areas now surfaced

The first-run onboarding now shows whether the user has configured:

- basic profile
- training types
- equipment
- planning preferences
- optional physiology-aware settings

## Why

The app previously gave new users too little guidance about which baseline inputs matter before the first recommendation.

That created two problems:
- first recommendations could be under-informed
- users were not clearly guided toward the most important setup areas

This change improves clarity without forcing users through a heavy onboarding wizard.

## Scope

This PR is intentionally limited to a lightweight first iteration:

- guided checklist cues inside the first-run onboarding card
- readiness messaging for minimum setup
- no full multi-step setup wizard
- no backend planning rewrite

## Validation

Ran:

```bash
node --check app/frontend/app.js