### PR TITLE
Harden frontend deploy so partial syncs cannot delete live assets and data

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -65,14 +65,21 @@ Why this is dangerous:
 
 Deploy frontend files explicitly and without destructive delete semantics against the live root.
 
-Safer examples:
+Documented safe path:
+- use `scripts/deploy_frontend_safe.sh`
 
-- copy only `index.html`
-- copy only `app.js`
-- copy only `i18n/da.json`
-- copy only `i18n/en.json`
+This script intentionally:
+- deploys only repo-managed frontend files
+- avoids broad destructive sync against the live root
+- checks that runtime-sensitive live directories such as `assets/` and `data/` still exist after deploy
 
-If rsync is used, it should target explicit files or an isolated static-only directory.
+Current managed frontend file list in the safe script:
+- `index.html`
+- `app.js`
+- `i18n/da.json`
+- `i18n/en.json`
+
+If additional frontend-managed files are added later, update the script in the same change.
 Do not use broad `--delete` sync against `/var/www/sovereign-strength/`.
 
 ### Safe backend deploy

--- a/scripts/deploy_frontend_safe.sh
+++ b/scripts/deploy_frontend_safe.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SRC_ROOT="app/frontend"
+TARGET_ROOT="/var/www/sovereign-strength"
+
+FILES=(
+  "index.html"
+  "app.js"
+  "i18n/da.json"
+  "i18n/en.json"
+)
+
+echo "Safe frontend deploy"
+echo "Source: ${SRC_ROOT}"
+echo "Target: ${TARGET_ROOT}"
+echo
+
+if [[ ! -d "${SRC_ROOT}" ]]; then
+  echo "ERROR: Source root not found: ${SRC_ROOT}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${TARGET_ROOT}" ]]; then
+  echo "ERROR: Target root not found: ${TARGET_ROOT}" >&2
+  exit 1
+fi
+
+for rel in "${FILES[@]}"; do
+  if [[ ! -f "${SRC_ROOT}/${rel}" ]]; then
+    echo "ERROR: Missing source file: ${SRC_ROOT}/${rel}" >&2
+    exit 1
+  fi
+done
+
+echo "Deploying managed frontend files only..."
+for rel in "${FILES[@]}"; do
+  echo "-> ${rel}"
+  sudo mkdir -p "$(dirname "${TARGET_ROOT}/${rel}")"
+  sudo rsync -av "${SRC_ROOT}/${rel}" "${TARGET_ROOT}/${rel}"
+done
+
+echo
+echo "Post-deploy safety checks..."
+
+if [[ ! -d "${TARGET_ROOT}/assets" ]]; then
+  echo "ERROR: assets directory missing after deploy: ${TARGET_ROOT}/assets" >&2
+  exit 1
+fi
+
+if [[ ! -d "${TARGET_ROOT}/data" ]]; then
+  echo "ERROR: data directory missing after deploy: ${TARGET_ROOT}/data" >&2
+  exit 1
+fi
+
+echo "OK: assets directory still present"
+echo "OK: data directory still present"
+echo "Frontend deploy completed safely."


### PR DESCRIPTION
## Summary

This PR implements a first iteration of issue #277 by adding a safe frontend deploy script and documenting it as the preferred deploy path.

## What changed

### Added
- `scripts/deploy_frontend_safe.sh`

### Updated
- `docs/deployment.md`

## Safe deploy behavior

The new frontend deploy script:

- deploys only repo-managed frontend files
- does not use destructive `--delete` sync against the live web root
- checks that runtime-sensitive live directories still exist after deploy:
  - `assets/`
  - `data/`

Current managed frontend file list:

- `index.html`
- `app.js`
- `i18n/da.json`
- `i18n/en.json`

## Why

A recent frontend deploy used a broad partial sync against the live root:

```bash
rsync -av --delete app/frontend/ /var/www/sovereign-strength/