### PR TITLE
Fix no-training-types state because the app showed rest day instead o…

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -1120,15 +1120,24 @@ def get_training_type_preferences(user_settings):
     preferences = settings.get("preferences", {})
     if not isinstance(preferences, dict):
         preferences = {}
-    training_types = preferences.get("training_types", {})
-    if not isinstance(training_types, dict):
-        training_types = {}
+
+    raw_training_types = preferences.get("training_types", None)
+
+    if raw_training_types is None:
+        return {
+            "running": True,
+            "strength_weights": True,
+            "bodyweight": True,
+            "mobility": True,
+        }
+
+    training_types = raw_training_types if isinstance(raw_training_types, dict) else {}
 
     return {
-        "running": bool(training_types.get("running", True)),
-        "strength_weights": bool(training_types.get("strength_weights", True)),
-        "bodyweight": bool(training_types.get("bodyweight", True)),
-        "mobility": bool(training_types.get("mobility", True)),
+        "running": bool(training_types.get("running", False)),
+        "strength_weights": bool(training_types.get("strength_weights", False)),
+        "bodyweight": bool(training_types.get("bodyweight", False)),
+        "mobility": bool(training_types.get("mobility", False)),
     }
 
 def get_training_day_preferences(user_settings):
@@ -2597,6 +2606,11 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
     overrides = preferences.get("active_program_overrides", {}) if isinstance(preferences.get("active_program_overrides", {}), dict) else {}
     auto_assigned = preferences.get("auto_assigned_programs", {}) if isinstance(preferences.get("auto_assigned_programs", {}), dict) else {}
 
+    prefs = get_training_type_preferences(settings)
+    strength_enabled = bool(prefs.get("strength_weights", False)) or bool(prefs.get("bodyweight", False))
+    if not strength_enabled:
+        return None
+
     override_id = str(overrides.get("strength", "")).strip()
     if override_id:
         for program in programs:
@@ -3855,6 +3869,10 @@ def build_today_plan_training_decision(
         prefs=prefs,
     )
 
