### PR TITLE
Compact profile card on overview to improve mobile home screen hierarchy

### DIFF
--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -652,5 +652,6 @@
   "onboarding.first_run.section.physiology_title": "Valgfrie fysiologi-hensyn",
   "onboarding.first_run.section.physiology_body": "Valgfrit. Slå kun dette til, hvis du vil have menstruationsrelaterede hensyn med i check-in.",
   "onboarding.first_run.section.physiology_toggle": "Vis valgfri menstruationsfelter i check-in",
-  "onboarding.first_run.section.finish_title": "Klar til første anbefaling"
+  "onboarding.first_run.section.finish_title": "Klar til første anbefaling",
+  "overview.more_profile_details": "Flere profiloplysninger"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -641,5 +641,6 @@
   "onboarding.first_run.section.physiology_title": "Optional physiology-aware settings",
   "onboarding.first_run.section.physiology_body": "Optional. Only turn this on if you want menstruation-related check-in considerations included.",
   "onboarding.first_run.section.physiology_toggle": "Show optional menstruation fields in check-in",
-  "onboarding.first_run.section.finish_title": "Ready for first recommendation"
+  "onboarding.first_run.section.finish_title": "Ready for first recommendation",
+  "overview.more_profile_details": "More profile details"
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -481,19 +481,24 @@
         </div>
         <div class="overview-status">
           <div class="stat-line" id="profileBodyLine" data-i18n="profile.loading">Profil indlæses...</div>
-        <div class="stat-line" id="profileTrainingTypesLine" data-i18n="profile.training_types_loading">Træningstyper indlæses...</div>
-        <div class="stat-line" id="profileTrainingDaysLine" data-i18n="profile.training_days_loading">Træningsdage indlæses...</div>
-        <div class="stat-line" id="profileEquipmentLine" data-i18n="profile.equipment_loading">Udstyr indlæses...</div>
-          <div class="stat-line" id="profileIncrementLine" data-i18n="profile.increment_loading">Vægtspring indlæses...</div>
-          <div class="stat-line" id="profileAccountLine" data-i18n="profile.account_loading">Konto indlæses...</div>
-          <div class="stat-line" id="profileAccountHelpLine" data-i18n="profile.account_help">Profil og adgangskode håndteres centralt via auth.</div>
+          <div class="stat-line" id="profileTrainingTypesLine" data-i18n="profile.training_types_loading">Træningstyper indlæses...</div>
+          <div class="stat-line" id="profileTrainingDaysLine" data-i18n="profile.training_days_loading">Træningsdage indlæses...</div>
+          <div class="stat-line" id="profileEquipmentLine" data-i18n="profile.equipment_loading">Udstyr indlæses...</div>
         </div>
+        <details id="profileEquipmentDetails" style="margin-top:12px">
+          <summary class="small" data-i18n="overview.more_profile_details">Flere profiloplysninger</summary>
+          <div class="overview-status" style="margin-top:10px">
+            <div class="stat-line" id="profileIncrementLine" data-i18n="profile.increment_loading">Vægtspring indlæses...</div>
+            <div class="stat-line" id="profileAccountLine" data-i18n="profile.account_loading">Konto indlæses...</div>
+            <div class="stat-line" id="profileAccountHelpLine" data-i18n="profile.account_help">Profil og adgangskode håndteres centralt via auth.</div>
+          </div>
+        </details>
         <div class="btn-row" style="margin-top:12px">
           <button type="button" id="openEquipmentSettingsBtn" data-i18n="button.edit_profile_equipment">Redigér profil og udstyr</button>
           <button type="button" id="openAccountSettingsSecondaryBtn" data-i18n="button.account_password">Konto og adgangskode</button>
         </div>
       </section>
-
+      
       <div id="equipmentEditorWrap" class="card wizard-step-hidden" style="margin-top:14px; display:none"></div>
 
       <div id="equipmentSettingsModal" class="modal-backdrop wizard-step-hidden" style="display:none">


### PR DESCRIPTION
## Summary
This PR improves the overview home screen by making the profile/equipment card more compact and reducing how much supporting information competes with the primary daily content.

## Problem
The overview screen contained several large full-width cards with similar visual weight. On mobile, the permanent profile/equipment block took up too much space and made the home screen feel heavier than necessary.

This weakened the intended hierarchy:
- expected today / primary next action
- current status
- supporting profile information

## What changed
- kept the most important profile/equipment information visible:
  - body metrics
  - training types
  - training days
  - available equipment
- moved secondary details into a collapsible section:
  - load increments
  - account line
  - account help text
- added i18n labels for the collapsible summary

## Why
The overview should feel like a calm mobile-first home screen:
- primary daily action first
- current status second
- supporting details available without dominating the page

## Scope
Frontend only:
- `app/frontend/index.html`
- `app/frontend/i18n/da.json`
- `app/frontend/i18n/en.json`

## Validation
Manual validation should confirm:
- overview is easier to scan on mobile
- profile/equipment card feels lighter
- collapsible details work correctly
- no layout regression around the profile editor or overview cards

Part of #321