### PR TITLE
Translate forecast status labels in overview and today flow

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1657,10 +1657,10 @@ function renderForecastHero(planItem, latestCheckin){
   }
 
   if (completedToday || completedRestDayToday){
-    setText("forecastType", "Færdig i dag");
+    setText("forecastType", tr("forecast.completed_today"));
     setText(
       "forecastSummary",
-      completedRestDayToday ? tr("today_plan.rest_day_acknowledged_saved") : "Dagens session er gemt."
+      completedRestDayToday ? tr("today_plan.rest_day_acknowledged_saved") : tr("forecast.session_saved_today")
     );
 
     const bits = [];
@@ -1683,13 +1683,13 @@ function renderForecastHero(planItem, latestCheckin){
 
     const btn = document.getElementById("forecastPrimaryBtn");
     if (btn){
-      btn.textContent = "Se status";
+      btn.textContent = tr("button.view_status");
       btn.onclick = () => showWizardStep(completedRestDayToday ? "overview" : "review");
     }
     return;
   }
 
-  setText("forecastType", plannedRestToday ? "Hviledag" : getForecastTypeLabel(planItem));
+  setText("forecastType", plannedRestToday ? tr("session_type.rest_day") : getForecastTypeLabel(planItem));
 
   const leadText = plannedRestToday
     ? tr("today_plan.rest_day_planned_today")

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -614,5 +614,9 @@
   "status.resetting_exercises_catalog": "Nulstiller øvelseskatalog...",
   "status.exercises_catalog_reset_done": "Øvelseskatalog nulstillet fra seed.",
   "exercise.viewer_short_guide": "Kort guide",
-  "exercise.viewer_technique_focus": "Teknikfokus"
+  "exercise.viewer_technique_focus": "Teknikfokus",
+  "forecast.completed_today": "Færdig i dag",
+  "forecast.session_saved_today": "Dagens session er gemt.",
+  "button.view_status": "Se status",
+  "session_type.rest_day": "Hviledag"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -603,5 +603,9 @@
   "status.resetting_exercises_catalog": "Resetting exercise catalog...",
   "status.exercises_catalog_reset_done": "Exercise catalog reset from seed.",
   "exercise.viewer_short_guide": "Short guide",
-  "exercise.viewer_technique_focus": "Technique focus"
+  "exercise.viewer_technique_focus": "Technique focus",
+  "forecast.completed_today": "Completed today",
+  "forecast.session_saved_today": "Today's session has been saved.",
+  "button.view_status": "View status",
+  "session_type.rest_day": "Rest day"
 }


### PR DESCRIPTION
## Summary
Translate remaining hardcoded forecast status labels in the overview and today flow so English UI no longer shows Danish-only status text in key forecast states.

## Why
Issue #341 tracks mixed-language leakage across the frontend.

After earlier language-aware fixes for the exercise viewer, exercise library, program display, and exercise lists, live sanity checks still showed very visible Danish-only labels in the forecast hero and related today-flow states, including:

- completed today status
- session saved status
- view status button label
- rest day type label

These are highly visible pieces of daily UI and should not remain hardcoded in Danish when the app is in English mode.

## Changes

### Frontend
Replace hardcoded Danish strings in `renderForecastHero(...)` with translated labels:

- `Færdig i dag`
- `Dagens session er gemt.`
- `Se status`
- `Hviledag`

### i18n
Add the required translation keys to both language files:

- `forecast.completed_today`
- `forecast.session_saved_today`
- `button.view_status`
- `session_type.rest_day`

## Impact
- English UI now gets translated forecast status labels in the overview/today flow
- Danish behavior remains intact
- the most visible remaining Danish-only forecast labels are now normalized into i18n

## Validation
- `node --check app/frontend/app.js`
- validated `app/frontend/i18n/da.json`
- validated `app/frontend/i18n/en.json`
- reviewed diff for forecast hero status rendering

## Notes
This is another incremental batch under #341.

It intentionally focuses on frontend-owned status labels only.
It does not yet attempt to solve every remaining mixed-language case in backend-driven explanations or free-text suggestion fields.