### PR TITLE
Add exercise-only catalog reset for controlled seed sync

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -4385,6 +4385,40 @@ def post_reset_catalog():
         }
     })
 
+
+@app.post("/api/admin/reset-exercises-catalog")
+def post_reset_exercises_catalog():
+    auth_user = require_auth_user()
+    if isinstance(auth_user, tuple):
+        return auth_user
+
+    user_id = auth_user.get("user_id")
+    if not user_id:
+        return jsonify({"ok": False, "error": "missing_user"}), 401
+
+    repo_root = Path(__file__).resolve().parents[2]
+    seed_dir = repo_root / "app" / "data" / "seed"
+    seed_exercises = seed_dir / "exercises.json"
+
+    if not seed_exercises.exists():
+        return jsonify({
+            "ok": False,
+            "error": "missing_seed_file",
+            "seed_file": str(seed_exercises),
+        }), 500
+
+    exercises = read_json_file(seed_exercises)
+    write_json_file(FILES["exercises"], exercises)
+
+    return jsonify({
+        "ok": True,
+        "message": "Exercise catalog reset from seed.",
+        "counts": {
+            "exercises": len(exercises) if isinstance(exercises, list) else 0,
+        }
+    })
+
+
 @app.get("/api/admin/today-plan-debug")
 def get_today_plan_debug():
     auth_user, auth_err = require_auth_user()

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2299,6 +2299,22 @@ async function handleEquipmentSettingsSubmit(ev){
   }
 }
 
+async function handleResetExercisesCatalogFromSeed(){
+  const statusEl = document.getElementById("equipmentSettingsStatus");
+  const btn = document.getElementById("resetExercisesCatalogFromSeedBtn");
+  try{
+    if (btn) btn.disabled = true;
+    if (statusEl) statusEl.textContent = tr("status.resetting_exercises_catalog");
+    await apiPost("/api/admin/reset-exercises-catalog", {});
+    await refreshAll();
+    if (statusEl) statusEl.textContent = tr("status.exercises_catalog_reset_done");
+  }catch(err){
+    if (statusEl) statusEl.textContent = tr("status.error_prefix") + (err?.message || String(err));
+  }finally{
+    if (btn) btn.disabled = false;
+  }
+}
+
 async function handleResetCatalogFromSeed(){
   const statusEl = document.getElementById("equipmentSettingsStatus");
   const btn = document.getElementById("resetCatalogFromSeedBtn");
@@ -2320,6 +2336,7 @@ function bindEquipmentEditor(){
   const openBtn = document.getElementById("openEquipmentSettingsBtn");
   const saveBtn = document.getElementById("saveEquipmentSettingsBtn");
   const cancelBtn = document.getElementById("cancelEquipmentSettingsBtn");
+  const resetExercisesBtn = document.getElementById("resetExercisesCatalogFromSeedBtn");
   const resetBtn = document.getElementById("resetCatalogFromSeedBtn");
   const statusEl = document.getElementById("equipmentSettingsStatus");
 
@@ -2352,6 +2369,11 @@ function bindEquipmentEditor(){
       ev.preventDefault();
       setEquipmentEditorOpen(false);
     };
+  }
+
+  if (resetExercisesBtn && !resetExercisesBtn.dataset.bound){
+    resetExercisesBtn.dataset.bound = "1";
+    resetExercisesBtn.onclick = () => handleResetExercisesCatalogFromSeed();
   }
 
   if (resetBtn && !resetBtn.dataset.bound){

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -609,5 +609,8 @@
   "onboarding.first_run.next_step_ready": "Du kan nu gå videre til dit første check-in.",
   "onboarding.first_run.next_step_missing": "Næste anbefalede skridt: {step}.",
   "onboarding.first_run.action_fix": "Udfyld dette nu",
-  "onboarding.first_run.action_review": "Gennemgå dette"
-}
+  "onboarding.first_run.action_review": "Gennemgå dette",
+  "button.reset_exercises_catalog_from_seed": "Reset kun øvelser",
+  "status.resetting_exercises_catalog": "Nulstiller øvelseskatalog...",
+  "status.exercises_catalog_reset_done": "Øvelseskatalog nulstillet fra seed."
+}\n

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -598,5 +598,8 @@
   "onboarding.first_run.next_step_ready": "You can now continue to your first check-in.",
   "onboarding.first_run.next_step_missing": "Recommended next step: {step}.",
   "onboarding.first_run.action_fix": "Fill this in now",
-  "onboarding.first_run.action_review": "Review this"
-}
+  "onboarding.first_run.action_review": "Review this",
+  "button.reset_exercises_catalog_from_seed": "Reset exercises only",
+  "status.resetting_exercises_catalog": "Resetting exercise catalog...",
+  "status.exercises_catalog_reset_done": "Exercise catalog reset from seed."
+}\n

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -583,7 +583,8 @@
             <div class="btn-row">
               <div style="display:flex;gap:10px;flex-wrap:wrap">
               <button type="submit" id="saveEquipmentSettingsBtn" class="primary-cta" data-i18n="button.save_profile_equipment">Gem profil og udstyr</button>
-              <button type="button" id="resetCatalogFromSeedBtn" class="secondary" data-i18n="button.reset_catalog_from_seed">Reset øvelser og programmer</button>
+              <button type="button" id="resetExercisesCatalogFromSeedBtn" class="secondary" data-i18n="button.reset_exercises_catalog_from_seed">Reset kun øvelser</button>
+                <button type="button" id="resetCatalogFromSeedBtn" class="secondary" data-i18n="button.reset_catalog_from_seed">Reset øvelser og programmer</button>
             </div>
             </div>
           </form>


### PR DESCRIPTION
## Summary
Add a controlled admin path for resetting only the exercise catalog from seed, without also resetting programs.

## Why
The app already had an admin reset route for restoring catalog data from seed, but it was too coarse for normal content maintenance.

`/api/admin/reset-catalog` resets both:
- exercises
- programs

That is acceptable for full catalog recovery, but too destructive when the real need is only to sync updated exercise metadata such as:
- notes
- technique cues
- image mappings

This became especially relevant after improving exercise guidance content, because exercise metadata now changes more often than program structure.

## Changes
### Backend
- add `POST /api/admin/reset-exercises-catalog`
- require authenticated user
- load seed data from `app/data/seed/exercises.json`
- write only to runtime `FILES["exercises"]`
- return exercise count in the response

### Frontend
- add a new equipment/settings action:
  - `Reset kun øvelser`
  - `Reset exercises only`
- add `handleResetExercisesCatalogFromSeed()`
- bind the new button separately from the existing full catalog reset
- keep the existing broader reset button for cases where both exercises and programs should be restored

### i18n
- add Danish and English labels/status strings for the new exercise-only reset flow

## Impact
This gives the app two distinct admin maintenance paths:
- reset exercises only
- reset exercises and programs

That improves operational precision and reduces the chance of unnecessary program resets during normal exercise-catalog maintenance.

## Validation
- `python3 -m py_compile app/backend/app.py`
- `node --check app/frontend/app.js`
- validated `app/frontend/i18n/da.json`
- validated `app/frontend/i18n/en.json`
- reviewed diff across backend, frontend, UI, and i18n files

## Notes
This does not replace the full catalog reset.

It adds a narrower maintenance tool so seed-to-runtime catalog sync can be done more safely when only exercise metadata needs to be refreshed.