### PR TITLE
Fix post-workout overview copy and next-step guidance consistency

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1720,7 +1720,15 @@ function renderForecastHero(planItem, latestCheckin){
       }
     }
 
-    const nextGuidanceMessage = String(planItem?.next_guidance?.message || "").trim();
+    let nextGuidanceMessage = String(planItem?.next_guidance?.message || "").trim();
+    const loweredNextGuidance = nextGuidanceMessage.toLowerCase();
+    if (
+      loweredNextGuidance.includes("there is no next training day yet") ||
+      loweredNextGuidance.includes("no next training day yet")
+    ){
+      nextGuidanceMessage = "";
+    }
+
     const forecastReasonEl = document.getElementById("forecastReason");
     if (forecastReasonEl){
       forecastReasonEl.textContent = [bits.join(" · "), nextGuidanceMessage].filter(Boolean).join("\n");
@@ -1830,7 +1838,7 @@ function renderOverviewStatus(planItem, latestCheckin, workouts){
     } else if (dailyUiState === "completed_rest_day_today"){
       latestCheckinLine.textContent = tr("today_plan.rest_day_acknowledged_saved");
     } else if (dailyUiState === "completed_session_today"){
-      latestCheckinLine.textContent = tr("review.session_saved_button");
+      latestCheckinLine.textContent = tr("overview.completed_today_status");
     } else if (latestCheckin?.date){
       latestCheckinLine.textContent = tr("overview.latest_checkin", { value: latestCheckin.date });
     } else {
@@ -1866,7 +1874,8 @@ function renderOverviewStatus(planItem, latestCheckin, workouts){
     } else if (dailyUiState === "completed_rest_day_today"){
       overviewWorkoutLine.textContent = tr("today_plan.rest_day_logged_title");
     } else if (dailyUiState === "completed_session_today"){
-      overviewWorkoutLine.textContent = tr("review.session_saved_button");
+      const nextOverviewText = getNextPlannedSessionOverviewText(planItem || null);
+      overviewWorkoutLine.textContent = nextOverviewText || tr("overview.completed_today_review_hint");
     } else if (sessionCount > 0){
       overviewWorkoutLine.textContent = tr("overview.logged_sessions_count", { count: sessionCount });
     } else {
@@ -6086,6 +6095,26 @@ function buildNextPlannedSessionHtml(planItem){
       ${nextTraining.note ? `<div class="small" style="margin-top:4px">${esc(nextTraining.note)}</div>` : ""}
     </div>
   `;
+}
+
+function getNextPlannedSessionOverviewText(planItem){
+  const info = getNextPlannedSessionInfo(planItem);
+  if (!info || !info.nextTraining) return "";
+
+  const tomorrow = info.tomorrow;
+  const nextTraining = info.nextTraining;
+
+  if (tomorrow && tomorrow.kind === "rest"){
+    return `${tr("review.tomorrow_rest_label")} · ${tomorrow.dateLabel || ""}`;
+  }
+
+  const bits = [
+    tr("review.next_planned_session_label"),
+    nextTraining.kindLabel || "",
+    nextTraining.dateLabel || nextTraining.date || "",
+  ].filter(Boolean);
+
+  return bits.join(": ").replace(": ", ": ").replace(/: ([^:]+): /, ": $1 · ");
 }
 
 function renderWeekPlanPreview(planItem){

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -179,6 +179,8 @@
   "overview.latest_time_budget": "Senest angivet tid: {minutes} min",
   "overview.no_history_first_point": "Ingen historik endnu. Du bygger første datapunkt nu.",
   "overview.logged_sessions_count": "Registrerede sessioner: {count}",
+  "overview.completed_today_status": "Dagens session er gemt.",
+  "overview.completed_today_review_hint": "Se review af dagens pas.",
   "overview.no_history_yet": "Ingen historik endnu.",
   "overview.time_today_short": "Tid i dag: {minutes} min",
   "profile.height_value": "Højde: {value}",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -167,6 +167,8 @@
   "overview.latest_time_budget": "Latest entered time: {minutes} min",
   "overview.no_history_first_point": "No history yet. You're creating the first data point now.",
   "overview.logged_sessions_count": "Logged sessions: {count}",
+  "overview.completed_today_status": "Today's session has been saved.",
+  "overview.completed_today_review_hint": "View today's review.",
   "overview.no_history_yet": "No history yet.",
   "overview.time_today_short": "Time today: {minutes} min",
   "profile.height_value": "Height: {value}",


### PR DESCRIPTION
Summary

This PR improves the completed-today overview state so the home screen gives a more consistent and useful post-workout summary.

Problem

After a session was saved, Overview and Review did not describe the same state very well.

The main problems were:

- Overview reused the generic “Session saved” review button copy as status text
- the status card could show duplicate low-value lines
- forecast hero could surface weak mixed-language next-guidance such as “There is no next training day yet”
- Review showed useful next-step guidance, while Overview often did not

This made the post-workout state feel inconsistent and less informative than it should.

What changed

Forecast hero

- suppresses low-value English fallback next-guidance in completed-today state

Overview status

- replaces generic completed-session status text with dedicated overview copy
- adds a short completed-today next-step summary by reusing next planned session info
- shows tomorrow planned rest day when relevant
- falls back to a review hint when no better next-step summary is available

i18n

- adds dedicated overview keys for completed-today status and fallback review hint in Danish and English

Why

Overview should work as a calm home-screen summary after training, not just as a weaker duplicate of Review or a place where low-quality fallback text leaks through.

Scope

- "app/frontend/app.js"
- "app/frontend/i18n/da.json"
- "app/frontend/i18n/en.json"

Validation

Validated manually in completed-session state on mobile.

Confirmed that:

- Overview no longer repeats generic “Session saved” text
- mixed-language fallback guidance is suppressed in the forecast hero
- Overview now shows a useful next-step line such as tomorrow planned rest day
- Review remains more detailed, while Overview becomes more coherent and useful

Closes #323