### PR TITLE
Expand strength starter catalog and improve gym program matching

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2524,6 +2524,23 @@ def infer_equipment_profile(user_settings):
     if not isinstance(user_settings, dict):
         return "minimal_home"
 
+    explicit_profile = str(user_settings.get("equipment_profile", "")).strip()
+    valid_profiles = {"minimal_home", "dumbbell_home", "gym_basic", "full_gym", "run_only", "hybrid_home"}
+    if explicit_profile in valid_profiles:
+        return explicit_profile
+
+    profile = user_settings.get("profile", {})
+    if isinstance(profile, dict):
+        explicit_profile = str(profile.get("equipment_profile", "")).strip()
+        if explicit_profile in valid_profiles:
+            return explicit_profile
+
+    preferences = user_settings.get("preferences", {})
+    if isinstance(preferences, dict):
+        explicit_profile = str(preferences.get("equipment_profile", "")).strip()
+        if explicit_profile in valid_profiles:
+            return explicit_profile
+
     available = user_settings.get("available_equipment", {})
     if not isinstance(available, dict):
         available = {}
@@ -2575,7 +2592,11 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
     if target_sessions >= 3 and equipment_profile in ("minimal_home", "dumbbell_home"):
         preferred_ids.append("strength_full_body_3x_beginner")
     if target_sessions == 2 and equipment_profile in ("gym_basic", "full_gym"):
-        preferred_ids.append("base_strength_a")
+        preferred_ids.extend(["starter_strength_gym_2x", "base_strength_a"])
+    if target_sessions == 3 and equipment_profile in ("gym_basic", "full_gym"):
+        preferred_ids.append("starter_strength_gym_3x")
+    if target_sessions == 4 and equipment_profile in ("gym_basic", "full_gym"):
+        preferred_ids.append("base_strength_gym_4x")
     if target_sessions == 2 and equipment_profile in ("minimal_home", "dumbbell_home"):
         preferred_ids.append("starter_strength_2x")
 
@@ -4128,13 +4149,34 @@ def detect_program_switch_recommendation(today_plan_item):
     weekly_status = item.get("weekly_status", {}) if isinstance(item.get("weekly_status"), dict) else {}
     target_sessions = int(weekly_status.get("weekly_target_sessions", weekly_status.get("target_sessions", 0)) or 0)
 
-    if selected_strength_program_id in ("starter_strength_2x", "base_strength_a") and target_sessions >= 3:
+    home_2x_programs = {"starter_strength_2x", "reentry_strength_2x"}
+    gym_2x_programs = {"starter_strength_gym_2x", "base_strength_a"}
+
+    if selected_strength_program_id in home_2x_programs and target_sessions >= 3:
         return {
             "switch_recommended": True,
             "current_program_id": selected_strength_program_id,
             "recommended_program_id": "strength_full_body_3x_beginner",
-            "switch_reason": "nuværende styrkeprogram er 2-dages, men ugentligt mål peger mod 3+ pas",
-            "guidance_message": "Dit nuværende styrkeprogram er 2-dages orienteret, men dit ugentlige mål peger mod 3 eller flere pas. Du kan overveje et 3-dages styrkeprogram.",
+            "switch_reason": "nuværende styrkeprogram er 2-dages hjemmeorienteret, men ugentligt mål peger mod 3+ pas",
+            "guidance_message": "Dit nuværende styrkeprogram er 2-dages orienteret, men dit ugentlige mål peger mod 3 eller flere pas. Du kan overveje et 3-dages hjemmeprogram.",
+        }
+
+    if selected_strength_program_id in gym_2x_programs and target_sessions == 3:
+        return {
+            "switch_recommended": True,
+            "current_program_id": selected_strength_program_id,
+            "recommended_program_id": "starter_strength_gym_3x",
+            "switch_reason": "nuværende styrkeprogram er 2-dages gym-orienteret, men ugentligt mål peger mod 3 pas",
+            "guidance_message": "Dit nuværende gymprogram er 2-dages orienteret, men dit ugentlige mål peger mod 3 pas. Du kan overveje et 3-dages gymprogram.",
+        }
+
+    if selected_strength_program_id in gym_2x_programs and target_sessions >= 4:
+        return {
+            "switch_recommended": True,
+            "current_program_id": selected_strength_program_id,
+            "recommended_program_id": "base_strength_gym_4x",
+            "switch_reason": "nuværende styrkeprogram er 2-dages gym-orienteret, men ugentligt mål peger mod 4+ pas",
+            "guidance_message": "Dit nuværende gymprogram er 2-dages orienteret, men dit ugentlige mål peger mod 4 eller flere pas. Du kan overveje et 4-dages upper/lower-program.",
         }
 
     return None

