### PR TITLE
Show active program source and expose recommended program actions

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2755,6 +2755,33 @@ def build_active_programs_by_domain(programs, user_settings):
     }
 
 
+def build_active_program_status_by_domain(programs, user_settings):
+    settings = user_settings if isinstance(user_settings, dict) else {}
+    preferences = settings.get("preferences", {}) if isinstance(settings.get("preferences", {}), dict) else {}
+    overrides = preferences.get("active_program_overrides", {}) if isinstance(preferences.get("active_program_overrides", {}), dict) else {}
+
+    active_programs = build_active_programs_by_domain(programs, settings)
+    status = {}
+
+    for domain in ("strength", "run"):
+        program_id = str(active_programs.get(domain, "") or "").strip()
+        override_id = str(overrides.get(domain, "") or "").strip()
+        if not program_id:
+            status[domain] = {
+                "program_id": None,
+                "selection_source": None,
+            }
+            continue
+
+        selection_source = "manual_override" if override_id and override_id == program_id else "automatic"
+        status[domain] = {
+            "program_id": program_id,
+            "selection_source": selection_source,
+        }
+
+    return status
+
+
 def build_strength_plan(programs, exercises, latest_strength, time_budget_min, fatigue_score, user_settings=None, user_id=None, selected_program_id=None):
     program = None
 
@@ -4976,6 +5003,10 @@ def get_user_settings():
             programs=programs,
             user_settings=item,
         ),
+        "active_program_status_by_domain": build_active_program_status_by_domain(
+            programs=programs,
+            user_settings=item,
+        ),
     }
     return jsonify({"ok": True, "item": item})
 
