### PR TITLE
Add safe exercise image mappings for viewer-supported exercises

### DIFF
--- a/app/data/seed/exercises.json
+++ b/app/data/seed/exercises.json
@@ -240,6 +240,11 @@
       "shoulder",
       "elbow",
       "wrist"
+    ],
+    "image_folder": "Barbell_Shoulder_Press",
+    "external_images": [
+      "Barbell_Shoulder_Press/0.jpg",
+      "Barbell_Shoulder_Press/1.jpg"
     ]
   },
   {
@@ -291,6 +296,11 @@
     "local_load_targets": [
       "hip",
       "low_back"
+    ],
+    "image_folder": "Barbell_Deadlift",
+    "external_images": [
+      "Barbell_Deadlift/0.jpg",
+      "Barbell_Deadlift/1.jpg"
     ]
   },
   {
@@ -756,6 +766,11 @@
       10,
       11,
       12
+    ],
+    "image_folder": "Bent_Over_Two-Dumbbell_Row",
+    "external_images": [
+      "Bent_Over_Two-Dumbbell_Row/0.jpg",
+      "Bent_Over_Two-Dumbbell_Row/1.jpg"
     ]
   },
   {
@@ -1171,6 +1186,11 @@
       "Pull yourself up with the working leg",
       "Avoid jumping or pushing too hard from below",
       "Lower back down with control"
+    ],
+    "image_folder": "Dumbbell_Step_Ups",
+    "external_images": [
+      "Dumbbell_Step_Ups/0.jpg",
+      "Dumbbell_Step_Ups/1.jpg"
     ]
   },
   {
@@ -1264,6 +1284,11 @@
     "notes_en": "Bodyweight calf training.",
     "local_load_targets": [
       "ankle_calf"
+    ],
+    "image_folder": "Calf_Raise_On_A_Dumbbell",
+    "external_images": [
+      "Calf_Raise_On_A_Dumbbell/0.jpg",
+      "Calf_Raise_On_A_Dumbbell/1.jpg"
     ]
   },
   {
@@ -1317,6 +1342,11 @@
       "Keep the spine long and steady",
       "Feel tension in the posterior chain without chasing depth",
       "Stand back up by bringing the hips forward again"
+    ],
+    "image_folder": "Good_Morning",
+    "external_images": [
+      "Good_Morning/0.jpg",
+      "Good_Morning/1.jpg"
     ]
   },
   {
@@ -1370,6 +1400,11 @@
       "Drive through the working foot",
       "Squeeze the glute at the top without overextending the lower back",
       "Lower back down with control"
+    ],
+    "image_folder": "Butt_Lift_Bridge",
+    "external_images": [
+      "Butt_Lift_Bridge/0.jpg",
+      "Butt_Lift_Bridge/1.jpg"
     ]
   },
   {


### PR DESCRIPTION
## Summary

This PR adds image mappings for a set of exercises that already have viewer support but were missing catalog image references in `app/data/seed/exercises.json`.

The goal is simple:
- make more exercise modals show actual images
- do it only for cases where a clearly matching asset folder already exists
- avoid speculative or misleading image assignments

## What changed

Added `image_folder` and `external_images` mappings for these exercises:

- `overhead_press` -> `Barbell_Shoulder_Press`
- `romanian_deadlift` -> `Barbell_Deadlift`
- `dumbbell_row` -> `Bent_Over_Two-Dumbbell_Row`
- `step_ups` -> `Dumbbell_Step_Ups`
- `calf_raises` -> `Calf_Raise_On_A_Dumbbell`
- `hip_hinge_bw` -> `Good_Morning`
- `single_leg_glute_bridge` -> `Butt_Lift_Bridge`

## Why

Several exercises had:
- notes
- technique cues
- viewer rendering support

but still showed no images because the seed catalog lacked image references.

This PR fills only the safest gaps first, using asset folders that were confirmed to exist in the current exercise image catalog.

## Scope

Changed file:
- `app/data/seed/exercises.json`

No frontend logic changes.
No runtime data changes.
No deploy-script changes.

## Validation

Validated locally:

- JSON syntax check passed
- git diff only affected `app/data/seed/exercises.json`
- all referenced asset folders were confirmed to exist under:
  `/var/www/sovereign-strength/assets/exercise-db/`

Verified folders:
- `Barbell_Shoulder_Press`
- `Barbell_Deadlift`
- `Bent_Over_Two-Dumbbell_Row`
- `Dumbbell_Step_Ups`
- `Calf_Raise_On_A_Dumbbell`
- `Good_Morning`
- `Butt_Lift_Bridge`

## Notes

This is an intentionally conservative first pass.

Some other exercises still lack image mappings, but they were left out here because the available asset matches were weaker or more ambiguous. Those can be handled in a follow-up PR.