### PR TITLE
Make exercise viewer language-aware for guidance copy

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -3319,6 +3319,34 @@ function getExerciseImages(exerciseId){
     .filter(Boolean);
 }
 
+function getExerciseViewerCopy(meta){
+  const item = meta && typeof meta === "object" ? meta : {};
+  const lang = getCurrentLang();
+  const isEnglish = lang === "en";
+
+  const name = String(
+    (isEnglish ? item.name_en : item.name) ||
+    item.name ||
+    item.name_en ||
+    ""
+  ).trim();
+
+  const notes = String(
+    (isEnglish ? item.notes_en : item.notes) ||
+    item.notes ||
+    item.notes_en ||
+    ""
+  ).trim();
+
+  const preferredCues = isEnglish ? item.form_cues_en : item.form_cues;
+  const fallbackCues = isEnglish ? item.form_cues : item.form_cues_en;
+  const formCues = Array.isArray(preferredCues) && preferredCues.length
+    ? preferredCues
+    : (Array.isArray(fallbackCues) ? fallbackCues : []);
+
+  return { name, notes, formCues };
+}
+
 function openExerciseViewer(exerciseId){
   try {
     const modal = document.getElementById("exerciseViewerModal");
@@ -3331,11 +3359,12 @@ function openExerciseViewer(exerciseId){
     }
 
     const meta = getExerciseMeta(exerciseId) || {};
-    const name = meta.name || exerciseId || "Øvelse";
+    const viewerCopy = getExerciseViewerCopy(meta);
+    const name = viewerCopy.name || exerciseId || tr("exercise.viewer_title");
     const images = getExerciseImages(exerciseId);
-    const notes = String(meta.notes || "").trim();
+    const notes = viewerCopy.notes;
     const category = String(meta.category || "").trim();
-    const formCues = Array.isArray(meta.form_cues) ? meta.form_cues.filter(Boolean).map(x => String(x).trim()).filter(Boolean) : [];
+    const formCues = Array.isArray(viewerCopy.formCues) ? viewerCopy.formCues.filter(Boolean).map(x => String(x).trim()).filter(Boolean) : [];
 
     titleEl.textContent = name;
 
@@ -3351,14 +3380,14 @@ function openExerciseViewer(exerciseId){
 
     const notesHtml = notes ? `
       <div style="margin-top:14px;padding:12px 14px;border-radius:14px;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08)">
-        <div style="font-weight:700;margin-bottom:8px">Kort guide</div>
+        <div style="font-weight:700;margin-bottom:8px">${esc(tr("exercise.viewer_short_guide"))}</div>
         <div class="small" style="line-height:1.5">${esc(notes)}</div>
       </div>
     ` : "";
 
     const cuesHtml = formCues.length ? `
       <div style="margin-top:14px;padding:12px 14px;border-radius:14px;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08)">
-        <div style="font-weight:700;margin-bottom:8px">Teknikfokus</div>
+        <div style="font-weight:700;margin-bottom:8px">${esc(tr("exercise.viewer_technique_focus"))}</div>
         <ul style="margin:0;padding-left:18px">
           ${formCues.map(cue => `<li style="margin-bottom:6px">${esc(cue)}</li>`).join("")}
         </ul>

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -612,5 +612,7 @@
   "onboarding.first_run.action_review": "Gennemgå dette",
   "button.reset_exercises_catalog_from_seed": "Reset kun øvelser",
   "status.resetting_exercises_catalog": "Nulstiller øvelseskatalog...",
-  "status.exercises_catalog_reset_done": "Øvelseskatalog nulstillet fra seed."
+  "status.exercises_catalog_reset_done": "Øvelseskatalog nulstillet fra seed.",
+  "exercise.viewer_short_guide": "Kort guide",
+  "exercise.viewer_technique_focus": "Teknikfokus"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -601,5 +601,7 @@
   "onboarding.first_run.action_review": "Review this",
   "button.reset_exercises_catalog_from_seed": "Reset exercises only",
   "status.resetting_exercises_catalog": "Resetting exercise catalog...",
-  "status.exercises_catalog_reset_done": "Exercise catalog reset from seed."
+  "status.exercises_catalog_reset_done": "Exercise catalog reset from seed.",
+  "exercise.viewer_short_guide": "Short guide",
+  "exercise.viewer_technique_focus": "Technique focus"
 }


### PR DESCRIPTION
## Summary
Make the exercise viewer use language-aware guidance copy so English UI surfaces `name_en`, `notes_en`, and `form_cues_en` when available.

## Why
The exercise viewer had improved guidance content, but it still read only the default Danish-oriented metadata fields:

- `name`
- `notes`
- `form_cues`

That meant the viewer stayed partially Danish even when the app UI was switched to English, despite many exercises already having:
- `name_en`
- `notes_en`
- `form_cues_en`

## Changes

### Frontend
Add a small helper:
- `getExerciseViewerCopy(meta)`

This helper:
- checks `getCurrentLang()`
- prefers English fields when the UI language is English
- falls back safely to Danish/default fields when English data is missing

Update `openExerciseViewer()` to use:
- language-aware exercise name
- language-aware short guide text
- language-aware technique cues

### i18n
Add localized section headings:
- `exercise.viewer_short_guide`
- `exercise.viewer_technique_focus`

These are now translated for both Danish and English instead of being hardcoded in Danish.

## Impact
- English users now get a more coherent exercise viewer experience
- existing Danish behavior is preserved
- missing English metadata still falls back gracefully to default fields

## Validation
- `node --check app/frontend/app.js`
- validated `app/frontend/i18n/da.json`
- validated `app/frontend/i18n/en.json`
- reviewed diff for viewer copy selection and localized section headings

## Notes
This change only affects viewer copy selection and section labels.
It does not change exercise data structure, planning logic, or image resolution behavior.