### PR TITLE
Clean up remaining frontend language tail labels

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1155,7 +1155,7 @@ function renderSessionHistory(items){
         </div>
         ${notes ? `<div class="small" style="margin-top:8px">${esc(notes)}</div>` : ""}
         <div class="btn-row" style="margin-top:10px">
-          <a href="/?edit_session=${encodeURIComponent(String(item?.id || ""))}" style="display:inline-block;padding:10px 12px;border:1px solid #2c2c2c;border-radius:10px;background:#242424;color:#f3f3f3;text-decoration:none">Åbn / redigér</a>
+          <a href="/?edit_session=${encodeURIComponent(String(item?.id || ""))}" style="display:inline-block;padding:10px 12px;border:1px solid #2c2c2c;border-radius:10px;background:#242424;color:#f3f3f3;text-decoration:none">${esc(tr("button.open_edit"))}</a>
         </div>
       </li>
     `;
@@ -1514,7 +1514,7 @@ function renderRecovery(items){
       ${item.suggestion ? `<div class="small" style="margin-top:8px">${esc(item.suggestion)}</div>` : ""}
       ${item.notes ? `<div style="margin-top:8px">${esc(item.notes)}</div>` : ""}
       <div class="btn-row" style="margin-top:10px">
-        <a class="edit-recovery-btn" data-recovery-id="${esc(item.id || "")}" href="/?edit_checkin=${encodeURIComponent(String(item.id || ""))}" style="display:inline-block;padding:10px 12px;border:1px solid #2c2c2c;border-radius:10px;background:#242424;color:#f3f3f3;text-decoration:none">Åbn / redigér</a>
+        <a class="edit-recovery-btn" data-recovery-id="${esc(item.id || "")}" href="/?edit_checkin=${encodeURIComponent(String(item.id || ""))}" style="display:inline-block;padding:10px 12px;border:1px solid #2c2c2c;border-radius:10px;background:#242424;color:#f3f3f3;text-decoration:none">${esc(tr("button.open_edit"))}</a>
       </div>
     </li>
   `).join("");
@@ -3937,7 +3937,7 @@ function renderPrograms(programs, exercises){
                 <li>
                   <div class="row">
                     <strong>${esc(name)}</strong>
-                    <span class="small">${tr("exercise.sets_by_reps", { sets: esc(ex.sets ?? ""), reps: esc(ex.reps ?? "") })}</span>
+                    <span class="small">${tr("exercise.sets_by_reps", { sets: esc(ex.sets ?? ""), reps: esc(formatTarget(String(ex.reps ?? ""))) })}</span>
                   </div>
                 </li>
               `;

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -618,5 +618,6 @@
   "forecast.completed_today": "Færdig i dag",
   "forecast.session_saved_today": "Dagens session er gemt.",
   "button.view_status": "Se status",
-  "session_type.rest_day": "Hviledag"
+  "session_type.rest_day": "Hviledag",
+  "button.open_edit": "Åbn / redigér"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -607,5 +607,6 @@
   "forecast.completed_today": "Completed today",
   "forecast.session_saved_today": "Today's session has been saved.",
   "button.view_status": "View status",
-  "session_type.rest_day": "Rest day"
+  "session_type.rest_day": "Rest day",
+  "button.open_edit": "Open / edit"
 }


### PR DESCRIPTION
## Summary
Clean up a few remaining frontend-owned mixed-language labels in session history, recovery history, and program rendering.

## Why
Issue #345 tracks the final frontend-owned language leaks that remained after the larger language-aware cleanup work.

Live sanity checks showed a smaller tail of visible Danish fragments still present in English UI, including:
- `Åbn / redigér` action links in history views
- raw program rep/target text that could still show Danish unit fragments such as `sek`

These are frontend-controlled rendering paths and should be normalized before treating the remaining language gaps as metadata/backend issues.

## Changes

### History action labels
Replace the hardcoded Danish action label in:
- session history
- recovery history

with a translated i18n key:
- `button.open_edit`

### Program target formatting
Update program rendering so the reps/target display goes through `formatTarget(...)` instead of rendering raw `ex.reps` directly.

This allows already-supported target normalization such as:
- `sek` -> localized seconds label
- known cardio target strings -> translated target text where mappings exist

### i18n
Add:
- `button.open_edit` to Danish and English language files

## Impact
- English UI no longer shows `Åbn / redigér` in those history surfaces
- program target/reps text becomes more language-aware and consistent
- this reduces the remaining frontend tail under #345

## Validation
- `node --check app/frontend/app.js`
- validated `app/frontend/i18n/da.json`
- validated `app/frontend/i18n/en.json`
- reviewed diff for:
  - `renderSessionHistory(...)`
  - `renderRecovery(...)`
  - `renderPrograms(...)`

## Notes
This is still frontend-tail cleanup only.

It does not attempt to solve remaining metadata-driven or backend-driven mixed-language content, which belongs in the separate follow-up issue for seed/backend normalization.