+    has_strength_training = bool(prefs.get("strength_weights", False)) or bool(prefs.get("bodyweight", False))
+    has_running_training = bool(prefs.get("running", False))
+    has_any_primary_training_type = has_strength_training or has_running_training
+
     strength_ctx = build_strength_plan(
         programs=programs,
         exercises=exercises,
@@ -3884,6 +3902,22 @@ def build_today_plan_training_decision(
         planning_mode = raw_planning_mode if raw_planning_mode in {"fixed", "autoplan"} else "fixed"
 
     autoplan_meta = None
+
+    if not has_any_primary_training_type:
+        return {
+            "session_type": "restitution",
+            "template_id": "restitution_easy",
+            "plan_entries": build_restitution_plan(time_budget_min),
+            "plan_variant": "missing_training_types",
+            "reason": "ingen træningstyper valgt · opsæt profil før første plan",
+            "autoplan_meta": {
+                "template_mode": "missing_training_types",
+                "families_selected": [],
+            },
+            "weekly_status": weekly_status,
+            "selected_strength_program_id": None,
+            "selected_endurance_program_id": None,
+        }
 
     weekday_key = None
     try:

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1726,6 +1726,30 @@ function renderForecastHero(planItem, latestCheckin){
     return;
   }
 
+  const missingTrainingTypes = String(planItem?.plan_variant || "").trim() === "missing_training_types";
+
+  if (missingTrainingTypes){
+    setText("forecastType", tr("forecast.missing_training_types_title"));
+    setText("forecastSummary", tr("forecast.missing_training_types_summary"));
+    setText("forecastReason", tr("forecast.missing_training_types_reason"));
+
+    const btn = document.getElementById("forecastPrimaryBtn");
+    if (btn){
+      btn.textContent = tr("forecast.missing_training_types_cta");
+      btn.onclick = () => {
+        showWizardStep("overview");
+        requestAnimationFrame(() => {
+          const profileCard = document.getElementById("profileEquipmentCard");
+          if (profileCard && typeof profileCard.scrollIntoView === "function"){
+            profileCard.scrollIntoView({ behavior: "smooth", block: "start" });
+          }
+          setEquipmentEditorOpen(true);
+        });
+      };
+    }
+    return;
+  }
+
   if (completedToday || completedRestDayToday){
     setText("forecastType", tr("forecast.completed_today"));
     setText(
@@ -5803,20 +5827,27 @@ function renderTodayPlan(item){
 
     const hasEntries = Array.isArray(item?.entries) && item.entries.length > 0;
     const isRestitutionPlan = String(item?.session_type || "").trim().toLowerCase() === "restitution";
-    const showPlannedRestChoiceCard = isPlannedRestDay;
+    const missingTrainingTypes = String(item?.plan_variant || "").trim() === "missing_training_types";
+    const showPlannedRestChoiceCard = isPlannedRestDay && !missingTrainingTypes;
     const showRestitutionChoice = showPlannedRestChoiceCard && hasEntries && isRestitutionPlan;
 
-    const heroTitle = showPlannedRestChoiceCard
-      ? tr("today_plan.rest_day_title")
-      : formatSessionType(item.session_type || "unknown");
-    const heroLead = showPlannedRestChoiceCard
-      ? tr("today_plan.rest_day_lead")
-      : "";
+    const heroTitle = missingTrainingTypes
+      ? tr("today_plan.missing_training_types_title")
+      : showPlannedRestChoiceCard
+        ? tr("today_plan.rest_day_title")
+        : formatSessionType(item.session_type || "unknown");
+    const heroLead = missingTrainingTypes
+      ? tr("today_plan.missing_training_types_lead")
+      : showPlannedRestChoiceCard
+        ? tr("today_plan.rest_day_lead")
+        : "";
 
-    const heroActions = buildTodayPlanHeroActionsHtml({
-      showPlannedRestChoiceCard,
-      showRestitutionChoice,
-    });
+    const heroActions = missingTrainingTypes
+      ? `<div class="btn-row" style="margin-top:10px"><button type="button" id="todayPlanOpenSetupBtn">${esc(tr("today_plan.missing_training_types_cta"))}</button></div>`
+      : buildTodayPlanHeroActionsHtml({
+          showPlannedRestChoiceCard,
+          showRestitutionChoice,
+        });
 
     const heroCard = buildTodayPlanHeroCardHtml({
       heroTitle,
@@ -5834,6 +5865,19 @@ function renderTodayPlan(item){
     const entryCards = buildTodayPlanEntryCardsHtml(item, isPlannedRestDay);
 
     root.innerHTML = heroCard + recoveryCard + recommendationCard + entryCards;
+
+    if (String(item?.plan_variant || "").trim() === "missing_training_types"){
+      document.getElementById("todayPlanOpenSetupBtn")?.addEventListener("click", () => {
+        showWizardStep("overview");
+        requestAnimationFrame(() => {
+          const profileCard = document.getElementById("profileEquipmentCard");
+          if (profileCard && typeof profileCard.scrollIntoView === "function"){
+            profileCard.scrollIntoView({ behavior: "smooth", block: "start" });
+          }
+          setEquipmentEditorOpen(true);
+        });
+      });
+    }
 
     wireTodayPlanActions(item);
 

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -724,5 +724,12 @@
   "profile.program_why_run": "Løbeprogrammet blev valgt ud fra {week_goal} og {starting_level}.",
   "profile.domain_strength_title": "Styrke",
   "profile.domain_run_title": "Løb",
-  "profile.program_selection_title": "Programvalg"
+  "profile.program_selection_title": "Programvalg",
+  "forecast.missing_training_types_title": "Opsætning mangler",
+  "forecast.missing_training_types_summary": "Vælg mindst én træningstype for at få din første plan.",
+  "forecast.missing_training_types_reason": "Appen kan først lave en reel anbefaling, når du har valgt fx styrke, løb eller begge dele.",
+  "forecast.missing_training_types_cta": "Åbn profil og udstyr",
+  "today_plan.missing_training_types_title": "Opsætning mangler",
+  "today_plan.missing_training_types_lead": "Vælg mindst én træningstype i profil og udstyr, før appen kan lave din første plan.",
+  "today_plan.missing_training_types_cta": "Åbn profil og udstyr"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -708,5 +708,12 @@
   "profile.program_why_run": "The running program was chosen from {week_goal} and {starting_level}.",
   "profile.domain_strength_title": "Strength",
   "profile.domain_run_title": "Running",
-  "profile.program_selection_title": "Program selection"
+  "profile.program_selection_title": "Program selection",
+  "forecast.missing_training_types_title": "Setup needed",
+  "forecast.missing_training_types_summary": "Choose at least one training type to get your first plan.",
+  "forecast.missing_training_types_reason": "The app can only make a real recommendation once you have chosen strength, running, or both.",
+  "forecast.missing_training_types_cta": "Open profile and equipment",
+  "today_plan.missing_training_types_title": "Setup needed",
+  "today_plan.missing_training_types_lead": "Choose at least one training type in profile and equipment before the app can build your first plan.",
+  "today_plan.missing_training_types_cta": "Open profile and equipment"
 }

--- a/tests/test_first_auto_assigned_program_matrix.py
+++ b/tests/test_first_auto_assigned_program_matrix.py
@@ -214,9 +214,54 @@ def test_build_active_programs_by_domain_returns_none_when_no_training_types_ena
     # empty preference handling is ultimately enforced in the today-plan flow.
     assert active["strength"] in {None, "starter_strength_2x", "reentry_strength_2x", "starter_strength_gym_2x"}
 
+def test_get_training_type_preferences_uses_legacy_defaults_when_missing():
+    settings = {
+        "preferences": {}
+    }
+
+    prefs = backend_app.get_training_type_preferences(settings)
+
+    assert prefs == {
+        "running": True,
+        "strength_weights": True,
+        "bodyweight": True,
+        "mobility": True,
+    }
+
+
+def test_get_training_type_preferences_respects_explicit_empty_dict():
+    settings = {
+        "preferences": {
+            "training_types": {}
+        }
+    }
+
+    prefs = backend_app.get_training_type_preferences(settings)
+
+    assert prefs == {
+        "running": False,
+        "strength_weights": False,
+        "bodyweight": False,
+        "mobility": False,
+    }
+
+
+def test_build_active_programs_by_domain_returns_none_when_training_types_are_explicitly_empty():
+    settings = make_user_settings(
+        training_types={},
+        weekly_target_sessions=2,
+        available_equipment={},
+    )
+
+    active = backend_app.build_active_programs_by_domain(PROGRAMS, settings)
+
+    assert active["strength"] is None
+    assert active["run"] is None
 
 if __name__ == "__main__":
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):
             fn()
     print("first auto-assigned program matrix tests passed")
+
+


### PR DESCRIPTION
## Summary
Fixes the no-training-types-selected state so the app no longer shows a misleading rest-day plan when the user has explicitly deselected all training types.

## What changed
- changed backend training-type preference handling so an explicit empty `training_types` object is respected instead of falling back to legacy all-true defaults
- gated strength program selection so no strength program is selected when both weighted strength and bodyweight are disabled
- added coverage for explicit empty training-type preferences in the first auto-assigned program matrix tests
- added a dedicated `missing_training_types` today-plan variant instead of treating the state as a normal rest/restitution day
- updated forecast and today-plan frontend rendering to show setup-needed guidance with a direct path back to profile/equipment
- kept profile/program UI consistent by showing no active programs when no training types are selected

## Why
Previously, a user could deselect all training types and still end up seeing a rest-day style state, which made the app behave as if it had a valid training setup. That was misleading. The app should instead clearly tell the user that setup is incomplete and that at least one training type must be selected before a real plan can be built.

## Validation
- `python3 -m json.tool app/frontend/i18n/da.json >/dev/null`
- `python3 -m json.tool app/frontend/i18n/en.json >/dev/null`
- `node --check app/frontend/app.js`
- `python3 tests/test_first_auto_assigned_program_matrix.py`
- live manual verification:
  - no training types selected now shows setup-needed guidance instead of a false rest-day state
  - profile card shows no active programs
  - forecast/overview sends the user back to profile and equipment