### PR TITLE
Confirm recommended program switch in the profile card

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2184,6 +2184,7 @@ function renderProfileEquipmentCard(){
   const recommendedCurrentStrengthLineEl = document.getElementById("profileRecommendedCurrentStrengthLine");
   const recommendedStrengthLineEl = document.getElementById("profileRecommendedStrengthLine");
   const recommendedStrengthReasonEl = document.getElementById("profileRecommendedStrengthReason");
+  const profileProgramActionStatusEl = document.getElementById("profileProgramActionStatus");
   const applyRecommendedStrengthProgramBtn = document.getElementById("applyRecommendedStrengthProgramBtn");
   const incrementLineEl = document.getElementById("profileIncrementLine");
   const accountLineEl = document.getElementById("profileAccountLine");
@@ -2436,6 +2437,22 @@ function renderProfileEquipmentCard(){
     profileActiveProgramCardsWrapEl.style.display = hasCards ? "" : "none";
   }
 
+  if (profileProgramActionStatusEl){
+    profileProgramActionStatusEl.classList.remove("ok", "warn");
+    if (PROFILE_PROGRAM_SWITCH_STATUS && PROFILE_PROGRAM_SWITCH_STATUS.kind === "ok"){
+      profileProgramActionStatusEl.textContent = PROFILE_PROGRAM_SWITCH_STATUS.message || "";
+      profileProgramActionStatusEl.style.display = PROFILE_PROGRAM_SWITCH_STATUS.message ? "" : "none";
+      profileProgramActionStatusEl.classList.add("ok");
+      requestAnimationFrame(() => {
+        profileProgramActionStatusEl.style.opacity = PROFILE_PROGRAM_SWITCH_STATUS.message ? "1" : "0";
+      });
+    } else {
+      profileProgramActionStatusEl.textContent = "";
+      profileProgramActionStatusEl.style.opacity = "0";
+      profileProgramActionStatusEl.style.display = "none";
+    }
+  }
+
   if (recommendedProgramWrapEl && recommendedStrengthLineEl && recommendedStrengthReasonEl){
     const hasRecommendation = strengthTrainingEnabled
       && Boolean(recommendedStrengthProgramId && recommendedStrengthProgramName)
@@ -2498,8 +2515,33 @@ function renderProfileEquipmentCard(){
     applyRecommendedStrengthProgramBtn.addEventListener("click", async () => {
       const recommendedProgramId = String(applyRecommendedStrengthProgramBtn.dataset.recommendedProgramId || "").trim();
       if (!recommendedProgramId || !strengthProgramSelectEl) return;
+
+      const recommendedProgramName = getProgramNameById(recommendedProgramId) || recommendedProgramId;
+
+      PROFILE_PROGRAM_SWITCH_STATUS = {
+        kind: "ok",
+        message: tr("profile.recommended_program_switch_success", { value: recommendedProgramName })
+      };
+
+      if (PROFILE_PROGRAM_SWITCH_STATUS_TIMEOUT){
+        clearTimeout(PROFILE_PROGRAM_SWITCH_STATUS_TIMEOUT);
+        PROFILE_PROGRAM_SWITCH_STATUS_TIMEOUT = null;
+      }
+
       strengthProgramSelectEl.value = recommendedProgramId;
       saveProfileProgramsBtn?.click();
+
+      PROFILE_PROGRAM_SWITCH_STATUS_TIMEOUT = setTimeout(() => {
+        const statusEl = document.getElementById("profileProgramActionStatus");
+        if (statusEl){
+          statusEl.style.opacity = "0";
+        }
+        setTimeout(() => {
+          PROFILE_PROGRAM_SWITCH_STATUS = null;
+          PROFILE_PROGRAM_SWITCH_STATUS_TIMEOUT = null;
+          renderProfileEquipmentCard();
+        }, 260);
+      }, 2200);
     });
   }
 
@@ -6723,6 +6765,8 @@ session_type:
 const AUTH_BASE = "https://auth.innosocia.dk";
 const AUTH_RETURN_TO = "https://strength.innosocia.dk";
 let AUTH_USER = null;
+let PROFILE_PROGRAM_SWITCH_STATUS = null;
+let PROFILE_PROGRAM_SWITCH_STATUS_TIMEOUT = null;
 
 function showAuthMessage(msg){
   const statusEl = document.getElementById("status");

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -735,5 +735,6 @@
   "profile.recommended_program_current_label": "Du bruger nu",
   "profile.recommended_program_suggested_label": "Appen anbefaler",
   "profile.recommended_current_strength_program_value": "{value}",
-  "profile.recommended_current_strength_program_missing": "Der er ikke valgt et aktivt styrkeprogram endnu"
+  "profile.recommended_current_strength_program_missing": "Der er ikke valgt et aktivt styrkeprogram endnu",
+  "profile.recommended_program_switch_success": "Styrkeprogram opdateret til: {value}"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -719,5 +719,6 @@
   "profile.recommended_program_current_label": "You are currently using",
   "profile.recommended_program_suggested_label": "The app recommends",
   "profile.recommended_current_strength_program_value": "{value}",
-  "profile.recommended_current_strength_program_missing": "No active strength program is selected yet"
+  "profile.recommended_current_strength_program_missing": "No active strength program is selected yet",
+  "profile.recommended_program_switch_success": "Strength program updated to: {value}"
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -508,6 +508,7 @@
         </details>
         <div class="overview-status" style="margin-top:12px">
           <div class="stat-line"><strong data-i18n="profile.program_selection_title">Programvalg</strong></div>
+          <div class="small" id="profileProgramActionStatus" style="margin:6px 0 10px; display:none; opacity:0; transition:opacity 220ms ease"></div>
           <div id="profileStrengthProgramControlWrap">
             <label class="small" for="profileStrengthProgramSelect" data-i18n="profile.active_program_strength_label">Styrkeprogram</label>
             <select id="profileStrengthProgramSelect" style="margin-bottom:10px">


### PR DESCRIPTION
## Summary
Adds visible feedback when the user accepts the recommended strength program from the profile card.

## What changed
- keeps the existing recommended-program switch action
- adds a success message under **Program selection** after the user switches to the recommended strength program
- lets that message stay visible briefly and then fade out
- ensures the feedback remains visible even when the recommendation box disappears after the switch
- keeps the program dropdown in sync with the newly saved active program

## Why
The switch action worked, but the feedback was too weak. After pressing **Switch to recommended program**, the recommendation block could disappear immediately because the recommendation was no longer relevant. That made the action feel uncertain, even when it succeeded.

This change makes the result explicit and gives the user a short confirmation in the same part of the UI where the program is managed.

## Validation
- `node --check app/frontend/app.js`
- frontend deployed safely
- live mobile verification:
  - click **Switch to recommended program**
  - active strength program updates correctly
  - success message appears under **Program selection**
  - success message fades out after a short delay
  - recommendation block disappears once the switch makes it irrelevant