### PR TITLE
Explain starting levels during first-run setup

### DIFF
--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -707,5 +707,11 @@
   "today_plan.recommended_strength_program_value": "Anbefalet styrkeprogram: {value}",
   "profile.active_program_selected_by_user": "Valgt af dig",
   "profile.active_program_selected_automatically": "Valgt automatisk",
-  "profile.active_program_auto_assigned": "Valgt automatisk fra start"
+  "profile.active_program_auto_assigned": "Valgt automatisk fra start",
+  "profile.strength_starting_profile_help": "Vælg hvor forsigtigt eller ambitiøst styrkedelen skal starte. Det påvirker dit første programvalg.",
+  "profile.strength_starting_profile_help_levels": "Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig træning · Let øvet = lidt mere vane og belastningstolerance.",
+  "profile.run_starting_profile_help": "Vælg hvor forsigtigt eller ambitiøst løbedelen skal starte. Det påvirker dit første programvalg.",
+  "profile.run_starting_profile_help_levels": "Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig løbetræning · Let øvet = lidt mere vane og kapacitet.",
+  "onboarding.first_run.section.planning_level_hint": "Dit startniveau hjælper appen med at vælge, hvor forsigtig eller ambitiøs den første programanbefaling skal være.",
+  "onboarding.first_run.finish_selection_hint": "Dit første program vælges ud fra træningstyper, ugemål, udstyr og startniveau."
 }

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -708,10 +708,10 @@
   "profile.active_program_selected_by_user": "Valgt af dig",
   "profile.active_program_selected_automatically": "Valgt automatisk",
   "profile.active_program_auto_assigned": "Valgt automatisk fra start",
-  "profile.strength_starting_profile_help": "Vælg hvor forsigtigt eller ambitiøst styrkedelen skal starte. Det påvirker dit første programvalg.",
-  "profile.strength_starting_profile_help_levels": "Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig træning · Let øvet = lidt mere vane og belastningstolerance.",
-  "profile.run_starting_profile_help": "Vælg hvor forsigtigt eller ambitiøst løbedelen skal starte. Det påvirker dit første programvalg.",
-  "profile.run_starting_profile_help_levels": "Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig løbetræning · Let øvet = lidt mere vane og kapacitet.",
+  "profile.strength_starting_profile_help": "Vælg hvor roligt eller ambitiøst styrkedelen skal starte. Det påvirker dit første programvalg.",
+  "profile.strength_starting_profile_help_levels": "Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig træning · Let øvet = mere vane og lidt højere belastningstolerance.",
+  "profile.run_starting_profile_help": "Vælg hvor roligt eller ambitiøst løbedelen skal starte. Det påvirker dit første programvalg.",
+  "profile.run_starting_profile_help_levels": "Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig løbetræning · Let øvet = mere vane og lidt højere kapacitet.",
   "onboarding.first_run.section.planning_level_hint": "Dit startniveau hjælper appen med at vælge, hvor forsigtig eller ambitiøs den første programanbefaling skal være.",
   "onboarding.first_run.finish_selection_hint": "Dit første program vælges ud fra træningstyper, ugemål, udstyr og startniveau."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -691,5 +691,11 @@
   "today_plan.recommended_strength_program_value": "Recommended strength program: {value}",
   "profile.active_program_selected_by_user": "Selected by you",
   "profile.active_program_selected_automatically": "Chosen automatically",
-  "profile.active_program_auto_assigned": "Auto-assigned initially"
+  "profile.active_program_auto_assigned": "Auto-assigned initially",
+  "profile.strength_starting_profile_help": "Choose how conservative or ambitious the strength side should start. This affects your first program choice.",
+  "profile.strength_starting_profile_help_levels": "Conservative / re-entry = start gently or return after a break · Beginner = new or only a little recent training · Novice = a bit more habit and load tolerance.",
+  "profile.run_starting_profile_help": "Choose how conservative or ambitious the running side should start. This affects your first program choice.",
+  "profile.run_starting_profile_help_levels": "Conservative / re-entry = start gently or return after a break · Beginner = new or only a little recent running · Novice = a bit more habit and capacity.",
+  "onboarding.first_run.section.planning_level_hint": "Your starting level helps the app choose how conservative or ambitious the first program recommendation should be.",
+  "onboarding.first_run.finish_selection_hint": "Your first program is chosen from your training types, weekly target, equipment, and starting level."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -692,10 +692,10 @@
   "profile.active_program_selected_by_user": "Selected by you",
   "profile.active_program_selected_automatically": "Chosen automatically",
   "profile.active_program_auto_assigned": "Auto-assigned initially",
