### PR TITLE
Fix load-based local progression for easier/harder on major lifts

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -3962,11 +3962,41 @@ function getNumericOptions(list){
   )].sort((a, b) => a - b);
 }
 
+function isLoadFirstProgressionExercise(entry){
+  const exerciseId = String(entry?.exercise_id || "").trim().toLowerCase();
+  return [
+    "squat",
+    "bench_press",
+    "overhead_press",
+    "barbell_row",
+    "romanian_deadlift",
+    "dumbbell_row"
+  ].includes(exerciseId);
+}
+
 function getEntryLoadBounds(entry){
   const exerciseId = String(entry?.exercise_id || "").trim().toLowerCase();
   const meta = getExerciseMeta(exerciseId) || {};
   const loadOptions = getNumericOptions(meta.load_options);
+
+  const bounds = {
+    "squat": { min: 20, max: 200 },
+    "bench_press": { min: 20, max: 160 },
+    "overhead_press": { min: 20, max: 120 },
+    "barbell_row": { min: 20, max: 160 },
+    "romanian_deadlift": { min: 20, max: 220 },
+    "dumbbell_row": { min: 2, max: 40 },
+  };
+  const fallback = bounds[exerciseId] || { min: 1, max: 200 };
+
   if (loadOptions.length){
+    if (isLoadFirstProgressionExercise(entry)){
+      return {
+        min: Math.max(fallback.min, loadOptions[0]),
+        max: fallback.max,
+        options: loadOptions
+      };
+    }
     return {
       min: loadOptions[0],
       max: loadOptions[loadOptions.length - 1],
@@ -3974,13 +4004,6 @@ function getEntryLoadBounds(entry){
     };
   }
 
-  const bounds = {
-    "squat": { min: 20, max: 200 },
-    "bench_press": { min: 20, max: 160 },
-    "barbell_row": { min: 20, max: 160 },
-    "dumbbell_row": { min: 2, max: 40 },
-  };
-  const fallback = bounds[exerciseId] || { min: 1, max: 200 };
   return { ...fallback, options: [] };
 }
 
@@ -4284,17 +4307,25 @@ function adjustPlanEntryAtIndex(item, idx, direction){
     let nextLoad = null;
     if (loadOptions.length){
       nextLoad = getAdjacentNumericOption(loadOptions, currentLoad, dir);
-    } else {
+    }
+
+    if (nextLoad == null){
       const step = getEntryLoadStep(entry);
       if (!step || currentLoad == null) return false;
       nextLoad = dir === "harder" ? currentLoad + step : currentLoad - step;
-      if (nextLoad < loadBounds.min || nextLoad > loadBounds.max) return false;
     }
 
-    if (nextLoad == null || nextLoad === currentLoad) return false;
+    if (nextLoad < loadBounds.min || nextLoad > loadBounds.max) return false;
+    if (nextLoad === currentLoad) return false;
 
     entry.target_load = formatKgLabel(nextLoad);
-    entry.sets = dir === "harder" ? setBounds.min : setBounds.max;
+
+    if (isLoadFirstProgressionExercise(entry)){
+      const softerSetFloor = Math.max(setBounds.min, Math.min(currentSets, Math.max(setBounds.min, currentSets - 1)));
+      entry.sets = dir === "harder" ? softerSetFloor : Math.min(setBounds.max, currentSets + 1);
+    } else {
+      entry.sets = dir === "harder" ? setBounds.min : setBounds.max;
+    }
 
     if (currentTarget){
       entry.target_reps = buildBoundaryTargetFromCurrentShape(entry, dir === "harder" ? "min" : "max");
@@ -4304,7 +4335,21 @@ function adjustPlanEntryAtIndex(item, idx, direction){
     return true;
   };
 
-  if (dir === "harder"){
+  if (isLoadFirstProgressionExercise(entry)){
+    if (dir === "harder"){
+      changed =
+        tryLoadStep() ||
+        tryTargetStep() ||
+        trySetStep() ||
+        applyVariantSwap(entry, "harder");
+    } else {
+      changed =
+        tryLoadStep() ||
+        tryTargetStep() ||
+        trySetStep() ||
+        applyVariantSwap(entry, "easier");
+    }
+  } else if (dir === "harder"){
     changed =
       tryTargetStep() ||
       trySetStep() ||


### PR DESCRIPTION
## Summary

This PR improves `Make easier` / `Make harder` for major load-based lifts in Today’s Plan.

The previous deterministic local cycling worked reasonably well for bodyweight and time-based exercises, but it behaved poorly for lifts such as squat and similar barbell/dumbbell movements.

In particular:
- load progression could be hard-capped by small `load_options` lists
- harder progression often went through reps and sets before load
- load increases could reset the entry too harshly

This PR introduces a load-first local progression path for major load-based lifts.

## What changed

### Added load-first classification
A new helper identifies load-based lifts that should use a different local adjustment strategy:

- `squat`
- `bench_press`
- `overhead_press`
- `barbell_row`
- `romanian_deadlift`
- `dumbbell_row`

### Changed load bounds behavior
For those lifts, `load_options` is no longer treated as the absolute maximum local progression ceiling.

Instead:
- known `load_options` can still be used when available
- but fallback max bounds remain exercise-appropriate
- this allows progression beyond small UI option lists such as squat stopping at `80 kg`

### Changed local adjustment order for major lifts
For load-first exercises, `adjustPlanEntryAtIndex(...)` now tries:

**Harder / Easier**
1. load
2. target reps
3. sets
4. variant swap

This differs from the generic path still used for non-load-first exercises.

### Reduced reset severity after load changes
When load changes for load-first lifts, the entry no longer resets as aggressively as before.

Instead of collapsing directly to the minimum set count, the logic now uses a milder set reset behavior that better matches the feel of a real local progression step.

## Why

The generic deterministic cycle was too mechanical for major lifts.

Example of problematic previous behavior:
- `50 kg · 4 sets · 6-8`
- `50 kg · 5 sets · 6-8`
- then
- `60 kg · 1 set · 4-6`

That is deterministic, but it is poor UX for a primary strength lift.

This PR keeps deterministic local progression, but makes it better match the actual nature of load-based strength work.

## Scope

Changed file:
- `app/frontend/app.js`

No backend changes.
No runtime data changes.
No catalog changes.

## Validation

Validated locally:

- `node --check app/frontend/app.js`
- diff limited to load-first progression logic in frontend
- no unrelated file changes included

## Notes

This PR does not remove the deterministic local progression model.

It narrows the model so major load-based lifts use more sensible local behavior, while bodyweight/time-based exercises continue to use the more generic target-first progression flow.