### PR TITLE
Backfill English exercise cues and normalize target text fallbacks

### DIFF
--- a/app/data/seed/exercises.json
+++ b/app/data/seed/exercises.json
@@ -61,6 +61,12 @@
       "Hold vægten over midten af foden",
       "Lad knæ og tæer pege nogenlunde samme vej",
       "Pres gulvet væk når du rejser dig"
+    ],
+    "form_cues_en": [
+      "Brace the core before lowering",
+      "Keep the weight over the middle of the foot",
+      "Let the knees and toes point roughly the same way",
+      "Drive the floor away as you stand up"
     ]
   },
   {
@@ -501,6 +507,12 @@
       "Sænk arm og ben langsomt og kontrolleret",
       "Stop før du mister spænding i kroppen",
       "Pust roligt ud mens du holder positionen"
+    ],
+    "form_cues_en": [
+      "Keep the lower back calmly stable through the movement",
+      "Lower the arm and leg slowly and with control",
+      "Stop before you lose trunk tension",
+      "Exhale gently while holding position"
     ]
   },
   {
@@ -711,6 +723,12 @@
       "Træk albuen mod hoften mere end skulderen mod øret",
       "Sænk vægten roligt tilbage",
       "Undgå at vride kroppen for at få vægten op"
+    ],
+    "form_cues_en": [
+      "Keep the chest proud and the back steady",
+      "Pull the elbow toward the hip more than the shoulder toward the ear",
+      "Lower the weight back with control",
+      "Avoid twisting the torso to get the weight up"
     ]
   },
   {

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1731,7 +1731,7 @@ function renderForecastHero(planItem, latestCheckin){
 
   const btn = document.getElementById("forecastPrimaryBtn");
   if (btn){
-    btn.textContent = plannedRestToday ? "Se hviledag" : tr("button.view_today_plan");
+    btn.textContent = plannedRestToday ? tr("button.view_rest_day") : tr("button.view_today_plan");
     btn.onclick = () => showWizardStep("plan");
   }
 }
@@ -2674,6 +2674,16 @@ function formatTarget(value){
     "20 min easy walk or very light jog": tr("cardio.target.easy_walk_or_jog_20")
   };
   if (mappedTargets[v]) return mappedTargets[v];
+
+  const easyRunMatch = v.match(/^(\d+)\s*min\s*roligt løb i snakketempo$/i);
+  if (easyRunMatch){
+    return tr("cardio.target.base_talk_variable", { minutes: easyRunMatch[1] });
+  }
+
+  const easyWalkMatch = v.match(/^(\d+)\s*min\s*rolig gang eller meget let jog$/i);
+  if (easyWalkMatch){
+    return tr("cardio.target.easy_walk_or_jog_variable", { minutes: easyWalkMatch[1] });
+  }
 
   if (v.endsWith("sek") || v.endsWith("sec")){
     const num = v.replace(/\s*(sek|sec)\s*$/, "").trim();

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -619,5 +619,8 @@
   "forecast.session_saved_today": "Dagens session er gemt.",
   "button.view_status": "Se status",
   "session_type.rest_day": "Hviledag",
-  "button.open_edit": "Åbn / redigér"
+  "button.open_edit": "Åbn / redigér",
+  "button.view_rest_day": "Se hviledag",
+  "cardio.target.base_talk_variable": "{minutes} min roligt løb i snakketempo",
+  "cardio.target.easy_walk_or_jog_variable": "{minutes} min rolig gang eller meget let jog"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -608,5 +608,8 @@
   "forecast.session_saved_today": "Today's session has been saved.",
   "button.view_status": "View status",
   "session_type.rest_day": "Rest day",
-  "button.open_edit": "Open / edit"
+  "button.open_edit": "Open / edit",
+  "button.view_rest_day": "View rest day",
+  "cardio.target.base_talk_variable": "{minutes} min easy run at conversational pace",
+  "cardio.target.easy_walk_or_jog_variable": "{minutes} min easy walk or very light jog"
 }


### PR DESCRIPTION
## Summary
Backfill missing English exercise technique cues and normalize frontend target text fallbacks so English UI no longer falls back to Danish in several common exercise and cardio target scenarios.

## Why
Issue #346 covers the remaining mixed-language problems that are now mostly driven by metadata gaps and backend/content-related text rather than broad frontend label cleanup.

A quick audit showed that the exercise metadata gap was smaller than expected:
- no missing `notes_en`
- only 3 exercises missing `form_cues_en`

Those missing English cues caused obvious mixed-language behavior in English UI, where viewers showed:
- English short guide
- Danish technique focus cues

Live sanity checks also showed variable target strings such as:
- `35 min roligt løb i snakketempo`

still leaking into English UI because the frontend target formatter only handled a few fixed hardcoded strings.

## Changes

### Seed exercise metadata
Add `form_cues_en` for:
- `squat`
- `dead_bug`
- `dumbbell_row`

This removes the most obvious mixed-language fallback behavior in the exercise viewer for these common exercises.

### Frontend target formatting
Extend `formatTarget(...)` so it can normalize variable Danish cardio target strings such as:
- `{minutes} min roligt løb i snakketempo`
- `{minutes} min rolig gang eller meget let jog`

into translated frontend output.

### Frontend rest-day button label
Replace the hardcoded Danish rest-day button label with:
- `button.view_rest_day`

### i18n
Add:
- `button.view_rest_day`
- `cardio.target.base_talk_variable`
- `cardio.target.easy_walk_or_jog_variable`

to both Danish and English language files.

## Impact
- English exercise viewers now show English technique cues for the patched exercises
- English UI can render variable cardio target strings more cleanly instead of leaking Danish text
- the rest-day forecast button becomes language-aware
- this reduces the most visible metadata-driven mixed-language cases without yet changing backend guidance generation

## Validation
- `node --check app/frontend/app.js`
- validated:
  - `app/data/seed/exercises.json`
  - `app/frontend/i18n/da.json`
  - `app/frontend/i18n/en.json`
- reviewed diff for:
  - new `form_cues_en` fields
  - `formatTarget(...)` variable target normalization
  - rest-day button label i18n

## Notes
This is batch 1 under #346.

It does not yet solve the larger backend-driven mixed-language issues such as:
- `next_guidance.message`
- backend-composed forecast reason text
- backend decision/reason strings still emitted in Danish