### PR TITLE
Refine active program cards by domain for calmer profile scanning

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2143,9 +2143,13 @@ function renderProfileEquipmentCard(){
   const trainingTypesLineEl = document.getElementById("profileTrainingTypesLine");
   const trainingDaysLineEl = document.getElementById("profileTrainingDaysLine");
   const activeProgramsLineEl = document.getElementById("profileActiveProgramsLine");
-  const profileProgramWhyWrapEl = document.getElementById("profileProgramWhyWrap");
-  const profileProgramWhyStrengthLineEl = document.getElementById("profileProgramWhyStrengthLine");
-  const profileProgramWhyRunLineEl = document.getElementById("profileProgramWhyRunLine");
+  const profileActiveProgramCardsWrapEl = document.getElementById("profileActiveProgramCardsWrap");
+  const profileStrengthProgramCardEl = document.getElementById("profileStrengthProgramCard");
+  const profileStrengthProgramSummaryEl = document.getElementById("profileStrengthProgramSummary");
+  const profileStrengthProgramWhyEl = document.getElementById("profileStrengthProgramWhy");
+  const profileRunProgramCardEl = document.getElementById("profileRunProgramCard");
+  const profileRunProgramSummaryEl = document.getElementById("profileRunProgramSummary");
+  const profileRunProgramWhyEl = document.getElementById("profileRunProgramWhy");
   const equipmentLineEl = document.getElementById("profileEquipmentLine");
   const strengthProgramControlWrapEl = document.getElementById("profileStrengthProgramControlWrap");
   const strengthProgramSelectEl = document.getElementById("profileStrengthProgramSelect");
@@ -2366,6 +2370,7 @@ function renderProfileEquipmentCard(){
     activeProgramsLineEl.textContent = activeProgramBits.length
       ? tr("profile.active_programs_value", { value: activeProgramBits.join(" · ") })
       : tr("profile.active_programs_none");
+    activeProgramsLineEl.style.display = activeProgramBits.length ? "none" : "";
   }
 
   const strengthWhy = strengthTrainingEnabled && activeStrengthProgramName
@@ -2375,16 +2380,35 @@ function renderProfileEquipmentCard(){
     ? buildProgramWhyReason("run")
     : "";
 
-  if (profileProgramWhyStrengthLineEl){
-    profileProgramWhyStrengthLineEl.textContent = strengthWhy;
-    profileProgramWhyStrengthLineEl.style.display = strengthWhy ? "" : "none";
+  if (profileStrengthProgramSummaryEl){
+    profileStrengthProgramSummaryEl.textContent = activeStrengthProgramName
+      ? [activeStrengthProgramName, activeStrengthSource].filter(Boolean).join(" · ")
+      : "";
   }
-  if (profileProgramWhyRunLineEl){
-    profileProgramWhyRunLineEl.textContent = runWhy;
-    profileProgramWhyRunLineEl.style.display = runWhy ? "" : "none";
+  if (profileStrengthProgramWhyEl){
+    profileStrengthProgramWhyEl.textContent = strengthWhy;
+    profileStrengthProgramWhyEl.style.display = strengthWhy ? "" : "none";
   }
-  if (profileProgramWhyWrapEl){
-    profileProgramWhyWrapEl.style.display = (strengthWhy || runWhy) ? "" : "none";
+  if (profileStrengthProgramCardEl){
+    profileStrengthProgramCardEl.style.display = strengthTrainingEnabled && activeStrengthProgramName ? "" : "none";
+  }
+
+  if (profileRunProgramSummaryEl){
+    profileRunProgramSummaryEl.textContent = activeEnduranceProgramName
+      ? [activeEnduranceProgramName, activeEnduranceSource].filter(Boolean).join(" · ")
+      : "";
+  }
+  if (profileRunProgramWhyEl){
+    profileRunProgramWhyEl.textContent = runWhy;
+    profileRunProgramWhyEl.style.display = runWhy ? "" : "none";
+  }
+  if (profileRunProgramCardEl){
+    profileRunProgramCardEl.style.display = runTrainingEnabled && activeEnduranceProgramName ? "" : "none";
+  }
+
+  if (profileActiveProgramCardsWrapEl){
+    const hasCards = (strengthTrainingEnabled && activeStrengthProgramName) || (runTrainingEnabled && activeEnduranceProgramName);
+    profileActiveProgramCardsWrapEl.style.display = hasCards ? "" : "none";
   }
 
   if (recommendedProgramWrapEl && recommendedStrengthLineEl && recommendedStrengthReasonEl){

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -721,5 +721,8 @@
   "profile.program_why_equipment_bodyweight": "du har kropsvægt til rådighed",
   "profile.program_why_equipment_basic": "dit udstyr matcher det valgte niveau",
   "profile.program_why_strength": "Styrkeprogrammet blev valgt ud fra {week_goal}, {equipment} og {starting_level}.",
-  "profile.program_why_run": "Løbeprogrammet blev valgt ud fra {week_goal} og {starting_level}."
+  "profile.program_why_run": "Løbeprogrammet blev valgt ud fra {week_goal} og {starting_level}.",
+  "profile.domain_strength_title": "Styrke",
+  "profile.domain_run_title": "Løb",
+  "profile.program_selection_title": "Programvalg"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -705,5 +705,8 @@
   "profile.program_why_equipment_bodyweight": "you have bodyweight available",
   "profile.program_why_equipment_basic": "your equipment matches the selected level",
   "profile.program_why_strength": "The strength program was chosen from {week_goal}, {equipment}, and {starting_level}.",
-  "profile.program_why_run": "The running program was chosen from {week_goal} and {starting_level}."
+  "profile.program_why_run": "The running program was chosen from {week_goal} and {starting_level}.",
+  "profile.domain_strength_title": "Strength",
+  "profile.domain_run_title": "Running",
+  "profile.program_selection_title": "Program selection"
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -483,10 +483,18 @@
           <div class="stat-line" id="profileBodyLine" data-i18n="profile.loading">Profil indlæses...</div>
           <div class="stat-line" id="profileTrainingTypesLine" data-i18n="profile.training_types_loading">Træningstyper indlæses...</div>
           <div class="stat-line" id="profileTrainingDaysLine" data-i18n="profile.training_days_loading">Træningsdage indlæses...</div>
-          <div class="stat-line" id="profileActiveProgramsLine" data-i18n="profile.active_programs_loading">Aktive programmer indlæses...</div>
-          <div id="profileProgramWhyWrap" style="margin-top:6px; display:none">
-            <div class="small" id="profileProgramWhyStrengthLine" style="display:none"></div>
-            <div class="small" id="profileProgramWhyRunLine" style="display:none; margin-top:4px"></div>
+          <div class="stat-line" id="profileActiveProgramsLine" data-i18n="profile.active_programs_loading" style="display:none">Aktive programmer indlæses...</div>
+          <div id="profileActiveProgramCardsWrap" style="margin-top:6px; display:none">
+            <div id="profileStrengthProgramCard" class="small" style="display:none; padding:10px 12px; border-radius:12px; border:1px solid var(--line); margin-bottom:8px">
+              <div style="font-weight:700" data-i18n="profile.domain_strength_title">Styrke</div>
+              <div id="profileStrengthProgramSummary" style="margin-top:4px"></div>
+              <div id="profileStrengthProgramWhy" style="margin-top:4px; opacity:0.85"></div>
+            </div>
+            <div id="profileRunProgramCard" class="small" style="display:none; padding:10px 12px; border-radius:12px; border:1px solid var(--line)">
+              <div style="font-weight:700" data-i18n="profile.domain_run_title">Løb</div>
+              <div id="profileRunProgramSummary" style="margin-top:4px"></div>
+              <div id="profileRunProgramWhy" style="margin-top:4px; opacity:0.85"></div>
+            </div>
           </div>
           <div class="stat-line" id="profileEquipmentLine" data-i18n="profile.equipment_loading">Udstyr indlæses...</div>
         </div>
@@ -499,7 +507,7 @@
           </div>
         </details>
         <div class="overview-status" style="margin-top:12px">
-          <div class="stat-line"><strong data-i18n="profile.active_program_controls_title">Aktive programmer</strong></div>
+          <div class="stat-line"><strong data-i18n="profile.program_selection_title">Programvalg</strong></div>
           <div id="profileStrengthProgramControlWrap">
             <label class="small" for="profileStrengthProgramSelect" data-i18n="profile.active_program_strength_label">Styrkeprogram</label>
             <select id="profileStrengthProgramSelect" style="margin-bottom:10px">


### PR DESCRIPTION
## Summary
This PR refines the profile equipment card so active programs are shown as separate domain-based cards instead of one combined text block.

## What changed
- split active program presentation into separate Strength and Running cards
- keep program summary and “why this was chosen” explanation inside each domain card
- hide the old combined active-program line when domain cards are present
- rename the lower control section from “Aktive programmer” to “Programvalg” / “Program selection”
- add i18n labels for domain titles and the new section title

## Why
The previous UI mixed multiple active domains into one dense line and made it harder to scan:
- strength and running explanations visually ran together
- users had to parse one long text block to understand what was active
- the lower control section title described state, not the actual action available there

This change makes the profile card calmer and easier to read while keeping the existing logic intact.

## Validation
- verified frontend renders correctly with both strength + running enabled
- verified frontend renders correctly with only one active domain
- verified the “Programvalg” section title appears as intended
- validated `app.js` with `node --check`
- validated `da.json` and `en.json` with `python3 -m json.tool`

## Result
The profile card now reads more clearly:
- active domains are separated visually
- each domain shows its own summary and selection reason
- the program control area is labelled according to its actual purpose