### PR TITLE
Clarify recommended vs active program in the profile card

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2181,6 +2181,7 @@ function renderProfileEquipmentCard(){
   const runProgramSelectEl = document.getElementById("profileRunProgramSelect");
   const saveProfileProgramsBtn = document.getElementById("saveProfileProgramsBtn");
   const recommendedProgramWrapEl = document.getElementById("profileRecommendedProgramWrap");
+  const recommendedCurrentStrengthLineEl = document.getElementById("profileRecommendedCurrentStrengthLine");
   const recommendedStrengthLineEl = document.getElementById("profileRecommendedStrengthLine");
   const recommendedStrengthReasonEl = document.getElementById("profileRecommendedStrengthReason");
   const applyRecommendedStrengthProgramBtn = document.getElementById("applyRecommendedStrengthProgramBtn");
@@ -2436,7 +2437,10 @@ function renderProfileEquipmentCard(){
   }
 
   if (recommendedProgramWrapEl && recommendedStrengthLineEl && recommendedStrengthReasonEl){
-    const hasRecommendation = strengthTrainingEnabled && Boolean(recommendedStrengthProgramId && recommendedStrengthProgramName);
+    const hasRecommendation = strengthTrainingEnabled
+      && Boolean(recommendedStrengthProgramId && recommendedStrengthProgramName)
+      && recommendedStrengthProgramId !== String(activeProgramsByDomain.strength || "").trim();
+
     recommendedProgramWrapEl.classList.toggle("wizard-step-hidden", !hasRecommendation);
     recommendedProgramWrapEl.style.display = hasRecommendation ? "" : "none";
 
@@ -2445,11 +2449,19 @@ function renderProfileEquipmentCard(){
     }
 
     if (hasRecommendation){
+      if (recommendedCurrentStrengthLineEl){
+        recommendedCurrentStrengthLineEl.textContent = activeStrengthProgramName
+          ? tr("profile.recommended_current_strength_program_value", { value: activeStrengthProgramName })
+          : tr("profile.recommended_current_strength_program_missing");
+      }
       recommendedStrengthLineEl.textContent = tr("profile.recommended_strength_program_value", {
         value: recommendedStrengthProgramName
       });
       recommendedStrengthReasonEl.textContent = recommendedStrengthReason || tr("profile.recommended_strength_program_default_reason");
     } else {
+      if (recommendedCurrentStrengthLineEl){
+        recommendedCurrentStrengthLineEl.textContent = "";
+      }
       recommendedStrengthLineEl.textContent = "";
       recommendedStrengthReasonEl.textContent = "";
     }

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -700,7 +700,7 @@
   "workout.rest.ready_next_exercise": "Klar til næste øvelse",
   "workout.rest.next_exercise_label": "Næste øvelse",
   "profile.recommended_program_title": "Anbefalet program",
-  "profile.recommended_strength_program_value": "Anbefalet styrkeprogram: {value}",
+  "profile.recommended_strength_program_value": "{value}",
   "profile.recommended_strength_program_default_reason": "Dette program passer bedre til dit nuværende ugemål og din opsætning.",
   "button.switch_to_recommended_program": "Skift til anbefalet program",
   "today_plan.recommended_program_title": "Anbefalet program",
@@ -731,5 +731,9 @@
   "forecast.missing_training_types_cta": "Åbn profil og udstyr",
   "today_plan.missing_training_types_title": "Opsætning mangler",
   "today_plan.missing_training_types_lead": "Vælg mindst én træningstype i profil og udstyr, før appen kan lave din første plan.",
-  "today_plan.missing_training_types_cta": "Åbn profil og udstyr"
+  "today_plan.missing_training_types_cta": "Åbn profil og udstyr",
+  "profile.recommended_program_current_label": "Du bruger nu",
+  "profile.recommended_program_suggested_label": "Appen anbefaler",
+  "profile.recommended_current_strength_program_value": "{value}",
+  "profile.recommended_current_strength_program_missing": "Der er ikke valgt et aktivt styrkeprogram endnu"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -684,7 +684,7 @@
   "workout.rest.ready_next_exercise": "Ready for next exercise",
   "workout.rest.next_exercise_label": "Next exercise",
   "profile.recommended_program_title": "Recommended program",
-  "profile.recommended_strength_program_value": "Recommended strength program: {value}",
+  "profile.recommended_strength_program_value": "{value}",
   "profile.recommended_strength_program_default_reason": "This program is a better fit for your current weekly target and setup.",
   "button.switch_to_recommended_program": "Switch to recommended program",
   "today_plan.recommended_program_title": "Recommended program",
@@ -715,5 +715,9 @@
   "forecast.missing_training_types_cta": "Open profile and equipment",
   "today_plan.missing_training_types_title": "Setup needed",
   "today_plan.missing_training_types_lead": "Choose at least one training type in profile and equipment before the app can build your first plan.",
-  "today_plan.missing_training_types_cta": "Open profile and equipment"
+  "today_plan.missing_training_types_cta": "Open profile and equipment",
+  "profile.recommended_program_current_label": "You are currently using",
+  "profile.recommended_program_suggested_label": "The app recommends",
+  "profile.recommended_current_strength_program_value": "{value}",
+  "profile.recommended_current_strength_program_missing": "No active strength program is selected yet"
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -523,10 +523,13 @@
           <div class="small" id="profileProgramOverrideHelp" style="margin-top:8px" data-i18n="profile.active_program_override_help">Vælg et program her for at overstyre den automatiske anbefaling.</div>
         <div id="profileRecommendedProgramWrap" class="overview-status wizard-step-hidden" style="margin-top:12px; display:none">
           <div class="stat-line"><strong data-i18n="profile.recommended_program_title">Anbefalet program</strong></div>
+          <div class="small" id="profileRecommendedProgramCurrentLabel" style="margin-top:4px" data-i18n="profile.recommended_program_current_label">Du bruger nu</div>
+          <div class="stat-line" id="profileRecommendedCurrentStrengthLine">-</div>
+          <div class="small" id="profileRecommendedProgramSuggestedLabel" style="margin-top:8px" data-i18n="profile.recommended_program_suggested_label">Appen anbefaler nu</div>
           <div class="stat-line" id="profileRecommendedStrengthLine">-</div>
           <div class="small" id="profileRecommendedStrengthReason" style="margin-top:6px">-</div>
           <div class="btn-row" style="margin-top:10px">
-            <button type="button" id="applyRecommendedStrengthProgramBtn" class="secondary" data-i18n="button.switch_to_recommended_program">Skift til anbefalet program</button>
+            <button type="button" id="applyRecommendedStrengthProgramBtn" class="primary" data-i18n="button.switch_to_recommended_program">Skift til anbefalet program</button>
           </div>
         </div>
         </div>


### PR DESCRIPTION
## Summary
Improves the profile card so users can more easily understand the difference between the program they are currently using and the program the app recommends switching to.

## What changed
- shows the current active strength program separately from the newly recommended strength program
- hides the recommendation box when the recommended program already matches the active program
- shortens the recommendation copy so the card is easier to scan on mobile
- keeps the switch action in the same place, but makes the recommendation block read more like a clear decision prompt than a status dump

## Why
The previous profile card made the recommendation harder to understand because the active and recommended states were not clearly separated. Users could see that a recommendation existed, but not immediately grasp:
- what they were using now
- what the app was recommending instead
- whether any action was actually needed

This change makes that comparison explicit and reduces scanning friction.

## Validation
- `python3 -m json.tool app/frontend/i18n/da.json >/dev/null`
- `python3 -m json.tool app/frontend/i18n/en.json >/dev/null`
- `node --check app/frontend/app.js`
- live manual verification on mobile:
  - recommendation box appears only when the recommended program differs from the active one
  - current program and recommended program are shown as separate lines
  - copy is shorter and easier to scan