-  "profile.strength_starting_profile_help": "Choose how conservative or ambitious the strength side should start. This affects your first program choice.",
-  "profile.strength_starting_profile_help_levels": "Conservative / re-entry = start gently or return after a break · Beginner = new or only a little recent training · Novice = a bit more habit and load tolerance.",
-  "profile.run_starting_profile_help": "Choose how conservative or ambitious the running side should start. This affects your first program choice.",
-  "profile.run_starting_profile_help_levels": "Conservative / re-entry = start gently or return after a break · Beginner = new or only a little recent running · Novice = a bit more habit and capacity.",
+  "profile.strength_starting_profile_help": "Choose how gently or ambitiously the strength side should start. This affects your first program choice.",
+  "profile.strength_starting_profile_help_levels": "Conservative / re-entry = start gently or return after a break · Beginner = new or only a little recent training · Novice = more habit and slightly higher load tolerance.",
+  "profile.run_starting_profile_help": "Choose how gently or ambitiously the running side should start. This affects your first program choice.",
+  "profile.run_starting_profile_help_levels": "Conservative / re-entry = start gently or return after a break · Beginner = new or only a little recent running · Novice = more habit and slightly higher capacity.",
   "onboarding.first_run.section.planning_level_hint": "Your starting level helps the app choose how conservative or ambitious the first program recommendation should be.",
   "onboarding.first_run.finish_selection_hint": "Your first program is chosen from your training types, weekly target, equipment, and starting level."
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -568,6 +568,7 @@
             <div class="first-run-setup-section" data-first-run-step="planning">
               <h4 style="margin:0 0 10px" data-i18n="onboarding.first_run.section.planning_title">Planning</h4>
               <p class="small" style="margin:0 0 12px" data-i18n="onboarding.first_run.section.planning_body">Pick training days and a rough weekly target so the first plan is less generic.</p>
+              <p class="small" style="margin:0 0 12px" data-i18n="onboarding.first_run.section.planning_level_hint">Your starting level helps decide how conservative or ambitious the first program recommendation should be.</p>
 
             <div style="margin:16px 0 6px; font-weight:700" data-i18n="profile.training_days_title">Jeg kan typisk træne på</div>
             <div class="small" style="margin-bottom:8px" data-i18n="profile.training_days_help">Dage du ikke vælger her, bliver altid hviledage.</div>
@@ -598,6 +599,8 @@
                 <option value="beginner" selected data-i18n="profile.strength_starting_profile_beginner">Begynder</option>
                 <option value="novice" data-i18n="profile.strength_starting_profile_novice">Let øvet</option>
               </select>
+              <div class="small" style="margin-top:6px" data-i18n="profile.strength_starting_profile_help">Vælg hvor forsigtigt eller ambitiøst styrkedelen skal starte. Det påvirker dit første programvalg.</div>
+              <div class="small" style="margin-top:6px" data-i18n="profile.strength_starting_profile_help_levels">Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig træning · Let øvet = lidt mere vane og belastningstolerance.</div>
             </label>
 
             <label>
@@ -607,6 +610,8 @@
                 <option value="beginner" selected data-i18n="profile.run_starting_profile_beginner">Begynder</option>
                 <option value="novice" data-i18n="profile.run_starting_profile_novice">Let øvet</option>
               </select>
+              <div class="small" style="margin-top:6px" data-i18n="profile.run_starting_profile_help">Vælg hvor forsigtigt eller ambitiøst løbedelen skal starte. Det påvirker dit første programvalg.</div>
+              <div class="small" style="margin-top:6px" data-i18n="profile.run_starting_profile_help_levels">Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig løbetræning · Let øvet = lidt mere vane og kapacitet.</div>
             </label>
             </div>
 
