### PR TITLE
Explain why the first auto-selected program was chosen

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2143,6 +2143,9 @@ function renderProfileEquipmentCard(){
   const trainingTypesLineEl = document.getElementById("profileTrainingTypesLine");
   const trainingDaysLineEl = document.getElementById("profileTrainingDaysLine");
   const activeProgramsLineEl = document.getElementById("profileActiveProgramsLine");
+  const profileProgramWhyWrapEl = document.getElementById("profileProgramWhyWrap");
+  const profileProgramWhyStrengthLineEl = document.getElementById("profileProgramWhyStrengthLine");
+  const profileProgramWhyRunLineEl = document.getElementById("profileProgramWhyRunLine");
   const equipmentLineEl = document.getElementById("profileEquipmentLine");
   const strengthProgramControlWrapEl = document.getElementById("profileStrengthProgramControlWrap");
   const strengthProgramSelectEl = document.getElementById("profileStrengthProgramSelect");
@@ -2261,6 +2264,51 @@ function renderProfileEquipmentCard(){
     return "";
   };
 
+  const getEquipmentReasonText = () => {
+    const hasBarbell = available.barbell !== false;
+    const hasBench = available.bench !== false;
+    const hasDumbbell = available.dumbbell !== false;
+    const hasBodyweight = available.bodyweight !== false;
+    if (hasBarbell && hasBench) return tr("profile.program_why_equipment_barbell_bench");
+    if (hasDumbbell) return tr("profile.program_why_equipment_dumbbell");
+    if (hasBodyweight) return tr("profile.program_why_equipment_bodyweight");
+    return tr("profile.program_why_equipment_basic");
+  };
+
+  const getStartingProfileLabel = (domain) => {
+    if (String(domain) === "strength"){
+      const value = String(preferences.strength_starting_profile || "beginner").trim() || "beginner";
+      if (value === "conservative_beginner") return tr("profile.strength_starting_profile_conservative");
+      if (value === "novice") return tr("profile.strength_starting_profile_novice");
+      return tr("profile.strength_starting_profile_beginner");
+    }
+    const value = String(preferences.run_starting_profile || "beginner").trim() || "beginner";
+    if (value === "conservative_beginner") return tr("profile.run_starting_profile_conservative");
+    if (value === "novice") return tr("profile.run_starting_profile_novice");
+    return tr("profile.run_starting_profile_beginner");
+  };
+
+  const buildProgramWhyReason = (domain) => {
+    const selectionSource = String(activeProgramStatusByDomain?.[domain]?.selection_source || "").trim().toLowerCase();
+    if (!selectionSource || selectionSource === "manual_override") return "";
+
+    const weekGoal = tr("profile.program_why_week_goal", { count: weeklyTargetSessions });
+    const startLevel = tr("profile.program_why_starting_level", { value: getStartingProfileLabel(domain) });
+
+    if (domain === "strength"){
+      return tr("profile.program_why_strength", {
+        week_goal: weekGoal,
+        equipment: getEquipmentReasonText(),
+        starting_level: startLevel
+      });
+    }
+
+    return tr("profile.program_why_run", {
+      week_goal: weekGoal,
+      starting_level: startLevel
+    });
+  };
+
   const strengthTrainingEnabled = Boolean(trainingTypes.strength_weights) || Boolean(trainingTypes.bodyweight);
   const runTrainingEnabled = Boolean(trainingTypes.running);
 
@@ -2318,6 +2366,25 @@ function renderProfileEquipmentCard(){
     activeProgramsLineEl.textContent = activeProgramBits.length
       ? tr("profile.active_programs_value", { value: activeProgramBits.join(" · ") })
       : tr("profile.active_programs_none");
+  }
+
+  const strengthWhy = strengthTrainingEnabled && activeStrengthProgramName
+    ? buildProgramWhyReason("strength")
+    : "";
+  const runWhy = runTrainingEnabled && activeEnduranceProgramName
+    ? buildProgramWhyReason("run")
+    : "";
+
+  if (profileProgramWhyStrengthLineEl){
+    profileProgramWhyStrengthLineEl.textContent = strengthWhy;
+    profileProgramWhyStrengthLineEl.style.display = strengthWhy ? "" : "none";
+  }
+  if (profileProgramWhyRunLineEl){
+    profileProgramWhyRunLineEl.textContent = runWhy;
+    profileProgramWhyRunLineEl.style.display = runWhy ? "" : "none";
+  }
+  if (profileProgramWhyWrapEl){
+    profileProgramWhyWrapEl.style.display = (strengthWhy || runWhy) ? "" : "none";
   }
 
   if (recommendedProgramWrapEl && recommendedStrengthLineEl && recommendedStrengthReasonEl){

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -713,5 +713,13 @@
   "profile.run_starting_profile_help": "Vælg hvor roligt eller ambitiøst løbedelen skal starte. Det påvirker dit første programvalg.",
   "profile.run_starting_profile_help_levels": "Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig løbetræning · Let øvet = mere vane og lidt højere kapacitet.",
   "onboarding.first_run.section.planning_level_hint": "Dit startniveau hjælper appen med at vælge, hvor forsigtig eller ambitiøs den første programanbefaling skal være.",
-  "onboarding.first_run.finish_selection_hint": "Dit første program vælges ud fra træningstyper, ugemål, udstyr og startniveau."
+  "onboarding.first_run.finish_selection_hint": "Dit første program vælges ud fra træningstyper, ugemål, udstyr og startniveau.",
+  "profile.program_why_week_goal": "{count} pas/uge",
+  "profile.program_why_starting_level": "startniveau: {value}",
+  "profile.program_why_equipment_barbell_bench": "dit udstyr matcher stang og bænk",
+  "profile.program_why_equipment_dumbbell": "dit udstyr matcher håndvægte",
+  "profile.program_why_equipment_bodyweight": "du har kropsvægt til rådighed",
+  "profile.program_why_equipment_basic": "dit udstyr matcher det valgte niveau",
+  "profile.program_why_strength": "Styrkeprogrammet blev valgt ud fra {week_goal}, {equipment} og {starting_level}.",
+  "profile.program_why_run": "Løbeprogrammet blev valgt ud fra {week_goal} og {starting_level}."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -697,5 +697,13 @@
   "profile.run_starting_profile_help": "Choose how gently or ambitiously the running side should start. This affects your first program choice.",
   "profile.run_starting_profile_help_levels": "Conservative / re-entry = start gently or return after a break · Beginner = new or only a little recent running · Novice = more habit and slightly higher capacity.",
   "onboarding.first_run.section.planning_level_hint": "Your starting level helps the app choose how conservative or ambitious the first program recommendation should be.",
-  "onboarding.first_run.finish_selection_hint": "Your first program is chosen from your training types, weekly target, equipment, and starting level."
+  "onboarding.first_run.finish_selection_hint": "Your first program is chosen from your training types, weekly target, equipment, and starting level.",
+  "profile.program_why_week_goal": "{count} sessions/week",
+  "profile.program_why_starting_level": "starting level: {value}",
+  "profile.program_why_equipment_barbell_bench": "your equipment matches barbell and bench",
+  "profile.program_why_equipment_dumbbell": "your equipment matches dumbbells",
+  "profile.program_why_equipment_bodyweight": "you have bodyweight available",
+  "profile.program_why_equipment_basic": "your equipment matches the selected level",
+  "profile.program_why_strength": "The strength program was chosen from {week_goal}, {equipment}, and {starting_level}.",
+  "profile.program_why_run": "The running program was chosen from {week_goal} and {starting_level}."
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -484,6 +484,10 @@
           <div class="stat-line" id="profileTrainingTypesLine" data-i18n="profile.training_types_loading">Træningstyper indlæses...</div>
           <div class="stat-line" id="profileTrainingDaysLine" data-i18n="profile.training_days_loading">Træningsdage indlæses...</div>
           <div class="stat-line" id="profileActiveProgramsLine" data-i18n="profile.active_programs_loading">Aktive programmer indlæses...</div>
+          <div id="profileProgramWhyWrap" style="margin-top:6px; display:none">
+            <div class="small" id="profileProgramWhyStrengthLine" style="display:none"></div>
+            <div class="small" id="profileProgramWhyRunLine" style="display:none; margin-top:4px"></div>
+          </div>
           <div class="stat-line" id="profileEquipmentLine" data-i18n="profile.equipment_loading">Udstyr indlæses...</div>
         </div>
         <details id="profileEquipmentDetails" style="margin-top:12px">


### PR DESCRIPTION
## Summary
This continues issue #425 by explaining why the first auto-selected program was chosen.

## Why
The app already showed:
- which active programs were selected
- whether they were chosen automatically or by the user

But it still did not explain *why* an automatic first choice happened.

That made the first recommendation feel more opaque than necessary, especially during early onboarding.

## What changed
### Profile card explanation
Added short explanation lines in the profile card for auto-selected programs.

These explanations are shown only when the active program was not manually overridden.

### Reason content
The explanation now uses existing profile data to describe the first automatic choice in plain language, based on:
- weekly target
- available equipment
- starting level

### Separate lines per domain
Instead of combining strength and running into one long explanation block, the UI now renders them as separate lines:
- one for strength
- one for running

This makes the explanation easier to scan on mobile.

## Outcome
The profile card now gives the user a clearer explanation of why the initial automatic program selection happened, without adding backend complexity or exposing internal planning details.