@@ -5056,6 +5087,10 @@ def post_user_settings():
     item = {
         **item,
         "active_programs_by_domain": build_active_programs_by_domain(
+            programs=programs,
+            user_settings=item,
+        ),
+        "active_program_status_by_domain": build_active_program_status_by_domain(
             programs=programs,
             user_settings=item,
         ),

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2147,6 +2147,10 @@ function renderProfileEquipmentCard(){
   const strengthProgramSelectEl = document.getElementById("profileStrengthProgramSelect");
   const runProgramSelectEl = document.getElementById("profileRunProgramSelect");
   const saveProfileProgramsBtn = document.getElementById("saveProfileProgramsBtn");
+  const recommendedProgramWrapEl = document.getElementById("profileRecommendedProgramWrap");
+  const recommendedStrengthLineEl = document.getElementById("profileRecommendedStrengthLine");
+  const recommendedStrengthReasonEl = document.getElementById("profileRecommendedStrengthReason");
+  const applyRecommendedStrengthProgramBtn = document.getElementById("applyRecommendedStrengthProgramBtn");
   const incrementLineEl = document.getElementById("profileIncrementLine");
   const accountLineEl = document.getElementById("profileAccountLine");
   const accountHelpLineEl = document.getElementById("profileAccountHelpLine");
@@ -2186,6 +2190,13 @@ function renderProfileEquipmentCard(){
   const activeProgramsByDomain = settings.active_programs_by_domain && typeof settings.active_programs_by_domain === "object"
     ? settings.active_programs_by_domain
     : {};
+  const nextGuidance = STATE.currentTodayPlan?.next_guidance && typeof STATE.currentTodayPlan.next_guidance === "object"
+    ? STATE.currentTodayPlan.next_guidance
+    : null;
+  const recommendedStrengthProgramId = nextGuidance?.kind === "program_switch_recommendation"
+    ? String(nextGuidance?.recommended_program_id || "").trim()
+    : "";
+  const recommendedStrengthReason = String(nextGuidance?.switch_reason || nextGuidance?.message || "").trim();
 
   const enabledEquipment = Object.entries(available)
     .filter(([, enabled]) => Boolean(enabled))
@@ -2206,6 +2217,8 @@ function renderProfileEquipmentCard(){
       : null;
     return found ? getProgramDisplayName(found) : id;
   };
+
+  const recommendedStrengthProgramName = getProgramNameById(recommendedStrengthProgramId);
 
   const fillProgramOverrideSelect = (selectEl, kind, selectedValue) => {
     if (!selectEl) return;
@@ -2287,8 +2300,38 @@ function renderProfileEquipmentCard(){
       : tr("profile.active_programs_none");
   }
 
+  if (recommendedProgramWrapEl && recommendedStrengthLineEl && recommendedStrengthReasonEl){
+    const hasRecommendation = Boolean(recommendedStrengthProgramId && recommendedStrengthProgramName);
+    recommendedProgramWrapEl.classList.toggle("wizard-step-hidden", !hasRecommendation);
+    recommendedProgramWrapEl.style.display = hasRecommendation ? "" : "none";
+
+    if (applyRecommendedStrengthProgramBtn){
+      applyRecommendedStrengthProgramBtn.dataset.recommendedProgramId = hasRecommendation ? recommendedStrengthProgramId : "";
+    }
+
+    if (hasRecommendation){
+      recommendedStrengthLineEl.textContent = tr("profile.recommended_strength_program_value", {
+        value: recommendedStrengthProgramName
+      });
+      recommendedStrengthReasonEl.textContent = recommendedStrengthReason || tr("profile.recommended_strength_program_default_reason");
+    } else {
+      recommendedStrengthLineEl.textContent = "";
+      recommendedStrengthReasonEl.textContent = "";
+    }
+  }
+
   fillProgramOverrideSelect(strengthProgramSelectEl, "strength", activeProgramOverrides.strength);
   fillProgramOverrideSelect(runProgramSelectEl, "run", activeProgramOverrides.run);
+
+  if (applyRecommendedStrengthProgramBtn && !applyRecommendedStrengthProgramBtn.dataset.bound){
+    applyRecommendedStrengthProgramBtn.dataset.bound = "1";
+    applyRecommendedStrengthProgramBtn.addEventListener("click", async () => {
+      const recommendedProgramId = String(applyRecommendedStrengthProgramBtn.dataset.recommendedProgramId || "").trim();
+      if (!recommendedProgramId || !strengthProgramSelectEl) return;
+      strengthProgramSelectEl.value = recommendedProgramId;
+      saveProfileProgramsBtn?.click();
+    });
+  }
 
   if (saveProfileProgramsBtn && !saveProfileProgramsBtn.dataset.bound){
     saveProfileProgramsBtn.dataset.bound = "1";
@@ -5285,6 +5328,41 @@ function renderActiveWorkoutCard(item){
       });
 }
 
+async function applyRecommendedStrengthProgram(programId){
+  const recommendedProgramId = String(programId || "").trim();
+  if (!recommendedProgramId) return;
+
+  const currentSettings = STATE.userSettings && typeof STATE.userSettings === "object" ? STATE.userSettings : {};
+  const currentPreferences = currentSettings.preferences && typeof currentSettings.preferences === "object"
+    ? currentSettings.preferences
+    : {};
+  const currentOverrides = currentPreferences.active_program_overrides && typeof currentPreferences.active_program_overrides === "object"
+    ? currentPreferences.active_program_overrides
+    : {};
+
+  const nextPreferences = {
+    ...currentPreferences,
+    active_program_overrides: {
+      ...currentOverrides,
+      strength: recommendedProgramId,
+    },
+  };
+
+  const payload = {
+    ...currentSettings,
+    preferences: nextPreferences,
+  };
+
+  const res = await apiPost("/api/user-settings", payload);
+  STATE.userSettings = res?.item && typeof res.item === "object" ? res.item : payload;
+
+  const todayPlanRes = await apiGet("/api/today-plan");
+  STATE.currentTodayPlan = todayPlanRes?.item || null;
+
+  renderProfileEquipmentCard();
+  renderTodayPlan(STATE.currentTodayPlan || null);
+}
+
 function wireTodayPlanActions(item){
   document.getElementById("startWorkoutBtn")?.addEventListener("click", () => {
     STATE.workoutInProgress = true;
@@ -5303,6 +5381,14 @@ function wireTodayPlanActions(item){
   document.getElementById("acknowledgeRestDayBtn")?.addEventListener("click", handleRestDayAcknowledge);
   document.getElementById("openManualTrainingBtn")?.addEventListener("click", () => {
     showWizardStep("manual");
+  });
+
+  document.querySelectorAll("[data-apply-recommended-strength-program]").forEach(btn => {
+    btn.addEventListener("click", async () => {
+      const programId = String(btn.getAttribute("data-apply-recommended-strength-program") || "").trim();
+      if (!programId) return;
+      await applyRecommendedStrengthProgram(programId);
+    });
   });
 
   document.querySelectorAll("[data-plan-entry-easier]").forEach(btn => {
@@ -5366,6 +5452,37 @@ function buildTodayPlanEntryCardsHtml(item, isPlannedRestDay){
       </li>
     `;
   }).join("");
+}
+
+function buildTodayPlanProgramRecommendationCardHtml(item){
+  const guidance = item?.next_guidance && typeof item.next_guidance === "object"
+    ? item.next_guidance
+    : null;
+  if (!guidance || guidance.kind !== "program_switch_recommendation") return "";
+
+  const recommendedProgramId = String(guidance.recommended_program_id || "").trim();
+  if (!recommendedProgramId) return "";
+
+  const found = Array.isArray(STATE.programs)
+    ? STATE.programs.find(program => String(program?.id || "").trim() === recommendedProgramId)
+    : null;
+  const recommendedProgramName = found ? getProgramDisplayName(found) : recommendedProgramId;
+  const reason = String(guidance.switch_reason || guidance.message || "").trim();
+
+  return `
+    <li>
+      <div style="font-weight:700">${esc(tr("today_plan.recommended_program_title"))}</div>
+      <div class="small" style="margin-top:8px; line-height:1.45">
+        ${esc(tr("today_plan.recommended_strength_program_value", { value: recommendedProgramName }))}
+      </div>
+      ${reason ? `<div class="small" style="margin-top:8px; line-height:1.45">${esc(reason)}</div>` : ""}
+      <div style="margin-top:10px">
+        <button type="button" class="secondary" data-apply-recommended-strength-program="${esc(recommendedProgramId)}">
+          ${esc(tr("button.switch_to_recommended_program"))}
+        </button>
+      </div>
+    </li>
+  `;
 }
 
 function buildTodayPlanRecoveryCardHtml(recovery){
@@ -5578,10 +5695,11 @@ function renderTodayPlan(item){
     });
 
     const recoveryCard = buildTodayPlanRecoveryCardHtml(recovery);
+    const recommendationCard = buildTodayPlanProgramRecommendationCardHtml(item);
 
     const entryCards = buildTodayPlanEntryCardsHtml(item, isPlannedRestDay);
 
-    root.innerHTML = heroCard + recoveryCard + entryCards;
+    root.innerHTML = heroCard + recoveryCard + recommendationCard + entryCards;
 
     wireTodayPlanActions(item);
 

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2190,6 +2190,9 @@ function renderProfileEquipmentCard(){
   const activeProgramsByDomain = settings.active_programs_by_domain && typeof settings.active_programs_by_domain === "object"
     ? settings.active_programs_by_domain
     : {};
+  const activeProgramStatusByDomain = settings.active_program_status_by_domain && typeof settings.active_program_status_by_domain === "object"
+    ? settings.active_program_status_by_domain
+    : {};
   const nextGuidance = STATE.currentTodayPlan?.next_guidance && typeof STATE.currentTodayPlan.next_guidance === "object"
     ? STATE.currentTodayPlan.next_guidance
     : null;
@@ -2248,14 +2251,25 @@ function renderProfileEquipmentCard(){
   if (profile.height_cm != null && profile.height_cm !== "") profileBits.push(tr("profile.height_value", { value: `${profile.height_cm} cm` }));
   if (profile.bodyweight_kg != null && profile.bodyweight_kg !== "") profileBits.push(tr("profile.bodyweight_value", { value: `${profile.bodyweight_kg} kg` }));
 
+  const formatProgramSelectionSource = (source) => {
+    const normalized = String(source || "").trim().toLowerCase();
+    if (normalized === "manual_override") return tr("profile.active_program_selected_by_user");
+    if (normalized === "automatic") return tr("profile.active_program_selected_automatically");
+    return "";
+  };
+
   const activeProgramBits = [];
   const activeStrengthProgramName = getProgramNameById(activeProgramsByDomain.strength);
+  const activeStrengthSource = formatProgramSelectionSource(activeProgramStatusByDomain?.strength?.selection_source);
   if (activeStrengthProgramName){
-    activeProgramBits.push(tr("profile.active_program_strength_value", { value: activeStrengthProgramName }));
+    const strengthLabel = tr("profile.active_program_strength_value", { value: activeStrengthProgramName });
+    activeProgramBits.push([strengthLabel, activeStrengthSource].filter(Boolean).join(" · "));
   }
   const activeEnduranceProgramName = getProgramNameById(activeProgramsByDomain.run);
+  const activeEnduranceSource = formatProgramSelectionSource(activeProgramStatusByDomain?.run?.selection_source);
   if (activeEnduranceProgramName){
-    activeProgramBits.push(tr("profile.active_program_endurance_value", { value: activeEnduranceProgramName }));
+    const enduranceLabel = tr("profile.active_program_endurance_value", { value: activeEnduranceProgramName });
+    activeProgramBits.push([enduranceLabel, activeEnduranceSource].filter(Boolean).join(" · "));
   }
 
   const selectedTraining = [

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -698,5 +698,11 @@
   "plan.rest_day_default_summary": "Hvile er dagens standard. Let bevægelse eller manuel træning er valgfrit.",
   "button.start_next_exercise": "Start næste øvelse",
   "workout.rest.ready_next_exercise": "Klar til næste øvelse",
-  "workout.rest.next_exercise_label": "Næste øvelse"
+  "workout.rest.next_exercise_label": "Næste øvelse",
+  "profile.recommended_program_title": "Anbefalet program",
+  "profile.recommended_strength_program_value": "Anbefalet styrkeprogram: {value}",
+  "profile.recommended_strength_program_default_reason": "Dette program passer bedre til dit nuværende ugemål og din opsætning.",
+  "button.switch_to_recommended_program": "Skift til anbefalet program",
+  "today_plan.recommended_program_title": "Anbefalet program",
+  "today_plan.recommended_strength_program_value": "Anbefalet styrkeprogram: {value}"
 }

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -704,5 +704,7 @@
   "profile.recommended_strength_program_default_reason": "Dette program passer bedre til dit nuværende ugemål og din opsætning.",
   "button.switch_to_recommended_program": "Skift til anbefalet program",
   "today_plan.recommended_program_title": "Anbefalet program",
-  "today_plan.recommended_strength_program_value": "Anbefalet styrkeprogram: {value}"
+  "today_plan.recommended_strength_program_value": "Anbefalet styrkeprogram: {value}",
+  "profile.active_program_selected_by_user": "Valgt af dig",
+  "profile.active_program_selected_automatically": "Valgt automatisk"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -688,5 +688,7 @@
   "profile.recommended_strength_program_default_reason": "This program is a better fit for your current weekly target and setup.",
   "button.switch_to_recommended_program": "Switch to recommended program",
   "today_plan.recommended_program_title": "Recommended program",
-  "today_plan.recommended_strength_program_value": "Recommended strength program: {value}"
+  "today_plan.recommended_strength_program_value": "Recommended strength program: {value}",
+  "profile.active_program_selected_by_user": "Selected by you",
+  "profile.active_program_selected_automatically": "Chosen automatically"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -682,5 +682,11 @@
   "plan.rest_day_default_summary": "Rest is the default today. Light movement or manual training is optional.",
   "button.start_next_exercise": "Start next exercise",
   "workout.rest.ready_next_exercise": "Ready for next exercise",
-  "workout.rest.next_exercise_label": "Next exercise"
+  "workout.rest.next_exercise_label": "Next exercise",
+  "profile.recommended_program_title": "Recommended program",
+  "profile.recommended_strength_program_value": "Recommended strength program: {value}",
+  "profile.recommended_strength_program_default_reason": "This program is a better fit for your current weekly target and setup.",
+  "button.switch_to_recommended_program": "Switch to recommended program",
+  "today_plan.recommended_program_title": "Recommended program",
+  "today_plan.recommended_strength_program_value": "Recommended strength program: {value}"
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -505,6 +505,14 @@
             <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
           </select>
           <div class="small" id="profileProgramOverrideHelp" style="margin-top:8px" data-i18n="profile.active_program_override_help">Vælg et program her for at overstyre den automatiske anbefaling.</div>
+        <div id="profileRecommendedProgramWrap" class="overview-status wizard-step-hidden" style="margin-top:12px; display:none">
+          <div class="stat-line"><strong data-i18n="profile.recommended_program_title">Anbefalet program</strong></div>
+          <div class="stat-line" id="profileRecommendedStrengthLine">-</div>
+          <div class="small" id="profileRecommendedStrengthReason" style="margin-top:6px">-</div>
+          <div class="btn-row" style="margin-top:10px">
+            <button type="button" id="applyRecommendedStrengthProgramBtn" class="secondary" data-i18n="button.switch_to_recommended_program">Skift til anbefalet program</button>
+          </div>
+        </div>
         </div>
         <div class="btn-row" style="margin-top:12px">
           <button type="button" id="saveProfileProgramsBtn" data-i18n="button.save_active_programs">Gem aktive programmer</button>


### PR DESCRIPTION
## Summary
This expands issue #386 by making strength program recommendations visible and actionable, and by showing how active programs were selected.

## Why
Program selection was too implicit:
- users could not clearly see the recommended strength program
- users could not act on the recommendation directly
- users could not tell whether the active program was chosen automatically or explicitly by them

That made the recommendation system harder to trust and correct.

## What changed
### Profile
The profile card now shows:
- the active strength and run programs
- whether each active program was selected automatically or explicitly by the user
- the recommended strength program when a switch recommendation exists
- a short explanation of why the recommendation exists
- a direct button to switch to the recommended program

### Today plan
The today-plan view now also shows:
- a dedicated recommended-program card when the planner returns a strength program switch recommendation
- the recommended strength program name
- the recommendation reason
- a direct button to switch to the recommended program

### Backend
The user-settings payload now includes:
- `active_programs_by_domain`
- `active_program_status_by_domain`

This gives the frontend a simple explicit source per domain:
- `manual_override`
- `automatic`

### Shared behavior
Recommendation actions use the same user-settings save flow:
- save strength override
- refresh user settings
- refresh today plan
- rerender profile and today plan

## Outcome
This makes program selection much more transparent.

The app now distinguishes between:
- current active program
- recommended program
- why the recommendation exists
- whether the active program was selected automatically or by the user

## Validation
Live testing confirmed:
- automatically selected programs show as chosen automatically
- manual overrides show as selected by the user
- recommendation cards appear when mismatch exists
- switching to the recommended program updates both profile and today plan
- recommendation disappears again when the mismatch is resolved

## Notes
This is still not the full end state of #386.
It is a strong product slice that improves transparency and direct action, while leaving broader onboarding and first-use recommendation design for later work.