### PR TITLE
Fix overview next-training summary for completed sessions

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1876,6 +1876,7 @@ function renderOverviewStatus(planItem, latestCheckin, workouts){
     } else if (dailyUiState === "completed_session_today"){
       const nextOverviewText = getNextPlannedSessionOverviewText(planItem || null);
       overviewWorkoutLine.textContent = nextOverviewText || tr("overview.completed_today_review_hint");
+      overviewWorkoutLine.style.whiteSpace = nextOverviewText ? "pre-line" : "";
     } else if (sessionCount > 0){
       overviewWorkoutLine.textContent = tr("overview.logged_sessions_count", { count: sessionCount });
     } else {
@@ -6104,17 +6105,23 @@ function getNextPlannedSessionOverviewText(planItem){
   const tomorrow = info.tomorrow;
   const nextTraining = info.nextTraining;
 
+  const lines = [];
+
   if (tomorrow && tomorrow.kind === "rest"){
-    return `${tr("review.tomorrow_rest_label")} · ${tomorrow.dateLabel || ""}`;
+    lines.push(`${tr("review.tomorrow_rest_label")} · ${tomorrow.dateLabel || ""}`);
   }
 
-  const bits = [
+  const nextBits = [
     tr("review.next_planned_session_label"),
     nextTraining.kindLabel || "",
     nextTraining.dateLabel || nextTraining.date || "",
   ].filter(Boolean);
 
-  return bits.join(": ").replace(": ", ": ").replace(/: ([^:]+): /, ": $1 · ");
+  if (nextBits.length){
+    lines.push(nextBits.join(": ").replace(": ", ": ").replace(/: ([^:]+): /, ": $1 · "));
+  }
+
+  return lines.filter(Boolean).join("\n");
 }
 
 function renderWeekPlanPreview(planItem){


### PR DESCRIPTION
Summary

This PR improves the completed-session overview state by showing both the immediate next-day context and the next planned training session.

Problem

The first completed-today overview improvement made the home screen more consistent, but the summary still only surfaced part of the forward-looking guidance.

In cases where the review showed:

- tomorrow planned rest day
- next planned training session
- next session date

the overview summary only showed one of those pieces at a time.

That meant Overview was improved, but still less useful than it should be as a short post-workout home summary.

What changed

- updated "getNextPlannedSessionOverviewText(...)"
- overview completed-session status can now show multiple short guidance lines
- preserves tomorrow planned rest day when relevant
- also includes next planned training label and date
- uses "pre-line" rendering so the summary displays cleanly as multiple lines

Why

After a session is completed, Overview should answer both:

- what happens tomorrow
- what the next planned training session is

without forcing the user into Review for basic forward guidance.

Scope

- "app/frontend/app.js"

Validation

Validated manually on mobile after a completed running session.

Confirmed that Overview now shows:

- "I morgen er planlagt hviledag · ..."
- "Næste planlagte træning: Styrke · ..."

while Review remains the more detailed screen.

Continues work on #323