--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -521,5 +521,471 @@
         ]
       }
     ]
+  },
+  {
+    "id": "starter_strength_gym_2x",
+    "name": "Gym foundation (2 days/week)",
+    "name_en": "Gym foundation (2 days/week)",
+    "kind": "strength",
+    "recommended_levels": [
+      "beginner"
+    ],
+    "supported_goals": [
+      "strength",
+      "general_health",
+      "mixed"
+    ],
+    "supported_weekly_sessions": [
+      2
+    ],
+    "equipment_profiles": [
+      "gym_basic",
+      "full_gym"
+    ],
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "bench_press",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "barbell_row",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "dead_bug",
+            "sets": 2,
+            "reps": "6/side"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "romanian_deadlift",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "overhead_press",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "lunges",
+            "sets": 2,
+            "reps": "6/leg"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 2,
+            "reps": "20-30 sec"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "starter_strength_gym_3x",
+    "name": "Gym foundation (3 days/week)",
+    "name_en": "Gym foundation (3 days/week)",
+    "kind": "strength",
+    "recommended_levels": [
+      "beginner"
+    ],
+    "supported_goals": [
+      "strength",
+      "general_health",
+      "mixed"
+    ],
+    "supported_weekly_sessions": [
+      3
+    ],
+    "equipment_profiles": [
+      "gym_basic",
+      "full_gym"
+    ],
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "bench_press",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "barbell_row",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "dead_bug",
+            "sets": 2,
+            "reps": "6/side"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "romanian_deadlift",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "overhead_press",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "lunges",
+            "sets": 2,
+            "reps": "6/leg"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 2,
+            "reps": "20-30 sec"
+          }
+        ]
+      },
+      {
+        "label": "Day C",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "push_ups",
+            "sets": 2,
+            "reps": "6-10"
+          },
+          {
+            "exercise_id": "dumbbell_row",
+            "sets": 2,
+            "reps": "8/side"
+          },
+          {
+            "exercise_id": "bird_dog",
+            "sets": 2,
+            "reps": "6/side"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "reentry_strength_2x",
+    "name": "Re-entry strength (2 days/week)",
+    "name_en": "Re-entry strength (2 days/week)",
+    "kind": "strength",
+    "recommended_levels": [
+      "beginner",
+      "novice"
+    ],
+    "supported_goals": [
+      "general_health",
+      "mixed"
+    ],
+    "supported_weekly_sessions": [
+      2
+    ],
+    "equipment_profiles": [
+      "minimal_home",
+      "dumbbell_home",
+      "gym_basic",
+      "full_gym"
+    ],
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "glute_bridge",
+            "sets": 2,
+            "reps": "8-12"
+          },
+          {
+            "exercise_id": "incline_push_ups",
+            "sets": 2,
+            "reps": "6-10"
+          },
+          {
+            "exercise_id": "dumbbell_row",
+            "sets": 2,
+            "reps": "8/side"
+          },
+          {
+            "exercise_id": "dead_bug",
+            "sets": 2,
+            "reps": "6/side"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "split_squat",
+            "sets": 2,
+            "reps": "6/leg"
+          },
+          {
+            "exercise_id": "overhead_press",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "glute_bridge",
+            "sets": 2,
+            "reps": "8-12"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 2,
+            "reps": "20-30 sec"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "base_strength_gym_3x",
+    "name": "Base gym (3 days/week)",
+    "name_en": "Base gym (3 days/week)",
+    "kind": "strength",
+    "recommended_levels": [
+      "novice"
+    ],
+    "supported_goals": [
+      "strength",
+      "general_health"
+    ],
+    "supported_weekly_sessions": [
+      3
+    ],
+    "equipment_profiles": [
+      "gym_basic",
+      "full_gym"
+    ],
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "bench_press",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "barbell_row",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 3,
+            "reps": "40 sec"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "romanian_deadlift",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "overhead_press",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "lunges",
+            "sets": 3,
+            "reps": "8/leg"
+          },
+          {
+            "exercise_id": "dead_bug",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      },
+      {
+        "label": "Day C",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "push_ups",
+            "sets": 3,
+            "reps": "8-12"
+          },
+          {
+            "exercise_id": "dumbbell_row",
+            "sets": 3,
+            "reps": "8/side"
+          },
+          {
+            "exercise_id": "bird_dog",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "base_strength_gym_4x",
+    "name": "Base upper/lower (4 days/week)",
+    "name_en": "Base upper/lower (4 days/week)",
+    "kind": "strength",
+    "recommended_levels": [
+      "novice"
+    ],
+    "supported_goals": [
+      "strength",
+      "hypertrophy",
+      "mixed"
+    ],
+    "supported_weekly_sessions": [
+      4
+    ],
+    "equipment_profiles": [
+      "gym_basic",
+      "full_gym"
+    ],
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "lunges",
+            "sets": 3,
+            "reps": "8/leg"
+          },
+          {
+            "exercise_id": "glute_bridge",
+            "sets": 3,
+            "reps": "10-12"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 3,
+            "reps": "40 sec"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "bench_press",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "overhead_press",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "barbell_row",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "dead_bug",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      },
+      {
+        "label": "Day C",
+        "exercises": [
+          {
+            "exercise_id": "romanian_deadlift",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "split_squat",
+            "sets": 3,
+            "reps": "8/leg"
+          },
+          {
+            "exercise_id": "glute_bridge",
+            "sets": 3,
+            "reps": "10-12"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 3,
+            "reps": "40 sec"
+          }
+        ]
+      },
+      {
+        "label": "Day D",
+        "exercises": [
+          {
+            "exercise_id": "bench_press",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "push_ups",
+            "sets": 3,
+            "reps": "8-12"
+          },
+          {
+            "exercise_id": "dumbbell_row",
+            "sets": 3,
+            "reps": "8/side"
+          },
+          {
+            "exercise_id": "bird_dog",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
This PR expands the strength program catalog and improves strength program selection for gym users.

Previously, the strength selector had very limited catalog coverage and could only match a small number of realistic strength cases well. In practice, this led to poor or misleading defaults for gym users training more than 2 days per week, and beginner gym users could fall back to older novice-oriented templates.

## What changed

### Strength catalog
Added 5 new strength programs to `app/data/seed/programs.json`:

- `starter_strength_gym_2x`
- `starter_strength_gym_3x`
- `reentry_strength_2x`
- `base_strength_gym_3x`
- `base_strength_gym_4x`

These improve catalog coverage for:
- beginner gym users on 2x/week
- beginner gym users on 3x/week
- novice gym users on 3x/week
- novice gym users on 4x/week
- re-entry / low-capacity users on 2x/week

### Strength selector
Updated `infer_equipment_profile()` so it can respect an explicit `equipment_profile` from:
- top-level user settings
- `profile`
- `preferences`

before falling back to `available_equipment` inference.

Updated `select_strength_program()` so gym users are matched more appropriately:
- gym 2x now prefers `starter_strength_gym_2x` before `base_strength_a`
- gym 3x now prefers `starter_strength_gym_3x`
- gym 4x now prefers `base_strength_gym_4x`

Home defaults remain stable:
- home 2x -> `starter_strength_2x`
- home 3x -> `strength_full_body_3x_beginner`

### Program switch guidance
Updated `detect_program_switch_recommendation()` so switch guidance reflects the expanded catalog:
- home 2x -> recommends `strength_full_body_3x_beginner` when weekly target is 3+
- gym 2x -> recommends `starter_strength_gym_3x` when weekly target is 3
- gym 2x -> recommends `base_strength_gym_4x` when weekly target is 4+

## Why
The selector can only recommend well if the catalog actually contains meaningful matches.

Before this change:
- gym beginners were under-supported
- 3x and 4x gym matching was too narrow
- switch guidance pointed to an outdated program space

This PR improves recommendation quality without introducing large-scale selector complexity.

## Validation
Validated with local selector checks and active-program flow checks:

- home beginner 2x -> `starter_strength_2x`
- home beginner 3x -> `strength_full_body_3x_beginner`
- gym beginner 2x -> `starter_strength_gym_2x`
- gym beginner 3x -> `starter_strength_gym_3x`
- gym 4x -> `base_strength_gym_4x`

Also verified:
- `python3 -m py_compile app/backend/app.py`

## Notes
This PR does not yet introduce true level-aware or re-entry-aware matching logic.
`reentry_strength_2x` is now available in the catalog, but not yet selected through a dedicated capacity signal.
That should be handled in a follow-up issue.