### PR TITLE
Unify local adjustment constraints with backend autoplan variant rules

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -1198,6 +1198,73 @@ def get_local_load_targets_for_exercise(exercise_id, exercises=None):
 
     return []
 
+def get_local_substitute_candidates(exercise_id, local_state=None):
+    exercise_id = str(exercise_id or "").strip()
+    local_state = local_state if isinstance(local_state, dict) else {}
+
+    substitution_map = {
+        "squat": ["lunges", "split_squat", "step_ups", "single_leg_sit_to_stand"],
+        "bench_press": ["push_ups", "incline_push_ups", "diamond_push_ups"],
+        "overhead_press": ["pike_push_ups", "push_ups", "incline_push_ups"],
+        "barbell_row": ["dumbbell_row", "reverse_snow_angels", "superman_hold"],
+        "incline_push_ups": ["bird_dog", "dead_bug", "plank"],
+        "dumbbell_row": ["reverse_snow_angels", "bird_dog", "dead_bug"],
+        "dead_bug": ["bird_dog", "plank", "glute_bridge"],
+        "romanian_deadlift": ["glute_bridge", "single_leg_glute_bridge", "hamstring_walkouts", "hip_hinge_bw"],
+    }
+
+    blocked_regions = []
+    for region, info in local_state.items():
+        if not isinstance(info, dict):
+            continue
+        if str(info.get("state", "")).strip() == "protect":
+            blocked_regions.append(str(region).strip())
+
+    blocked_regions = sorted(set(x for x in blocked_regions if x))
+
+    ankle_calf_protect = "ankle_calf" in blocked_regions
+    knee_protect = "knee" in blocked_regions
+    hip_protect = "hip" in blocked_regions
+    upper_body_protect = any(region in {"shoulder", "elbow", "wrist"} for region in blocked_regions)
+
+    substitute_candidates = substitution_map.get(exercise_id, [])
+
+    if exercise_id == "incline_push_ups" and upper_body_protect:
+        substitute_candidates = ["bird_dog", "dead_bug", "plank"]
+    elif exercise_id == "dumbbell_row" and upper_body_protect:
+        substitute_candidates = ["reverse_snow_angels", "bird_dog", "dead_bug"]
+    elif exercise_id == "squat" and ankle_calf_protect:
+        substitute_candidates = ["glute_bridge", "hamstring_walkouts", "hip_hinge_bw", "split_squat", "step_ups"]
+    elif exercise_id == "squat" and knee_protect:
+        substitute_candidates = ["glute_bridge", "hip_hinge_bw", "hamstring_walkouts", "step_ups", "split_squat"]
+    elif exercise_id == "squat" and hip_protect:
+        substitute_candidates = ["glute_bridge", "hamstring_walkouts", "bird_dog", "plank"]
+    elif exercise_id == "dead_bug" and hip_protect:
+        substitute_candidates = ["bird_dog", "plank", "glute_bridge"]
+
+    if isinstance(substitute_candidates, str):
+        substitute_candidates = [substitute_candidates]
+
+    cleaned = []
+    seen = set()
+    for candidate_id in substitute_candidates or []:
+        cid = str(candidate_id or "").strip()
+        if not cid or cid in seen:
+            continue
+        seen.add(cid)
+        cleaned.append(cid)
+
+    return {
+        "candidate_ids": cleaned,
+        "blocked_regions": blocked_regions,
+        "upper_body_protect": upper_body_protect,
+        "ankle_calf_protect": ankle_calf_protect,
+        "knee_protect": knee_protect,
+        "hip_protect": hip_protect,
+    }
+
+
+
 def choose_best_substitute(original_exercise_id, candidate_ids, exercise_map, available_equipment, local_state=None, exercises=None):
     original_meta = exercise_map.get(original_exercise_id, {}) or {}
     original_pattern = str(original_meta.get("movement_pattern", "")).strip()
