### PR TITLE
Refine first-run overview copy to reduce repetition between forecast hero and onboarding card

### DIFF
--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -582,9 +582,9 @@
     }
   },
   "onboarding.first_run.title": "Velkommen til SovereignStrength",
-  "onboarding.first_run.intro": "Appen hjælper dig med at vælge dagens træning ud fra check-in, udstyr og dine præferencer.",
-  "onboarding.first_run.flow": "Flow: overblik → check-in → dagens plan → efter træning.",
-  "onboarding.first_run.setup_reason": "Jo bedre profil og udstyr er sat op, jo mere brugbar bliver din første anbefaling.",
+  "onboarding.first_run.intro": "Her får du et roligt første overblik over, hvordan appen bruges.",
+  "onboarding.first_run.flow": "Flowet er enkelt: opsætning først, derefter check-in, plan og efter træning.",
+  "onboarding.first_run.setup_reason": "Begynd med profil og udstyr, så din første anbefaling passer bedre til dig.",
   "onboarding.first_run.soft_landing": "Start roligt: kig overblikket igennem, sæt profil og udstyr op, og tag derefter din første check-in.",
   "onboarding.first_run.continue_checkin": "Fortsæt til check-in",
   "onboarding.first_run.ready": "Klar til første anbefaling.",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -571,9 +571,9 @@
     }
   },
   "onboarding.first_run.title": "Welcome to SovereignStrength",
-  "onboarding.first_run.intro": "The app helps you choose today's training based on check-in, equipment, and your preferences.",
-  "onboarding.first_run.flow": "Flow: overview → check-in → today's plan → after training.",
-  "onboarding.first_run.setup_reason": "The better your profile and equipment are set up, the more useful your first recommendation becomes.",
+  "onboarding.first_run.intro": "This is your calm first overview of how the app works.",
+  "onboarding.first_run.flow": "The flow is simple: setup first, then check-in, plan, and after training.",
+  "onboarding.first_run.setup_reason": "Start with profile and equipment so your first recommendation fits you better.",
   "onboarding.first_run.soft_landing": "Start gently: review the overview, set up profile and equipment, and then take your first check-in.",
   "onboarding.first_run.continue_checkin": "Continue to check-in",
   "onboarding.first_run.ready": "Ready for a first recommendation.",


### PR DESCRIPTION
## Summary
This PR refines the first-run overview copy so the forecast hero and onboarding card have clearer and less repetitive roles.

## Problem
After the first-run soft landing and guided setup flow were implemented, the overview still contained some copy overlap:
- the forecast hero explained the immediate setup direction
- the onboarding card repeated similar setup framing and value explanation

This was no longer a functional issue, but it weakened hierarchy and made the first impression feel slightly repetitive.

## What changed
- refined first-run overview copy in the forecast hero
- refined first-run onboarding copy so it complements rather than repeats the hero
- preserved the current CTA behavior and guided setup logic

## Why
The first-run overview should feel clear and lightweight:
- forecast hero = short, action-oriented summary
- onboarding card = fuller explanation, checklist, and next-step guidance

## Scope
Frontend copy only:
- `app/frontend/app.js`
- `app/frontend/i18n/da.json`
- `app/frontend/i18n/en.json`
- optionally `app/frontend/index.html` if needed for text structure only

## Validation
Manual first-run validation should confirm:
- the overview no longer feels repetitive
- the hero and onboarding card have clearly different communication roles
- no regression in CTA behavior
- no regression in guided setup flow

Closes #358