### PR TITLE
Finish final frontend language tail cleanup

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -5089,7 +5089,7 @@ def build_session_summary(session_item):
         explanation_bits.append(next_step_hint)
 
     if hit_failure_count > 0:
-        explanation_bits.append(f"Failure-markører: {hit_failure_count}")
+        explanation_bits.append(f"Failure markers: {hit_failure_count}")
 
     return {
         "completion_state": "completed_session",

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -598,7 +598,7 @@ function refreshProgramDaySelect(){
   daySelect.innerHTML =
     `<option value="">${tr("workout.no_day_selected")}</option>` +
     program.days.map((day, idx) =>
-      `<option value="${idx}">${esc(day.label || `Dag ${idx+1}`)}</option>`
+      `<option value="${idx}">${esc(getProgramDayDisplayLabel(day) || `${tr("common.day")} ${idx+1}`)}</option>`
     ).join("");
 }
 
@@ -1054,7 +1054,7 @@ async function loadSessionEditFromUrl(){
 
   const statusEl = document.getElementById("sessionResultStatus");
   try{
-    setText("sessionResultStatus", "Åbner session til redigering...");
+    setText("sessionResultStatus", tr("status.opening_session_for_edit"));
     statusEl?.classList.remove("warn");
     const data = await apiJsonRequest("GET", `/api/session-results/${encodeURIComponent(sessionId)}`);
     const item = data?.item;
@@ -1067,7 +1067,7 @@ async function loadSessionEditFromUrl(){
     prefillSessionReviewFormFromHistoryItem(item);
 
     const submitBtn = document.querySelector('#sessionResultForm button[type="submit"]');
-    if (submitBtn) submitBtn.textContent = "Gem ændringer";
+    if (submitBtn) submitBtn.textContent = tr("button.save_changes");
     const deleteBtn = document.getElementById("deleteSessionResultBtn");
     if (deleteBtn) deleteBtn.classList.remove("wizard-step-hidden");
 

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -558,7 +558,7 @@ function applyEntryInputMode(exerciseId){
 
   if (loadEl.tagName === "SELECT"){
     const loadOptions = Array.isArray(meta.load_options) && meta.load_options.length ? meta.load_options : [];
-    const placeholder = loadOptional ? "(Tom = kropsvægt)" : tr("workout.load_placeholder");
+    const placeholder = loadOptional ? tr("workout.load_optional_placeholder") : tr("workout.load_placeholder");
     fillSimpleSelect(loadEl, loadOptions, loadEl.value, placeholder);
   }
 
@@ -2490,12 +2490,17 @@ function getProgramKindDisplayLabel(value){
 function getProgramDayDisplayLabel(day){
   const item = day && typeof day === "object" ? day : {};
   const isEnglish = getCurrentLang() === "en";
-  return String(
+  const raw = String(
     (isEnglish ? item.label_en : item.label) ||
     item.label ||
     item.label_en ||
     tr("common.day")
   ).trim();
+  if (isEnglish){
+    const m = raw.match(/^Dag\s+([A-Z0-9]+)$/i);
+    if (m) return `Day ${m[1].toUpperCase()}`;
+  }
+  return raw;
 }
 
 function getExerciseDisplayCopy(item){
@@ -2824,7 +2829,7 @@ function buildReviewSetFields(entry, idx, setIdx){
 
       <label>
         ${esc(tr("load.title"))}
-        ${buildReviewValueSelect(`review_set_load_${idx}_${setIdx}`, getReviewLoadOptions(meta), existingLoad || currentLoad, meta?.load_optional ? "(Tom = kropsvægt)" : tr("workout.load_placeholder"))}
+        ${buildReviewValueSelect(`review_set_load_${idx}_${setIdx}`, getReviewLoadOptions(meta), existingLoad || currentLoad, meta?.load_optional ? tr("workout.load_optional_placeholder") : tr("workout.load_placeholder"))}
       </label>
 
       ${meta?.load_optional && meta?.supports_bodyweight ? `<div class="small" style="margin-top:6px">${esc(tr("review.bodyweight_empty_means"))}</div>` : ""}
@@ -3233,10 +3238,10 @@ function renderSessionResultSummary(summary){
     </div>
     <div class="small" style="margin-bottom:8px">
       ${esc(tr("after_training.completed_exercises_label"))}: ${esc(String(completedExercises))}/${esc(String(totalExercises))}<br>
-      Sæt: ${esc(String(totalSets))}<br>
-      Reps: ${esc(String(totalReps))}<br>
-      Estimeret volumen: ${esc(String(estimatedVolume))}<br>
-      Failure-markører: ${esc(String(hitFailureCount))}
+      ${esc(tr("review.summary_sets_label"))}: ${esc(String(totalSets))}<br>
+      ${esc(tr("review.summary_reps_label"))}: ${esc(String(totalReps))}<br>
+      ${esc(tr("review.summary_volume_label"))}: ${esc(String(estimatedVolume))}<br>
+      ${esc(tr("review.summary_failure_markers_label"))}: ${esc(String(hitFailureCount))}
     </div>
     <div class="small" style="margin-bottom:8px">
       ${tr("review.next_progression_label")}: ${esc(nextStepHint || tr("common.no_recommendation"))}

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -630,5 +630,7 @@
   "review.summary_reps_label": "Reps",
   "review.summary_tut_label": "TUT",
   "review.summary_volume_label": "Estimeret volumen",
-  "review.summary_failure_markers_label": "Failure-markører"
+  "review.summary_failure_markers_label": "Failure-markører",
+  "status.opening_session_for_edit": "Åbner session til redigering...",
+  "button.save_changes": "Gem ændringer"
 }

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -624,5 +624,11 @@
   "cardio.target.base_talk_variable": "{minutes} min roligt løb i snakketempo",
   "cardio.target.easy_walk_or_jog_variable": "{minutes} min rolig gang eller meget let jog",
   "after_training.select_time": "(Vælg tid)",
-  "button.back_to_overview": "Til overblik"
+  "button.back_to_overview": "Til overblik",
+  "workout.load_optional_placeholder": "(Tom = kropsvægt)",
+  "review.summary_sets_label": "Sæt",
+  "review.summary_reps_label": "Reps",
+  "review.summary_tut_label": "TUT",
+  "review.summary_volume_label": "Estimeret volumen",
+  "review.summary_failure_markers_label": "Failure-markører"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -619,5 +619,7 @@
   "review.summary_reps_label": "Reps",
   "review.summary_tut_label": "TUT",
   "review.summary_volume_label": "Estimated volume",
-  "review.summary_failure_markers_label": "Failure markers"
+  "review.summary_failure_markers_label": "Failure markers",
+  "status.opening_session_for_edit": "Opening session for editing...",
+  "button.save_changes": "Save changes"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -613,5 +613,11 @@
   "cardio.target.base_talk_variable": "{minutes} min easy run at conversational pace",
   "cardio.target.easy_walk_or_jog_variable": "{minutes} min easy walk or very light jog",
   "after_training.select_time": "(Select time)",
-  "button.back_to_overview": "Back to overview"
+  "button.back_to_overview": "Back to overview",
+  "workout.load_optional_placeholder": "(Empty = bodyweight)",
+  "review.summary_sets_label": "Sets",
+  "review.summary_reps_label": "Reps",
+  "review.summary_tut_label": "TUT",
+  "review.summary_volume_label": "Estimated volume",
+  "review.summary_failure_markers_label": "Failure markers"
 }


### PR DESCRIPTION
## Summary
Finish the last visible frontend language-tail cleanup in English mode by normalizing program day labels in the manual workout day selector and removing the final hardcoded Danish edit-session strings.

## Why
After the previous language cleanup batches, live sanity checks showed only a very small remaining frontend tail in English mode:

- `Dag A / Dag B` still appeared in the manual workout program day selector
- edit-session flow still showed Danish strings such as:
  - `Åbner session til redigering...`
  - `Gem ændringer`

The previously observed Danish exercise viewer cues for `squat` and `dead_bug` were confirmed to come from stale exercise data and were resolved by resetting the exercise catalog, so that part is not included in this patch.

## Changes

### Program day selector
Update `refreshProgramDaySelect()` to use `getProgramDayDisplayLabel(day)` instead of raw `day.label`, so English mode now renders:
- `Day A`
- `Day B`

instead of:
- `Dag A`
- `Dag B`

### Edit-session language cleanup
Replace the final hardcoded Danish edit-session strings with i18n-backed labels:
- `status.opening_session_for_edit`
- `button.save_changes`

## Validation
- `node --check app/frontend/app.js`
- validated:
  - `app/frontend/i18n/da.json`
  - `app/frontend/i18n/en.json`
- reviewed diff for:
  - `refreshProgramDaySelect()`
  - `loadSessionEditFromUrl()`
  - English/ Danish i18n additions

## Notes
This patch is intended to remove the final visible frontend language-tail leftovers in English mode.

The earlier mixed-language exercise viewer cues were caused by stale exercise data rather than frontend rendering logic, and were resolved separately by resetting the exercise catalog.