### PR TITLE
Normalize final progression hints to English

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -5089,7 +5089,7 @@ def build_session_summary(session_item):
         explanation_bits.append(next_step_hint)
 
     if hit_failure_count > 0:
-        explanation_bits.append(f"Failure-markører: {hit_failure_count}")
+        explanation_bits.append(f"Failure markers: {hit_failure_count}")
 
     return {
         "completion_state": "completed_session",

--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -5054,13 +5054,13 @@ def build_session_summary(session_item):
 
     if fatigue_points >= 4:
         fatigue = "high"
-        next_step_hint = "Tag en lettere næste session."
+        next_step_hint = "Take a lighter next session."
     elif fatigue_points >= 2:
         fatigue = "moderate"
-        next_step_hint = "Hold progressionen rolig næste session."
+        next_step_hint = "Keep progression conservative next session."
     else:
         fatigue = "light"
-        next_step_hint = "Du kan sandsynligvis progressere næste gang."
+        next_step_hint = "You can probably progress next time."
 
     recovery_recommendation = {
         "level": fatigue,

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -598,7 +598,7 @@ function refreshProgramDaySelect(){
   daySelect.innerHTML =
     `<option value="">${tr("workout.no_day_selected")}</option>` +
     program.days.map((day, idx) =>
-      `<option value="${idx}">${esc(day.label || `Dag ${idx+1}`)}</option>`
+      `<option value="${idx}">${esc(getProgramDayDisplayLabel(day) || `${tr("common.day")} ${idx+1}`)}</option>`
     ).join("");
 }
 
@@ -1054,7 +1054,7 @@ async function loadSessionEditFromUrl(){
 
   const statusEl = document.getElementById("sessionResultStatus");
   try{
-    setText("sessionResultStatus", "Åbner session til redigering...");
+    setText("sessionResultStatus", tr("status.opening_session_for_edit"));
     statusEl?.classList.remove("warn");
     const data = await apiJsonRequest("GET", `/api/session-results/${encodeURIComponent(sessionId)}`);
     const item = data?.item;
@@ -1067,7 +1067,7 @@ async function loadSessionEditFromUrl(){
     prefillSessionReviewFormFromHistoryItem(item);
 
     const submitBtn = document.querySelector('#sessionResultForm button[type="submit"]');
-    if (submitBtn) submitBtn.textContent = "Gem ændringer";
+    if (submitBtn) submitBtn.textContent = tr("button.save_changes");
     const deleteBtn = document.getElementById("deleteSessionResultBtn");
     if (deleteBtn) deleteBtn.classList.remove("wizard-step-hidden");
 

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -558,7 +558,7 @@ function applyEntryInputMode(exerciseId){
 
   if (loadEl.tagName === "SELECT"){
     const loadOptions = Array.isArray(meta.load_options) && meta.load_options.length ? meta.load_options : [];
-    const placeholder = loadOptional ? "(Tom = kropsvægt)" : tr("workout.load_placeholder");
+    const placeholder = loadOptional ? tr("workout.load_optional_placeholder") : tr("workout.load_placeholder");
     fillSimpleSelect(loadEl, loadOptions, loadEl.value, placeholder);
   }
 
@@ -2490,12 +2490,17 @@ function getProgramKindDisplayLabel(value){
 function getProgramDayDisplayLabel(day){
   const item = day && typeof day === "object" ? day : {};
   const isEnglish = getCurrentLang() === "en";
-  return String(
+  const raw = String(
     (isEnglish ? item.label_en : item.label) ||
     item.label ||
     item.label_en ||
     tr("common.day")
   ).trim();
+  if (isEnglish){
+    const m = raw.match(/^Dag\s+([A-Z0-9]+)$/i);
+    if (m) return `Day ${m[1].toUpperCase()}`;
+  }
+  return raw;
 }
 
 function getExerciseDisplayCopy(item){
@@ -2824,7 +2829,7 @@ function buildReviewSetFields(entry, idx, setIdx){
 
       <label>
         ${esc(tr("load.title"))}
-        ${buildReviewValueSelect(`review_set_load_${idx}_${setIdx}`, getReviewLoadOptions(meta), existingLoad || currentLoad, meta?.load_optional ? "(Tom = kropsvægt)" : tr("workout.load_placeholder"))}
+        ${buildReviewValueSelect(`review_set_load_${idx}_${setIdx}`, getReviewLoadOptions(meta), existingLoad || currentLoad, meta?.load_optional ? tr("workout.load_optional_placeholder") : tr("workout.load_placeholder"))}
       </label>
 
       ${meta?.load_optional && meta?.supports_bodyweight ? `<div class="small" style="margin-top:6px">${esc(tr("review.bodyweight_empty_means"))}</div>` : ""}
@@ -3233,10 +3238,10 @@ function renderSessionResultSummary(summary){
     </div>
     <div class="small" style="margin-bottom:8px">
       ${esc(tr("after_training.completed_exercises_label"))}: ${esc(String(completedExercises))}/${esc(String(totalExercises))}<br>
-      Sæt: ${esc(String(totalSets))}<br>
-      Reps: ${esc(String(totalReps))}<br>
-      Estimeret volumen: ${esc(String(estimatedVolume))}<br>
-      Failure-markører: ${esc(String(hitFailureCount))}
+      ${esc(tr("review.summary_sets_label"))}: ${esc(String(totalSets))}<br>
+      ${esc(tr("review.summary_reps_label"))}: ${esc(String(totalReps))}<br>
+      ${esc(tr("review.summary_volume_label"))}: ${esc(String(estimatedVolume))}<br>
+      ${esc(tr("review.summary_failure_markers_label"))}: ${esc(String(hitFailureCount))}
     </div>
     <div class="small" style="margin-bottom:8px">
       ${tr("review.next_progression_label")}: ${esc(nextStepHint || tr("common.no_recommendation"))}

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -630,5 +630,7 @@
   "review.summary_reps_label": "Reps",
   "review.summary_tut_label": "TUT",
   "review.summary_volume_label": "Estimeret volumen",
-  "review.summary_failure_markers_label": "Failure-markører"
+  "review.summary_failure_markers_label": "Failure-markører",
+  "status.opening_session_for_edit": "Åbner session til redigering...",
+  "button.save_changes": "Gem ændringer"
 }

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -624,5 +624,11 @@
   "cardio.target.base_talk_variable": "{minutes} min roligt løb i snakketempo",
   "cardio.target.easy_walk_or_jog_variable": "{minutes} min rolig gang eller meget let jog",
   "after_training.select_time": "(Vælg tid)",
-  "button.back_to_overview": "Til overblik"
+  "button.back_to_overview": "Til overblik",
+  "workout.load_optional_placeholder": "(Tom = kropsvægt)",
+  "review.summary_sets_label": "Sæt",
+  "review.summary_reps_label": "Reps",
+  "review.summary_tut_label": "TUT",
+  "review.summary_volume_label": "Estimeret volumen",
+  "review.summary_failure_markers_label": "Failure-markører"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -619,5 +619,7 @@
   "review.summary_reps_label": "Reps",
   "review.summary_tut_label": "TUT",
   "review.summary_volume_label": "Estimated volume",
-  "review.summary_failure_markers_label": "Failure markers"
+  "review.summary_failure_markers_label": "Failure markers",
+  "status.opening_session_for_edit": "Opening session for editing...",
+  "button.save_changes": "Save changes"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -613,5 +613,11 @@
   "cardio.target.base_talk_variable": "{minutes} min easy run at conversational pace",
   "cardio.target.easy_walk_or_jog_variable": "{minutes} min easy walk or very light jog",
   "after_training.select_time": "(Select time)",
-  "button.back_to_overview": "Back to overview"
+  "button.back_to_overview": "Back to overview",
+  "workout.load_optional_placeholder": "(Empty = bodyweight)",
+  "review.summary_sets_label": "Sets",
+  "review.summary_reps_label": "Reps",
+  "review.summary_tut_label": "TUT",
+  "review.summary_volume_label": "Estimated volume",
+  "review.summary_failure_markers_label": "Failure markers"
 }


### PR DESCRIPTION
## Summary
Normalize the final remaining progression hint strings in backend session summaries so English mode no longer shows Danish `next_step_hint` and `progression_summary` text in the after-training flow.

## Why
After the broader frontend and backend language cleanup, live sanity checks showed one last visible mixed-language tail in English mode:

- `Next progression: Du kan sandsynligvis progressere næste gang.`
- `Light overall load recorded. · Du kan sandsynligvis progressere næste gang.`

The source was confirmed to be backend-generated summary strings in `build_session_summary(...)`.

## Changes
Replace the remaining Danish progression hint strings with English equivalents:

- `Tag en lettere næste session.`
  -> `Take a lighter next session.`

- `Hold progressionen rolig næste session.`
  -> `Keep progression conservative next session.`

- `Du kan sandsynligvis progressere næste gang.`
  -> `You can probably progress next time.`

## Impact
- `next_step_hint` is now English in English UI flows
- `progression_summary` is now English in English UI flows
- after-training review no longer mixes English labels with Danish progression advice

## Validation
- `python3 -m py_compile app/backend/app.py`
- reviewed diff in `build_session_summary(...)`

## Notes
This is intended as the final remaining visible mixed-language tail in the English after-training summary flow.