### PR TITLE
Expand running program library because endurance matching needs real structure

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2666,6 +2666,9 @@ def select_endurance_program(programs, user_settings, weekly_target_sessions, pr
     equipment_profile = infer_equipment_profile(settings)
     target_sessions = int(weekly_target_sessions or 2)
     prefs = prefs if isinstance(prefs, dict) else {}
+    run_starting_profile = str(preferences.get("run_starting_profile", "beginner") or "beginner").strip()
+    if run_starting_profile not in ("conservative_beginner", "beginner", "novice"):
+        run_starting_profile = "beginner"
 
     running_enabled = bool(prefs.get("running", True))
     strength_enabled = bool(prefs.get("strength_weights", True)) or bool(prefs.get("bodyweight", True))
@@ -2673,20 +2676,32 @@ def select_endurance_program(programs, user_settings, weekly_target_sessions, pr
     if not running_enabled:
         return None
 
-    if running_enabled and strength_enabled and target_sessions >= 3:
-        for program in programs:
-            if program.get("id") == "hybrid_run_strength_3x_beginner":
-                return "hybrid_run_strength_3x_beginner"
+    preferred_ids = []
 
-    if target_sessions >= 3:
-        for program in programs:
-            if program.get("id") == "base_run_3x":
-                return "base_run_3x"
+    if running_enabled and strength_enabled:
+        if target_sessions >= 3:
+            preferred_ids.append("hybrid_run_strength_3x_beginner")
+        if target_sessions == 2:
+            preferred_ids.append("hybrid_run_strength_2x_beginner")
 
-    if target_sessions == 2:
+    if run_starting_profile == "conservative_beginner" and target_sessions == 2:
+        preferred_ids.append("reentry_run_2x")
+
+    if target_sessions >= 4:
+        preferred_ids.append("base_run_4x")
+    elif target_sessions == 3:
+        if run_starting_profile == "novice":
+            preferred_ids.append("base_run_3x")
+        else:
+            preferred_ids.append("starter_run_3x_beginner")
+            preferred_ids.append("base_run_3x")
+    elif target_sessions == 2:
+        preferred_ids.append("starter_run_2x")
+
+    for pid in preferred_ids:
         for program in programs:
-            if program.get("id") == "starter_run_2x":
-                return "starter_run_2x"
+            if program.get("id") == pid:
+                return pid
 
     for program in programs:
         if str(program.get("kind", "")).strip() != "run":

--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -987,5 +987,206 @@
         ]
       }
     ]