@@ -683,6 +688,7 @@
             <div class="first-run-setup-section" data-first-run-step="finish">
               <h4 style="margin:0 0 10px" data-i18n="onboarding.first_run.section.finish_title">Ready for first recommendation</h4>
               <p class="small" id="firstRunSetupFinishText" style="margin:0 0 12px" data-i18n="onboarding.first_run.finish_default">Review your setup and save when you are ready to continue to your first check-in.</p>
+              <p class="small" style="margin:0 0 12px" data-i18n="onboarding.first_run.finish_selection_hint">Your first program is chosen from your training types, weekly target, equipment, and starting level.</p>
             </div>
 
             <div id="firstRunSetupNav" class="btn-row wizard-step-hidden" style="display:none; margin-top:10px">

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -599,8 +599,8 @@
                 <option value="beginner" selected data-i18n="profile.strength_starting_profile_beginner">Begynder</option>
                 <option value="novice" data-i18n="profile.strength_starting_profile_novice">Let øvet</option>
               </select>
-              <div class="small" style="margin-top:6px" data-i18n="profile.strength_starting_profile_help">Vælg hvor forsigtigt eller ambitiøst styrkedelen skal starte. Det påvirker dit første programvalg.</div>
-              <div class="small" style="margin-top:6px" data-i18n="profile.strength_starting_profile_help_levels">Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig træning · Let øvet = lidt mere vane og belastningstolerance.</div>
+              <div class="small" style="margin-top:6px" data-i18n="profile.strength_starting_profile_help">Vælg hvor roligt eller ambitiøst styrkedelen skal starte. Det påvirker dit første programvalg.</div>
+              <div class="small" style="margin-top:6px; margin-bottom:14px" data-i18n="profile.strength_starting_profile_help_levels">Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig træning · Let øvet = mere vane og lidt højere belastningstolerance.</div>
             </label>
 
             <label>
@@ -610,8 +610,8 @@
                 <option value="beginner" selected data-i18n="profile.run_starting_profile_beginner">Begynder</option>
                 <option value="novice" data-i18n="profile.run_starting_profile_novice">Let øvet</option>
               </select>
-              <div class="small" style="margin-top:6px" data-i18n="profile.run_starting_profile_help">Vælg hvor forsigtigt eller ambitiøst løbedelen skal starte. Det påvirker dit første programvalg.</div>
-              <div class="small" style="margin-top:6px" data-i18n="profile.run_starting_profile_help_levels">Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig løbetræning · Let øvet = lidt mere vane og kapacitet.</div>
+              <div class="small" style="margin-top:6px" data-i18n="profile.run_starting_profile_help">Vælg hvor roligt eller ambitiøst løbedelen skal starte. Det påvirker dit første programvalg.</div>
+              <div class="small" style="margin-top:6px; margin-bottom:14px" data-i18n="profile.run_starting_profile_help_levels">Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig løbetræning · Let øvet = mere vane og lidt højere kapacitet.</div>
             </label>
             </div>
 


### PR DESCRIPTION
## Summary
This starts issue #425 by making the starting-level choice clearer during first-run setup.

## Why
The app already supports starting profiles for strength and running, but setup did not explain these choices clearly enough.

Users could choose:
- conservative / re-entry
- beginner
- novice

But the UI did not explain what these levels meant in practice or how they affected the first recommendation.

## What changed
### Starting-level help text
Added short helper text under:
- strength starting profile
- running starting profile

These explain the practical meaning of the three levels in plain language.

### Planning hint
Added a short planning hint that explains that starting level affects how conservative or ambitious the first program recommendation should be.

### Finish hint
Added a short explanation in the final first-run step clarifying that the first program is chosen from:
- training types
- weekly target
- equipment
- starting level

### Micro-cleanup
Refined wording and spacing so the level explanations read more naturally and visually separate cleanly from the next setup field.

## Outcome
First-run setup now gives users a clearer mental model of:
- what the level choices mean
- what they influence
- why the first recommendation is shaped the way it is

This improves onboarding clarity without changing the underlying selection logic.