### PR TITLE
Hide inactive program controls in profile

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2144,7 +2144,9 @@ function renderProfileEquipmentCard(){
   const trainingDaysLineEl = document.getElementById("profileTrainingDaysLine");
   const activeProgramsLineEl = document.getElementById("profileActiveProgramsLine");
   const equipmentLineEl = document.getElementById("profileEquipmentLine");
+  const strengthProgramControlWrapEl = document.getElementById("profileStrengthProgramControlWrap");
   const strengthProgramSelectEl = document.getElementById("profileStrengthProgramSelect");
+  const runProgramControlWrapEl = document.getElementById("profileRunProgramControlWrap");
   const runProgramSelectEl = document.getElementById("profileRunProgramSelect");
   const saveProfileProgramsBtn = document.getElementById("saveProfileProgramsBtn");
   const recommendedProgramWrapEl = document.getElementById("profileRecommendedProgramWrap");
@@ -2258,16 +2260,19 @@ function renderProfileEquipmentCard(){
     return "";
   };
 
+  const strengthTrainingEnabled = Boolean(trainingTypes.strength_weights) || Boolean(trainingTypes.bodyweight);
+  const runTrainingEnabled = Boolean(trainingTypes.running);
+
   const activeProgramBits = [];
   const activeStrengthProgramName = getProgramNameById(activeProgramsByDomain.strength);
   const activeStrengthSource = formatProgramSelectionSource(activeProgramStatusByDomain?.strength?.selection_source);
-  if (activeStrengthProgramName){
+  if (strengthTrainingEnabled && activeStrengthProgramName){
     const strengthLabel = tr("profile.active_program_strength_value", { value: activeStrengthProgramName });
     activeProgramBits.push([strengthLabel, activeStrengthSource].filter(Boolean).join(" · "));
   }
   const activeEnduranceProgramName = getProgramNameById(activeProgramsByDomain.run);
   const activeEnduranceSource = formatProgramSelectionSource(activeProgramStatusByDomain?.run?.selection_source);
-  if (activeEnduranceProgramName){
+  if (runTrainingEnabled && activeEnduranceProgramName){
     const enduranceLabel = tr("profile.active_program_endurance_value", { value: activeEnduranceProgramName });
     activeProgramBits.push([enduranceLabel, activeEnduranceSource].filter(Boolean).join(" · "));
   }
@@ -2315,7 +2320,7 @@ function renderProfileEquipmentCard(){
   }
 
   if (recommendedProgramWrapEl && recommendedStrengthLineEl && recommendedStrengthReasonEl){
-    const hasRecommendation = Boolean(recommendedStrengthProgramId && recommendedStrengthProgramName);
+    const hasRecommendation = strengthTrainingEnabled && Boolean(recommendedStrengthProgramId && recommendedStrengthProgramName);
     recommendedProgramWrapEl.classList.toggle("wizard-step-hidden", !hasRecommendation);
     recommendedProgramWrapEl.style.display = hasRecommendation ? "" : "none";
 
@@ -2334,8 +2339,31 @@ function renderProfileEquipmentCard(){
     }
   }
 
-  fillProgramOverrideSelect(strengthProgramSelectEl, "strength", activeProgramOverrides.strength);
-  fillProgramOverrideSelect(runProgramSelectEl, "run", activeProgramOverrides.run);
+  if (strengthProgramControlWrapEl){
+    strengthProgramControlWrapEl.style.display = strengthTrainingEnabled ? "" : "none";
+  }
+  if (runProgramControlWrapEl){
+    runProgramControlWrapEl.style.display = runTrainingEnabled ? "" : "none";
+  }
+  if (saveProfileProgramsBtn){
+    saveProfileProgramsBtn.style.display = (strengthTrainingEnabled || runTrainingEnabled) ? "" : "none";
+  }
+  const overrideHelpEl = document.getElementById("profileProgramOverrideHelp");
+  if (overrideHelpEl){
+    overrideHelpEl.style.display = (strengthTrainingEnabled || runTrainingEnabled) ? "" : "none";
+  }
+
+  if (strengthTrainingEnabled){
+    fillProgramOverrideSelect(strengthProgramSelectEl, "strength", activeProgramOverrides.strength);
+  } else if (strengthProgramSelectEl){
+    strengthProgramSelectEl.value = "";
+  }
+
+  if (runTrainingEnabled){
+    fillProgramOverrideSelect(runProgramSelectEl, "run", activeProgramOverrides.run);
+  } else if (runProgramSelectEl){
+    runProgramSelectEl.value = "";
+  }
 
   if (applyRecommendedStrengthProgramBtn && !applyRecommendedStrengthProgramBtn.dataset.bound){
     applyRecommendedStrengthProgramBtn.dataset.bound = "1";

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -707,5 +707,4 @@
   "today_plan.recommended_strength_program_value": "Anbefalet styrkeprogram: {value}",
   "profile.active_program_selected_by_user": "Valgt af dig",
   "profile.active_program_selected_automatically": "Valgt automatisk"
-  "today_plan.recommended_strength_program_value": "Anbefalet styrkeprogram: {value}"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -691,5 +691,4 @@
   "today_plan.recommended_strength_program_value": "Recommended strength program: {value}",
   "profile.active_program_selected_by_user": "Selected by you",
   "profile.active_program_selected_automatically": "Chosen automatically"
-  "today_plan.recommended_strength_program_value": "Recommended strength program: {value}"
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -496,14 +496,18 @@
         </details>
         <div class="overview-status" style="margin-top:12px">
           <div class="stat-line"><strong data-i18n="profile.active_program_controls_title">Aktive programmer</strong></div>
-          <label class="small" for="profileStrengthProgramSelect" data-i18n="profile.active_program_strength_label">Styrkeprogram</label>
-          <select id="profileStrengthProgramSelect" style="margin-bottom:10px">
-            <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
-          </select>
-          <label class="small" for="profileRunProgramSelect" data-i18n="profile.active_program_run_label">Løbeprogram</label>
-          <select id="profileRunProgramSelect">
-            <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
-          </select>
+          <div id="profileStrengthProgramControlWrap">
+            <label class="small" for="profileStrengthProgramSelect" data-i18n="profile.active_program_strength_label">Styrkeprogram</label>
+            <select id="profileStrengthProgramSelect" style="margin-bottom:10px">
+              <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
+            </select>
+          </div>
+          <div id="profileRunProgramControlWrap">
+            <label class="small" for="profileRunProgramSelect" data-i18n="profile.active_program_run_label">Løbeprogram</label>
+            <select id="profileRunProgramSelect">
+              <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
+            </select>
+          </div>
           <div class="small" id="profileProgramOverrideHelp" style="margin-top:8px" data-i18n="profile.active_program_override_help">Vælg et program her for at overstyre den automatiske anbefaling.</div>
         <div id="profileRecommendedProgramWrap" class="overview-status wizard-step-hidden" style="margin-top:12px; display:none">
           <div class="stat-line"><strong data-i18n="profile.recommended_program_title">Anbefalet program</strong></div>


### PR DESCRIPTION
## Summary
This fixes issue #415 by hiding program controls that do not match the user's selected training types.

## Why
The profile UI could show strength or run program controls even when that training domain was not enabled.

That created obvious inconsistency:
- users could see irrelevant program controls
- the active program summary could show programs for domains they had not selected
- the profile card felt contradictory

## What changed
### Profile program controls
The profile card now:
- hides the strength program control when neither strength with weights nor bodyweight is enabled
- hides the run program control when running is not enabled

### Active program summary
The active program summary now only shows programs for domains that are actually enabled.

### Recommendation visibility
The strength recommendation block is now only shown when strength is an active training domain.

### Program override help and save action
The override help text and save button continue to work for relevant domains and no longer sit next to irrelevant hidden controls.

## Validation
Live testing confirmed:
- run-only profile shows only run program controls and run summary
- strength-only profile shows only strength program controls and strength summary
- hybrid profile still shows both controls and both summaries

## Outcome
The profile card is now consistent with the user's selected training types and no longer exposes irrelevant program controls.