### PR TITLE
Fix catalog reset auth handling and invalid i18n JSON endings

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -4350,9 +4350,10 @@ def get_today_plan_traces():
 
 @app.post("/api/admin/reset-catalog")
 def post_reset_catalog():
-    auth_user = require_auth_user()
-    if isinstance(auth_user, tuple):
-        return auth_user
+    auth_user, auth_err = require_auth_user()
+    if auth_err:
+        return auth_err
+
     user_id = auth_user.get("user_id")
     if not user_id:
         return jsonify({"ok": False, "error": "missing_user"}), 401
@@ -4388,9 +4389,9 @@ def post_reset_catalog():
 
 @app.post("/api/admin/reset-exercises-catalog")
 def post_reset_exercises_catalog():
-    auth_user = require_auth_user()
-    if isinstance(auth_user, tuple):
-        return auth_user
+    auth_user, auth_err = require_auth_user()
+    if auth_err:
+        return auth_err
 
     user_id = auth_user.get("user_id")
     if not user_id:

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -613,4 +613,4 @@
   "button.reset_exercises_catalog_from_seed": "Reset kun øvelser",
   "status.resetting_exercises_catalog": "Nulstiller øvelseskatalog...",
   "status.exercises_catalog_reset_done": "Øvelseskatalog nulstillet fra seed."
-}\n
+}

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -602,4 +602,4 @@
   "button.reset_exercises_catalog_from_seed": "Reset exercises only",
   "status.resetting_exercises_catalog": "Resetting exercise catalog...",
   "status.exercises_catalog_reset_done": "Exercise catalog reset from seed."
-}\n
+}


### PR DESCRIPTION
## Summary
Fix the catalog reset admin routes to use the correct auth contract and remove invalid literal `\n` endings from frontend i18n JSON files.

## Why
Two separate runtime problems were uncovered during live testing:

1. the catalog reset routes used outdated auth handling and could fail at runtime
2. the frontend i18n files had literal `\n` characters after the closing JSON brace, which caused JSON parse failures during boot

These issues made the new exercise-only catalog reset flow unreliable until fixed directly in the runtime path.

## Changes

### Backend
Update both admin reset routes to use the actual `require_auth_user()` contract:

- `POST /api/admin/reset-catalog`
- `POST /api/admin/reset-exercises-catalog`

Changed from:
- `auth_user = require_auth_user()`
- `if isinstance(auth_user, tuple): return auth_user`

To:
- `auth_user, auth_err = require_auth_user()`
- `if auth_err: return auth_err`

### Frontend
Fix invalid JSON endings in:
- `app/frontend/i18n/da.json`
- `app/frontend/i18n/en.json`

This removes the literal trailing `\n` text after the closing brace and restores valid JSON parsing.

## Impact
- admin catalog reset routes now follow the same auth pattern as the rest of the backend
- frontend boot no longer fails because of malformed i18n JSON
- the exercise-only catalog reset flow can now work reliably in live operation

## Validation
- `python3 -m py_compile app/backend/app.py`
- validated `app/frontend/i18n/da.json`
- validated `app/frontend/i18n/en.json`
- confirmed live backend health returned `200`
- confirmed reset routes resolved correctly after deploying to the actual runtime backend path

## Notes
This branch captures runtime fixes that were discovered during live debugging and should become repo truth so the system does not regress the next time backend or frontend files are deployed.