### PR TITLE
Align planning mode lookup with preferences

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -3798,7 +3798,9 @@ def build_today_plan_training_decision(
 
     planning_mode = "fixed"
     if isinstance(user_settings, dict):
-        planning_mode = str(user_settings.get("planning_mode", "fixed")).strip() or "fixed"
+        preferences = user_settings.get("preferences", {}) if isinstance(user_settings.get("preferences", {}), dict) else {}
+        raw_planning_mode = str(preferences.get("planning_mode", "")).strip() or str(user_settings.get("planning_mode", "")).strip() or "fixed"
+        planning_mode = raw_planning_mode if raw_planning_mode in {"fixed", "autoplan"} else "fixed"
 
     autoplan_meta = None
 


### PR DESCRIPTION
## Summary
This fixes issue #417 by aligning `planning_mode` lookup with the current user settings structure.

## Why
The today-plan decision logic still read `planning_mode` from the top level of `user_settings`, even though settings are now primarily stored under `preferences`.

That created an unnecessary inconsistency and made the planning-mode behavior depend on legacy structure.

## What changed
The backend now resolves `planning_mode` like this:
1. read `preferences.planning_mode` first
2. fall back to top-level `planning_mode` for legacy compatibility
3. normalize to supported values only:
   - `fixed`
   - `autoplan`

Unsupported or malformed values now fall back safely to `fixed`.

## Outcome
This keeps planning-mode lookup aligned with the current settings model while preserving compatibility with older stored user settings.

## Validation
Live validation confirmed:
- backend service restarted cleanly
- no traceback appeared in the journal
- normal check-in and today-plan generation still worked after the change