### PR TITLE
Normalize exercise list and summary defaults for language-aware UI

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1002,7 +1002,7 @@ function buildSessionPlanFromHistoryItem(item){
   const results = Array.isArray(item?.results) ? item.results : [];
   return {
     date: item?.date || new Date().toISOString().slice(0,10),
-    session_type: item?.session_type || "styrke",
+    session_type: item?.session_type || "strength",
     timing_state: item?.timing_state || "",
     readiness_score: item?.readiness_score ?? null,
     entries: results.map(result => {
@@ -1260,18 +1260,30 @@ function renderExercises(items){
     return;
   }
 
-  const sorted = [...items].sort((a,b) => String(a.name).localeCompare(String(b.name), "da"));
+  const sorted = [...items].sort((a, b) => {
+    const aCopy = getExerciseDisplayCopy(a);
+    const bCopy = getExerciseDisplayCopy(b);
+    return String(aCopy.name || "").localeCompare(
+      String(bCopy.name || ""),
+      getCurrentLang() === "en" ? "en" : "da"
+    );
+  });
 
-  root.innerHTML = sorted.map(item => `
+  root.innerHTML = sorted.map(item => {
+    const display = getExerciseDisplayCopy(item);
+    const name = display.name || tr("common.unknown_lower");
+    const notes = display.notes;
+    return `
     <li data-recovery-id="${esc(String(item.id || ""))}">
       <div class="row">
-        <strong>${esc(item.name || tr("common.unknown_lower"))}</strong>
+        <strong>${esc(name)}</strong>
         <span class="small">${esc(item.default_unit || "")}</span>
       </div>
       <div class="pill">${esc(formatExerciseCategory(item.category || tr("common.unknown_lower")))}</div>
-      ${item.notes ? `<div class="small" style="margin-top:8px">${esc(item.notes)}</div>` : ""}
+      ${notes ? `<div class="small" style="margin-top:8px">${esc(notes)}</div>` : ""}
     </li>
-  `).join("");
+  `;
+  }).join("");
 
   setText("exerciseMeta", tr("common.items_count", { count: sorted.length }));
 }
@@ -4617,7 +4629,7 @@ async function handleSessionResultSubmit(ev){
     
 session_type:
   plan.session_type
-  || (Array.isArray(plan.entries) && plan.entries.some(e => String(e.exercise_id||"").includes("cardio")) ? "løb" : "styrke"),
+      || (Array.isArray(plan.entries) && plan.entries.some(e => String(e.exercise_id||"").includes("cardio")) ? "run" : "strength"),
 
     timing_state: plan.timing_state || "",
     readiness_score: plan.readiness_score ?? null,
@@ -5387,12 +5399,12 @@ function buildWeeklyPlanPreview(){
     .map(([, label]) => label);
 
   const selectedTypes = [
-    trainingTypes.strength_weights !== false || trainingTypes.bodyweight !== false ? "styrke" : "",
-    trainingTypes.running === true ? "løb" : "",
-    trainingTypes.mobility === true ? "mobilitet" : ""
+    trainingTypes.strength_weights !== false || trainingTypes.bodyweight !== false ? tr("workout.type.strength") : "",
+    trainingTypes.running === true ? tr("session_type.run") : "",
+    trainingTypes.mobility === true ? tr("session_type.mobility") : ""
   ].filter(Boolean);
 
-  let typeLabel = "træning";
+  let typeLabel = tr("common.training_lower");
   if (selectedTypes.length === 1){
     typeLabel = selectedTypes[0];
   } else if (selectedTypes.length > 1){


### PR DESCRIPTION
## Summary
Normalize exercise list rendering and selected frontend summary defaults so English UI no longer falls back to Danish-first values in several common surfaces.

## Why
Issue #341 tracks broader mixed-language leakage across the frontend.

After the earlier viewer, exercise-library preview, and program-display fixes, live sanity checks still showed remaining mixed-language problems in areas such as:
- exercise lists still rendering default names/notes directly
- session/history fallback values still defaulting to Danish-first strings like `styrke` and `løb`
- weekly plan preview still using Danish-first selected training type labels

This batch addresses those remaining frontend defaults and list render paths.

## Changes

### Exercise list rendering
Update `renderExercises(...)` to use language-aware exercise display copy for:
- sorting
- exercise names
- exercise notes

This reuses the centralized display-copy helper instead of rendering raw metadata directly.

### Session type defaults
Normalize Danish-first fallback values to language-neutral internal values:
- `styrke` -> `strength`
- `løb` -> `run`

Applied in:
- session plan reconstruction from history
- session result payload fallback logic

### Weekly plan preview
Update selected training type labels to use translated UI labels instead of hardcoded Danish values:
- strength
- run
- mobility
- generic training label

## Impact
- English UI gets more coherent exercise list rendering
- frontend summaries rely less on Danish-first fallback strings
- Danish UI remains intact through `tr(...)`
- display behavior becomes more consistent across list and summary surfaces

## Validation
- `node --check app/frontend/app.js`
- reviewed diff for:
  - `renderExercises(...)`
  - session type fallback values
  - weekly plan preview selected type labels

## Notes
This is another incremental batch under #341 and does not yet cover every remaining mixed-language surface such as:
- all overview/today-plan backend-driven summaries
- every historical user note field
- every remaining status message or helper with Danish-first wording