### PR TITLE
Clean up remaining English UI leaks in review flow

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -1302,7 +1302,7 @@ def format_time_progression_target(current_target, increment=5):
     secs = parse_seconds_value(current_target)
     if secs is None:
         return current_target
-    return f"{secs + increment} sek"
+    return f"{secs + increment} sec"
 
 
 def session_has_failure(session):
@@ -1459,13 +1459,13 @@ def build_restitution_plan(time_budget_min):
         time_budget_min = 20
 
     if time_budget_min <= 20:
-        duration = "20 sek"
+        duration = "20 sec"
         rounds = 2
     elif time_budget_min <= 30:
-        duration = "30 sek"
+        duration = "30 sec"
         rounds = 2
     else:
-        duration = "40 sek"
+        duration = "40 sec"
         rounds = 3
 
     return [
@@ -1559,7 +1559,7 @@ def build_reentry_strength_plan(time_budget_min):
         {
             "exercise_id": "bird_dog",
             "sets": rounds,
-            "target_reps": "20 sek",
+            "target_reps": "20 sec",
             "target_load": None,
             "progression_decision": "no_progression",
             "progression_reason": "re-entry strength prioritized",
@@ -5071,19 +5071,19 @@ def build_session_summary(session_item):
 
     session_type_value = str(session_item.get("session_type", "") or "").strip().lower()
     if session_type_value in ("restitution", "recovery", "rest", "mobilitet", "mobility"):
-        post_workout_message = "Dagens restitution er registreret."
+        post_workout_message = "Today's recovery has been logged."
     elif session_type_value in ("løb", "run", "cardio"):
-        post_workout_message = "Dagens konditionssession er gemt."
+        post_workout_message = "Today's cardio session has been saved."
     else:
-        post_workout_message = "Dagens session er gemt."
+        post_workout_message = "Today's session has been saved."
 
     explanation_bits = []
     if fatigue == "high":
-        explanation_bits.append("Høj samlet belastning registreret.")
+        explanation_bits.append("High overall load recorded.")
     elif fatigue == "moderate":
-        explanation_bits.append("Moderat samlet belastning registreret.")
+        explanation_bits.append("Moderate overall load recorded.")
     elif fatigue == "light":
-        explanation_bits.append("Lav samlet belastning registreret.")
+        explanation_bits.append("Light overall load recorded.")
 
     if next_step_hint:
         explanation_bits.append(next_step_hint)

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2763,9 +2763,10 @@ function getReviewRepOptions(meta){
 }
 
 function getReviewTimeOptions(meta){
-  return Array.isArray(meta?.time_options) && meta.time_options.length
+  const options = Array.isArray(meta?.time_options) && meta.time_options.length
     ? meta.time_options
-    : ["20 sek", "30 sek", "40 sek", "45 sek", "60 sek"];
+    : ["20 sec", "30 sec", "40 sec", "45 sec", "60 sec"];
+  return options.map(x => formatTarget(String(x || "").trim()));
 }
 
 function getReviewLoadOptions(meta){
@@ -2790,8 +2791,8 @@ function buildReviewSetFields(entry, idx, setIdx){
         <div class="small" style="margin-bottom:8px">${tr("exercise.set_label", { number: setIdx + 1 })}</div>
 
         <label>
-          Tid
-          ${buildReviewValueSelect(`review_set_reps_${idx}_${setIdx}`, getReviewTimeOptions(meta), existingReps, "(Vælg tid)")}
+          ${tr("input_kind.time")}
+          ${buildReviewValueSelect(`review_set_reps_${idx}_${setIdx}`, getReviewTimeOptions(meta), existingReps, tr("after_training.select_time"))}
         </label>
         <div class="small" style="margin-top:6px">${tr("exercise.load_bodyweight")}</div>
       </div>
@@ -3122,7 +3123,7 @@ function renderReviewSummary(item){
 function buildFeedbackFooterHtml(){
   return `
     <div style="margin-top:14px; display:flex; gap:10px; flex-wrap:wrap">
-      <button type="button" id="finishFeedbackBtn" class="secondary">Til overblik</button>
+      <button type="button" id="finishFeedbackBtn" class="secondary">${tr("button.back_to_overview")}</button>
     </div>
   `;
 }

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -622,5 +622,7 @@
   "button.open_edit": "Åbn / redigér",
   "button.view_rest_day": "Se hviledag",
   "cardio.target.base_talk_variable": "{minutes} min roligt løb i snakketempo",
-  "cardio.target.easy_walk_or_jog_variable": "{minutes} min rolig gang eller meget let jog"
+  "cardio.target.easy_walk_or_jog_variable": "{minutes} min rolig gang eller meget let jog",
+  "after_training.select_time": "(Vælg tid)",
+  "button.back_to_overview": "Til overblik"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -611,5 +611,7 @@
   "button.open_edit": "Open / edit",
   "button.view_rest_day": "View rest day",
   "cardio.target.base_talk_variable": "{minutes} min easy run at conversational pace",
-  "cardio.target.easy_walk_or_jog_variable": "{minutes} min easy walk or very light jog"
+  "cardio.target.easy_walk_or_jog_variable": "{minutes} min easy walk or very light jog",
+  "after_training.select_time": "(Select time)",
+  "button.back_to_overview": "Back to overview"
 }


### PR DESCRIPTION
## Summary
Clean up the remaining visible English UI language leaks in the review flow by normalizing review time labels, the feedback footer button, and backend-generated after-training summary copy.

## Why
Issue #351 tracks the final visible mixed-language leftovers after the larger frontend, metadata, and backend language cleanup work.

Live sanity checks still showed a small but obvious tail in English mode, especially in:
- review time fields and placeholders
- the feedback footer button
- after-training summary copy
- time/progression strings that still used `sek`

These are highly visible last-mile issues and make English mode feel unfinished even though the broader cleanup work is already in place.

## Changes

### Frontend review flow
Update review UI to use language-aware copy for:
- time label
- time placeholder
- time option defaults
- feedback footer button

Examples:
- `Tid` -> translated time label
- `(Vælg tid)` -> translated placeholder
- `20 sek` -> `20 sec`
- `Til overblik` -> translated overview button label

### Backend after-training summary
Normalize backend-generated session summary copy in `build_session_summary(...)`:
- recovery saved message
- cardio saved message
- generic session saved message
- load summary lines:
  - high
  - moderate
  - light overall load

### Backend time strings
Normalize backend-generated time strings from `sek` to `sec` in:
- time progression target formatting
- restitution plan duration targets
- re-entry strength plan time target

## Impact
- English review flow becomes more coherent
- after-training summary no longer shows obvious Danish text
- time-based targets and progression text align better with English UI expectations
- this removes a large part of the final visible English UI tail

## Validation
- `node --check app/frontend/app.js`
- `python3 -m py_compile app/backend/app.py`
- validated:
  - `app/frontend/i18n/da.json`
  - `app/frontend/i18n/en.json`
- reviewed diff for:
  - review time UI
  - feedback footer
  - backend session summary strings
  - backend time target formatting

## Notes
This is a final-tail cleanup batch under #351.

A small remaining follow-up may still be needed if any progression hint or runtime-loaded exercise cue text continues to leak Danish in live UI after deploy.