@@ -2638,32 +2705,6 @@ def build_strength_plan(programs, exercises, latest_strength, time_budget_min, f
     if not isinstance(local_state, dict):
         local_state = {}
 
-    substitution_map = {
-        "squat": ["lunges", "split_squat", "step_ups", "single_leg_sit_to_stand"],
-        "bench_press": ["push_ups", "incline_push_ups", "diamond_push_ups"],
-        "overhead_press": ["pike_push_ups", "push_ups", "incline_push_ups"],
-        "barbell_row": ["dumbbell_row", "reverse_snow_angels", "superman_hold"],
-        "incline_push_ups": ["bird_dog", "dead_bug", "plank"],
-        "dumbbell_row": ["reverse_snow_angels", "bird_dog", "dead_bug"],
-        "dead_bug": ["bird_dog", "plank", "glute_bridge"],
-        "romanian_deadlift": ["glute_bridge", "single_leg_glute_bridge", "hamstring_walkouts", "hip_hinge_bw"],
-    }
-
-    ankle_calf_protect = False
-    ankle_info = local_state.get("ankle_calf", {}) if isinstance(local_state, dict) else {}
-    if isinstance(ankle_info, dict):
-        ankle_calf_protect = str(ankle_info.get("state", "")).strip() == "protect"
-
-    knee_protect = False
-    knee_info = local_state.get("knee", {}) if isinstance(local_state, dict) else {}
-    if isinstance(knee_info, dict):
-        knee_protect = str(knee_info.get("state", "")).strip() == "protect"
-
-    hip_protect = False
-    hip_info = local_state.get("hip", {}) if isinstance(local_state, dict) else {}
-    if isinstance(hip_info, dict):
-        hip_protect = str(hip_info.get("state", "")).strip() == "protect"
-
     filtered_exercises = []
     excluded_due_to_equipment = []
     substitutions_used = []
@@ -2694,52 +2735,11 @@ def build_strength_plan(programs, exercises, latest_strength, time_budget_min, f
             filtered_exercises.append(ex)
             continue
 
-        substitute_candidates = substitution_map.get(exercise_id, [])
-        upper_body_protect = local_blocked and any(region in {"shoulder", "elbow", "wrist"} for region in blocked_regions)
-
-        if exercise_id == "incline_push_ups" and upper_body_protect:
-            substitute_candidates = [
-                "bird_dog",
-                "dead_bug",
-                "plank",
-            ]
-        elif exercise_id == "dumbbell_row" and upper_body_protect:
-            substitute_candidates = [
-                "reverse_snow_angels",
-                "bird_dog",
-                "dead_bug",
-            ]
-        elif exercise_id == "squat" and local_blocked and ankle_calf_protect:
-            substitute_candidates = [
-                "glute_bridge",
-                "hamstring_walkouts",
-                "hip_hinge_bw",
-                "split_squat",
-                "step_ups",
-            ]
-        elif exercise_id == "squat" and local_blocked and knee_protect:
-            substitute_candidates = [
-                "glute_bridge",
-                "hip_hinge_bw",
-                "hamstring_walkouts",
-                "step_ups",
-                "split_squat",
-            ]
-        elif exercise_id == "squat" and local_blocked and hip_protect:
-            substitute_candidates = [
-                "glute_bridge",
-                "hamstring_walkouts",
-                "bird_dog",
-                "plank",
-            ]
-        elif exercise_id == "dead_bug" and local_blocked and hip_protect:
-            substitute_candidates = [
-                "bird_dog",
-                "plank",
-                "glute_bridge",
-            ]
-        if isinstance(substitute_candidates, str):
-            substitute_candidates = [substitute_candidates]
+        substitute_ctx = get_local_substitute_candidates(
+            exercise_id=exercise_id,
+            local_state=local_state,
+        )
+        substitute_candidates = substitute_ctx.get("candidate_ids", [])
 
         chosen_substitute_id = choose_best_substitute(
             original_exercise_id=exercise_id,
@@ -3048,6 +3048,166 @@ def compute_progression_for_exercise(exercise_id, user_id=None):
 
 
 
+
+
+def resolve_local_plan_entry_substitute(entry, direction, user_id=None, exercises=None, user_settings=None):
+    entry = entry if isinstance(entry, dict) else {}
+    direction = str(direction or "").strip().lower()
+    if direction not in {"easier", "harder"}:
+        return {
+            "ok": False,
+            "error": "invalid_direction",
+            "message": "direction must be easier or harder",
+        }
+
+    exercise_id = str(entry.get("exercise_id", "")).strip()
+    if not exercise_id:
+        return {
+            "ok": False,
+            "error": "missing_exercise_id",
+            "message": "entry.exercise_id is required",
+        }
+
+    exercises = exercises if isinstance(exercises, list) else read_json_file(FILES["exercises"])
+    exercise_map = {
+        str(item.get("id", "")).strip(): item
+        for item in exercises
+        if isinstance(item, dict) and str(item.get("id", "")).strip()
+    }
+
+    current_meta = exercise_map.get(exercise_id, {}) or {}
+    current_pattern = str(current_meta.get("movement_pattern", "")).strip()
+    try:
+        current_tier = int(current_meta.get("difficulty_tier", 1) or 1)
+    except Exception:
+        current_tier = 1
+
+    if not isinstance(user_settings, dict):
+        user_settings = get_user_settings_for(user_id) if user_id not in (None, "") else {}
+    available_equipment = user_settings.get("available_equipment", {}) if isinstance(user_settings, dict) else {}
+    if not isinstance(available_equipment, dict):
+        available_equipment = {}
+
+    state = get_live_adaptation_state_for(user_id) if user_id not in (None, "") else {}
+    local_state = state.get("local_state", {}) if isinstance(state, dict) else {}
+    if not isinstance(local_state, dict):
+        local_state = {}
+
+    ladder_candidate_id = get_adjacent_variation(
+        exercise_id=exercise_id,
+        direction=direction,
+        exercise_map=exercise_map,
+    )
+    chosen_substitute_id = None
+    chosen_source = None
+    blocked_regions = []
+    caution_regions = []
+
+    if ladder_candidate_id:
+        allowed, ladder_blocked_regions, ladder_caution_regions = is_candidate_allowed_for_local_adjustment(
+            candidate_id=ladder_candidate_id,
+            exercise_map=exercise_map,
+            available_equipment=available_equipment,
+            local_state=local_state,
+            exercises=exercises,
+        )
+        if allowed:
+            chosen_substitute_id = ladder_candidate_id
+            chosen_source = "progression_ladder"
+            caution_regions = ladder_caution_regions
+
+    if not chosen_substitute_id and direction == "easier":
+        substitute_ctx = get_local_substitute_candidates(
+            exercise_id=exercise_id,
+            local_state=local_state,
+        )
+        ordered_candidate_ids = substitute_ctx.get("candidate_ids", [])
+
+        chosen_substitute_id = choose_best_substitute(
+            original_exercise_id=exercise_id,
+            candidate_ids=ordered_candidate_ids,
+            exercise_map=exercise_map,
+            available_equipment=available_equipment,
+            local_state=local_state,
+            exercises=exercises,
+        )
+        if chosen_substitute_id:
+            chosen_source = "substitution_fallback"
+
+    if not chosen_substitute_id:
+        return {
+            "ok": True,
+            "changed": False,
+            "exercise_id": exercise_id,
+            "direction": direction,
+            "reason": "no_valid_substitute",
+        }
+
+    chosen_meta = exercise_map.get(chosen_substitute_id, {}) or {}
+    _, blocked_regions, caution_regions = is_candidate_allowed_for_local_adjustment(
+        candidate_id=chosen_substitute_id,
+        exercise_map=exercise_map,
+        available_equipment=available_equipment,
+        local_state=local_state,
+        exercises=exercises,
+    )
+
+    reason_bits = [f"{exercise_id} -> {chosen_substitute_id}", f"source={chosen_source}"]
+
+    return {
+        "ok": True,
+        "changed": True,
+        "direction": direction,
+        "exercise_id": chosen_substitute_id,
+        "substituted_from": exercise_id,
+        "reason": " | ".join(reason_bits),
+        "missing_equipment_type": None,
+        "local_protection_regions": sorted(set(blocked_regions)),
+        "caution_regions": sorted(set(caution_regions)),
+        "movement_pattern": str(chosen_meta.get("movement_pattern", "")).strip(),
+        "difficulty_tier": chosen_meta.get("difficulty_tier"),
+        "source": chosen_source,
+    }
+
+
+@app.post("/api/resolve-local-adjustment")
+def api_resolve_local_adjustment():
+    auth_user, auth_err = require_auth_user()
+    if auth_err:
+        log_auth_failure("resolve-local-adjustment", auth_err)
+        return auth_err
+
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        return jsonify({
+            "ok": False,
+            "error": "invalid_payload",
+            "message": "JSON object required",
+        }), 400
+
+    entry = payload.get("entry", {})
+    direction = payload.get("direction", "")
+
+    if not isinstance(entry, dict):
+        return jsonify({
+            "ok": False,
+            "error": "invalid_entry",
+            "message": "entry must be an object",
+        }), 400
+
+    exercises = read_json_file(FILES["exercises"])
+    user_settings = get_user_settings_for(auth_user.get("user_id"))
+
+    result = resolve_local_plan_entry_substitute(
+        entry=entry,
+        direction=direction,
+        user_id=auth_user.get("user_id"),
+        exercises=exercises,
+        user_settings=user_settings,
+    )
+
+    status = 200 if result.get("ok") else 400
+    return jsonify(result), status
 
 @app.get("/api/health")
 def api_health():
@@ -5939,6 +6099,87 @@ def _is_bodyweight_like(result_item, exercise_meta):
         if not raw_load:
             return True
     return False
+
+
+
+def get_progression_ladder_for_exercise(exercise_id, exercise_map):
+    exercise_id = str(exercise_id or "").strip()
+    exercise_map = exercise_map if isinstance(exercise_map, dict) else {}
+    if not exercise_id:
+        return []
+
+    own_meta = exercise_map.get(exercise_id, {}) or {}
+    own_ladder = own_meta.get("progression_ladder", [])
+    if isinstance(own_ladder, list):
+        normalized = [str(x).strip() for x in own_ladder if str(x).strip()]
+        if exercise_id in normalized:
+            return normalized
+
+    for _, item in exercise_map.items():
+        if not isinstance(item, dict):
+            continue
+        ladder = item.get("progression_ladder", [])
+        if not isinstance(ladder, list):
+            continue
+        normalized = [str(x).strip() for x in ladder if str(x).strip()]
+        if exercise_id in normalized:
+            return normalized
+
+    return []
+
+
+def get_adjacent_variation(exercise_id, direction, exercise_map):
+    exercise_id = str(exercise_id or "").strip()
+    direction = str(direction or "").strip().lower()
+    ladder = get_progression_ladder_for_exercise(exercise_id, exercise_map)
+    if not ladder or direction not in {"easier", "harder"}:
+        return None
+
+    try:
+        idx = ladder.index(exercise_id)
+    except ValueError:
+        return None
+
+    if direction == "easier" and idx > 0:
+        return ladder[idx - 1]
+    if direction == "harder" and idx < len(ladder) - 1:
+        return ladder[idx + 1]
+    return None
+
+
+def is_candidate_allowed_for_local_adjustment(candidate_id, exercise_map, available_equipment, local_state=None, exercises=None):
+    candidate_id = str(candidate_id or "").strip()
+    exercise_map = exercise_map if isinstance(exercise_map, dict) else {}
+    available_equipment = available_equipment if isinstance(available_equipment, dict) else {}
+    local_state = local_state if isinstance(local_state, dict) else {}
+    exercises = exercises if isinstance(exercises, list) else []
+
+    candidate_meta = exercise_map.get(candidate_id, {}) or {}
+    if not candidate_meta:
+        return False, [], []
+
+    equipment_type = str(candidate_meta.get("equipment_type", "")).strip()
+    allowed = (not equipment_type) or bool(available_equipment.get(equipment_type, True))
+    if not allowed:
+        return False, [], []
+
+    blocked_regions = []
+    caution_regions = []
+    local_targets = get_local_load_targets_for_exercise(candidate_id, exercises=exercises)
+    for region in local_targets:
+        info = local_state.get(region, {}) if isinstance(local_state, dict) else {}
+        if not isinstance(info, dict):
+            continue
+        region_state = str(info.get("state", "")).strip()
+        if region_state == "protect":
+            blocked_regions.append(region)
+        elif region_state == "caution":
+            caution_regions.append(region)
+
+    if blocked_regions:
+        return False, sorted(set(blocked_regions)), sorted(set(caution_regions))
+
+    return True, [], sorted(set(caution_regions))
 
 
 

--- a/app/data/seed/exercises.json
+++ b/app/data/seed/exercises.json
@@ -1133,6 +1133,10 @@
       "Keep the load balanced and controlled",
       "Lower vertically instead of falling forward",
       "Drive back up evenly without losing balance"
+    ],
+    "progression_ladder": [
+      "step_ups",
+      "split_squat"
     ]
   },
   {
@@ -1191,6 +1195,10 @@
     "external_images": [
       "Dumbbell_Step_Ups/0.jpg",
       "Dumbbell_Step_Ups/1.jpg"
+    ],
+    "progression_ladder": [
+      "step_ups",
+      "split_squat"
     ]
   },
   {

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1386,6 +1386,19 @@ async function apiJsonRequest(method, path, payload){
   return data;
 }
 
+async function resolveLocalAdjustmentVariant(entry, direction){
+  const payload = {
+    entry: {
+      exercise_id: entry?.exercise_id || "",
+      sets: entry?.sets || "",
+      target_reps: entry?.target_reps || "",
+      target_load: entry?.target_load || ""
+    },
+    direction
+  };
+  return apiJsonRequest("POST", "/api/resolve-local-adjustment", payload);
+}
+
 function resetRecoveryFormLocalSignals(form){
   ["knee", "low_back", "shoulder", "elbow", "hip", "ankle_calf", "wrist"].forEach((region) => {
     if (form[`local_signal_${region}`]) form[`local_signal_${region}`].value = "";
@@ -4244,13 +4257,45 @@ function buildBoundaryTargetFromCurrentShape(entry, which){
   return current;
 }
 
-function applyVariantSwap(entry, direction){
+async function applyVariantSwap(entry, direction){
   const currentExerciseId = String(entry?.exercise_id || "").trim();
+  if (!currentExerciseId) return false;
+
+  try{
+    const resolved = await resolveLocalAdjustmentVariant(entry, direction);
+    if (resolved?.changed && resolved?.exercise_id){
+      const nextExerciseId = String(resolved.exercise_id || "").trim();
+      entry.substituted_from = resolved.substituted_from || currentExerciseId;
+      entry.exercise_id = nextExerciseId;
+      entry.local_regression_reason = resolved.reason || "";
+      entry.manual_adjustment_reason = direction === "harder" ? "variant_step_up_backend" : "variant_step_down_backend";
+
+      const setBounds = getEntrySetBounds(entry);
+      entry.sets = direction === "harder" ? setBounds.min : setBounds.max;
+
+      const meta = getExerciseMeta(nextExerciseId) || {};
+      const inputKind = String(meta.input_kind || "").trim().toLowerCase();
+      if (entry.target_reps){
+        entry.target_reps = buildBoundaryTargetFromCurrentShape(entry, direction === "harder" ? "min" : "max");
+      } else if (inputKind === "time" || inputKind === "cardio_time" || inputKind === "bodyweight_reps" || inputKind === "load_reps"){
+        entry.target_reps = buildBoundaryTargetFromCurrentShape(entry, direction === "harder" ? "min" : "max");
+      }
+
+      if (meta.supports_load !== true){
+        entry.target_load = "";
+      }
+
+      return true;
+    }
+  }catch(err){
+  }
+
   const nextExerciseId = getExerciseVariantSwap(currentExerciseId, direction);
   if (!nextExerciseId) return false;
 
   entry.substituted_from = currentExerciseId;
   entry.exercise_id = nextExerciseId;
+  entry.manual_adjustment_reason = direction === "harder" ? "variant_step_up_frontend_fallback" : "variant_step_down_frontend_fallback";
 
   const setBounds = getEntrySetBounds(entry);
   entry.sets = direction === "harder" ? setBounds.min : setBounds.max;
@@ -4277,7 +4322,7 @@ function removePlanEntryByIndex(item, idx){
   renderTodayPlan(item);
 }
 
-function adjustPlanEntryAtIndex(item, idx, direction){
+async function adjustPlanEntryAtIndex(item, idx, direction){
   const entries = Array.isArray(item?.entries) ? item.entries : [];
   if (idx < 0 || idx >= entries.length) return;
 
@@ -4373,26 +4418,26 @@ function adjustPlanEntryAtIndex(item, idx, direction){
         (!currentTargetAtMax && tryTargetStep()) ||
         (currentTargetAtMax && tryVolumeCycleSetStep()) ||
         tryLoadStep() ||
-        applyVariantSwap(entry, "harder");
+        await applyVariantSwap(entry, "harder");
     } else {
       changed =
         (!currentTargetAtMin && tryTargetStep()) ||
         (currentTargetAtMin && currentSets > setBounds.min && tryVolumeCycleSetStep()) ||
         tryLoadStep() ||
-        applyVariantSwap(entry, "easier");
+        await applyVariantSwap(entry, "easier");
     }
   } else if (dir === "harder"){
     changed =
       tryTargetStep() ||
       trySetStep() ||
       tryLoadStep() ||
-      applyVariantSwap(entry, "harder");
+      await applyVariantSwap(entry, "harder");
   } else {
     changed =
       tryTargetStep() ||
       trySetStep() ||
       tryLoadStep() ||
-      applyVariantSwap(entry, "easier");
+      await applyVariantSwap(entry, "easier");
   }
 
   if (!changed){
@@ -5147,16 +5192,16 @@ function wireTodayPlanActions(item){
   });
 
   document.querySelectorAll("[data-plan-entry-easier]").forEach(btn => {
-    btn.addEventListener("click", () => {
+    btn.addEventListener("click", async () => {
       const idx = Number(btn.getAttribute("data-plan-entry-easier"));
-      adjustPlanEntryAtIndex(item, idx, "easier");
+      await adjustPlanEntryAtIndex(item, idx, "easier");
     });
   });
 
   document.querySelectorAll("[data-plan-entry-harder]").forEach(btn => {
-    btn.addEventListener("click", () => {
+    btn.addEventListener("click", async () => {
       const idx = Number(btn.getAttribute("data-plan-entry-harder"));
-      adjustPlanEntryAtIndex(item, idx, "harder");
+      await adjustPlanEntryAtIndex(item, idx, "harder");
     });
   });
 


### PR DESCRIPTION
## Summary

This PR unifies local `Make easier` / `Make harder` variant resolution with the same backend rule base used by autoplan.

Before this change, local adjustment could still rely on frontend-only variant logic, which meant local swaps could drift away from backend equipment constraints, local protection rules, and progression ladder behavior.

This PR moves local variant authority toward the backend while keeping simple local rep/set/load stepping in the frontend.

## What changed

### Backend
- extracted shared local substitute candidate logic into `get_local_substitute_candidates(...)`
- updated `build_strength_plan(...)` to use the shared substitute candidate helper instead of its own embedded substitution setup
- added backend ladder-aware helpers:
  - `get_progression_ladder_for_exercise(...)`
  - `get_adjacent_variation(...)`
  - `is_candidate_allowed_for_local_adjustment(...)`
- added `resolve_local_plan_entry_substitute(...)`
- added authenticated endpoint:
  - `POST /api/resolve-local-adjustment`

### Resolver behavior
The backend resolver now uses this order:

1. try the adjacent exercise from `progression_ladder`
2. validate that candidate against:
   - available equipment
   - local protection state
3. only for `easier`, fall back to conservative substitution logic if no ladder step is valid
4. for `harder`, do **not** use conservative fallback substitutions

This prevents incorrect behavior such as:
- `harder` on a lift or variant jumping into unrelated fallback substitutions
- frontend-only variant swaps that ignore backend constraints

### Frontend
- added `resolveLocalAdjustmentVariant(...)`
- changed local variant swap flow to call the backend resolver first
- kept the old frontend ladder logic only as a technical fallback path if the backend call fails unexpectedly
- made local adjustment handlers async so variant resolution can wait for backend authority

### Metadata
- added a shared `progression_ladder` relation for:
  - `step_ups`
  - `split_squat`

This replaces earlier frontend-only behavior with catalog-backed variant progression.

## Why this matters

This removes a structural inconsistency between:
- what autoplan considers a valid substitute or regression
- what local easier/harder considered a valid variant step

After this change:
- local variant swaps respect backend constraints
- progression ladder steps are resolved from backend metadata
- conservative fallback substitutions remain available for regression cases
- `harder` no longer drifts into unrelated substitution behavior

## Examples fixed

- `incline_push_ups` harder -> `push_ups`
- `push_ups` easier -> `incline_push_ups`
- `step_ups` harder -> `split_squat`
- `split_squat` easier -> `step_ups`
- `split_squat` harder -> no valid substitute
- `squat` harder no longer degrades into conservative fallback substitutions such as `lunges`

## Validation

Validated through:
- backend resolver tests against active exercise catalog data
- sync of active live exercise catalog with updated seed metadata
- live UI checks of local easier/harder behavior for ladder-driven variants
- syntax validation:
  - `python3 -m py_compile app/backend/app.py`
  - `node --check app/frontend/app.js`

## Notes

This PR does **not** move local rep/set/load stepping to the backend.
That remains local in the frontend.

This PR specifically unifies backend authority for:
- variant swaps
- equipment-aware validity
- local protection-aware validity
- progression ladder interpretation