+  },
+  {
+    "id": "reentry_run_2x",
+    "name": "Return to running (2 days/week)",
+    "name_en": "Return to running (2 days/week)",
+    "kind": "run",
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "run_easy",
+            "sets": 1,
+            "reps": "15-20 min roligt"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "run_intervals",
+            "sets": 1,
+            "reps": "4 x 1 min roligt / 1 min gang"
+          }
+        ]
+      }
+    ],
+    "recommended_levels": [
+      "beginner"
+    ],
+    "supported_goals": [
+      "general_health",
+      "fat_loss",
+      "mixed"
+    ],
+    "supported_weekly_sessions": [
+      2
+    ],
+    "equipment_profiles": [
+      "run_only",
+      "hybrid_home"
+    ]
+  },
+  {
+    "id": "starter_run_3x_beginner",
+    "name": "Getting started run (3 days/week)",
+    "name_en": "Getting started run (3 days/week)",
+    "kind": "run",
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "run_easy",
+            "sets": 1,
+            "reps": "20-25 min"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "run_intervals",
+            "sets": 1,
+            "reps": "6 x 1 min hurtigt / 1 min roligt"
+          }
+        ]
+      },
+      {
+        "label": "Day C",
+        "exercises": [
+          {
+            "exercise_id": "run_easy",
+            "sets": 1,
+            "reps": "25-30 min"
+          }
+        ]
+      }
+    ],
+    "recommended_levels": [
+      "beginner"
+    ],
+    "supported_goals": [
+      "performance",
+      "general_health",
+      "fat_loss"
+    ],
+    "supported_weekly_sessions": [
+      3
+    ],
+    "equipment_profiles": [
+      "run_only",
+      "hybrid_home"
+    ]
+  },
+  {
+    "id": "base_run_4x",
+    "name": "Base run (4 days/week)",
+    "name_en": "Base run (4 days/week)",
+    "kind": "run",
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "run_easy",
+            "sets": 1,
+            "reps": "25-30 min"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "run_intervals",
+            "sets": 1,
+            "reps": "10 x 1 min hurtigt / 1 min roligt"
+          }
+        ]
+      },
+      {
+        "label": "Day C",
+        "exercises": [
+          {
+            "exercise_id": "run_easy",
+            "sets": 1,
+            "reps": "30-35 min"
+          }
+        ]
+      },
+      {
+        "label": "Day D",
+        "exercises": [
+          {
+            "exercise_id": "run_easy",
+            "sets": 1,
+            "reps": "40-50 min"
+          }
+        ]
+      }
+    ],
+    "recommended_levels": [
+      "novice"
+    ],
+    "supported_goals": [
+      "performance",
+      "general_health",
+      "fat_loss"
+    ],
+    "supported_weekly_sessions": [
+      4
+    ],
+    "equipment_profiles": [
+      "run_only",
+      "hybrid_home"
+    ]
+  },
+  {
+    "id": "hybrid_run_strength_2x_beginner",
+    "name": "Hybrid run + strength foundation (2 sessions/week)",
+    "name_en": "Hybrid run + strength foundation (2 sessions/week)",
+    "kind": "run",
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "run_easy",
+            "sets": 1,
+            "reps": "20-25 min"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "run_intervals",
+            "sets": 1,
+            "reps": "5 x 1 min hurtigt / 1 min roligt"
+          }
+        ]
+      }
+    ],
+    "recommended_levels": [
+      "beginner"
+    ],
+    "supported_goals": [
+      "performance",
+      "general_health",
+      "mixed"
+    ],
+    "supported_weekly_sessions": [
+      2
+    ],
+    "equipment_profiles": [
+      "hybrid_home"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
This expands the running program catalog and aligns basic endurance program selection with the broader catalog.

## Why
The previous running catalog was too narrow:
- `starter_run_2x`
- `base_run_3x`

That made endurance matching structurally weak and limited what future onboarding/capacity logic could realistically do.

## What changed

### Catalog
Added the following running programs:
- `reentry_run_2x`
- `starter_run_3x_beginner`
- `base_run_4x`
- `hybrid_run_strength_2x_beginner`

These improve coverage for:
- return-to-running / conservative starts
- beginner 3x/week users
- novice 4x/week users
- beginner hybrid 2x/week users

### Selector alignment
Updated `select_endurance_program(...)` so the new catalog entries can actually be selected.

The selector now supports:
- conservative 2x running → `reentry_run_2x`
- beginner 3x running → `starter_run_3x_beginner`
- novice 3x running → `base_run_3x`
- novice 4x running → `base_run_4x`
- hybrid 2x beginner → `hybrid_run_strength_2x_beginner`
- hybrid 3x beginner → `hybrid_run_strength_3x_beginner`

## Notes
This is not the full onboarding/profile implementation for run starting profiles.
It is a catalog-expansion and selector-alignment step that prepares the ground for richer cardio starter-capacity matching later.

## Validation
Checked:
- `python3 -m py_compile app/backend/app.py`

Manual selector sanity tests confirmed:
- run only 2x beginner → `starter_run_2x`
- run only 2x conservative → `reentry_run_2x`
- run only 3x beginner → `starter_run_3x_beginner`
- run only 3x novice → `base_run_3x`
- run only 4x novice → `base_run_4x`
- hybrid 2x beginner → `hybrid_run_strength_2x_beginner`
- hybrid 3x beginner → `hybrid_run_strength_3x_beginner`