### PR TITLE
Distinguish accepted recommendation from manual override

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2847,6 +2847,7 @@ def build_active_program_status_by_domain(programs, user_settings):
     preferences = settings.get("preferences", {}) if isinstance(settings.get("preferences", {}), dict) else {}
     overrides = preferences.get("active_program_overrides", {}) if isinstance(preferences.get("active_program_overrides", {}), dict) else {}
     auto_assigned = preferences.get("auto_assigned_programs", {}) if isinstance(preferences.get("auto_assigned_programs", {}), dict) else {}
+    accepted_recommendations = preferences.get("accepted_program_recommendations", {}) if isinstance(preferences.get("accepted_program_recommendations", {}), dict) else {}
 
     active_programs = build_active_programs_by_domain(programs, settings)
     status = {}
@@ -2855,6 +2856,7 @@ def build_active_program_status_by_domain(programs, user_settings):
         program_id = str(active_programs.get(domain, "") or "").strip()
         override_id = str(overrides.get(domain, "") or "").strip()
         auto_assigned_id = str(auto_assigned.get(domain, "") or "").strip()
+        accepted_id = str(accepted_recommendations.get(domain, "") or "").strip()
         if not program_id:
             status[domain] = {
                 "program_id": None,
@@ -2863,7 +2865,7 @@ def build_active_program_status_by_domain(programs, user_settings):
             continue
 
         if override_id and override_id == program_id:
-            selection_source = "manual_override"
+            selection_source = "accepted_recommendation" if accepted_id and accepted_id == program_id else "manual_override"
         elif auto_assigned_id and auto_assigned_id == program_id:
             selection_source = "auto_assigned"
         else:
@@ -5165,6 +5167,20 @@ def post_user_settings():
         clean_preferences = {**clean_preferences, "active_program_overrides": clean_overrides}
     elif "active_program_overrides" in clean_preferences:
         clean_preferences = {k: v for k, v in clean_preferences.items() if k != "active_program_overrides"}
+
+    raw_accepted_recommendations = clean_preferences.get("accepted_program_recommendations", {}) if isinstance(clean_preferences.get("accepted_program_recommendations", {}), dict) else {}
+    clean_accepted_recommendations = {}
+    if isinstance(raw_accepted_recommendations, dict):
+        raw_strength_accepted = str(raw_accepted_recommendations.get("strength", "")).strip()
+        raw_run_accepted = str(raw_accepted_recommendations.get("run", "")).strip()
+        if raw_strength_accepted:
+            clean_accepted_recommendations["strength"] = raw_strength_accepted
+        if raw_run_accepted:
+            clean_accepted_recommendations["run"] = raw_run_accepted
+    if clean_accepted_recommendations:
+        clean_preferences = {**clean_preferences, "accepted_program_recommendations": clean_accepted_recommendations}
+    elif "accepted_program_recommendations" in clean_preferences:
+        clean_preferences = {k: v for k, v in clean_preferences.items() if k != "accepted_program_recommendations"}
 
     raw_auto_assigned = clean_preferences.get("auto_assigned_programs", {}) if isinstance(clean_preferences.get("auto_assigned_programs", {}), dict) else {}
     clean_auto_assigned = {}

--- a/app/backend/db.py
+++ b/app/backend/db.py
@@ -25,9 +25,20 @@ def init_db():
         user_id TEXT PRIMARY KEY,
         equipment_increments TEXT,
         available_equipment TEXT,
+        profile TEXT,
+        preferences TEXT,
         updated_at TEXT
     )
     """)
+
+    user_settings_columns = {
+        row["name"] if isinstance(row, sqlite3.Row) else row[1]
+        for row in cur.execute("PRAGMA table_info(user_settings)").fetchall()
+    }
+    if "profile" not in user_settings_columns:
+        cur.execute("ALTER TABLE user_settings ADD COLUMN profile TEXT")
+    if "preferences" not in user_settings_columns:
+        cur.execute("ALTER TABLE user_settings ADD COLUMN preferences TEXT")
 
     cur.execute("""
     CREATE TABLE IF NOT EXISTS workouts (

--- a/app/backend/storage.py
+++ b/app/backend/storage.py
@@ -511,17 +511,21 @@ class SQLiteStorage:
         with self._conn() as conn:
             conn.execute(
                 """
-                INSERT INTO user_settings (user_id, equipment_increments, available_equipment, updated_at)
-                VALUES (?, ?, ?, datetime('now'))
+                INSERT INTO user_settings (user_id, equipment_increments, available_equipment, profile, preferences, updated_at)
+                VALUES (?, ?, ?, ?, ?, datetime('now'))
                 ON CONFLICT(user_id) DO UPDATE SET
                     equipment_increments = excluded.equipment_increments,
                     available_equipment = excluded.available_equipment,
+                    profile = excluded.profile,
+                    preferences = excluded.preferences,
                     updated_at = datetime('now')
                 """,
                 (
                     str(user_id),
                     json.dumps(clean["equipment_increments"], ensure_ascii=False),
                     json.dumps(clean["available_equipment"], ensure_ascii=False),
+                    json.dumps(clean["profile"], ensure_ascii=False),
+                    json.dumps(clean["preferences"], ensure_ascii=False),
                 )
             )
             conn.commit()

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2289,6 +2289,7 @@ function renderProfileEquipmentCard(){
   const formatProgramSelectionSource = (source) => {
     const normalized = String(source || "").trim().toLowerCase();
     if (normalized === "manual_override") return tr("profile.active_program_selected_by_user");
+    if (normalized === "accepted_recommendation") return tr("profile.active_program_accepted_recommendation");
     if (normalized === "auto_assigned") return tr("profile.active_program_auto_assigned");
     if (normalized === "automatic" || normalized === "automatic_recommendation") return tr("profile.active_program_selected_automatically");
     return "";
@@ -2522,6 +2523,10 @@ function renderProfileEquipmentCard(){
         kind: "ok",
         message: tr("profile.recommended_program_switch_success", { value: recommendedProgramName })
       };
+      PROFILE_ACCEPTED_RECOMMENDATION_PENDING = {
+        domain: "strength",
+        program_id: recommendedProgramId
+      };
 
       if (PROFILE_PROGRAM_SWITCH_STATUS_TIMEOUT){
         clearTimeout(PROFILE_PROGRAM_SWITCH_STATUS_TIMEOUT);
@@ -2566,6 +2571,40 @@ function renderProfileEquipmentCard(){
         delete nextPreferences.active_program_overrides;
       }
 
+      const currentAcceptedRecommendations = currentPreferences.accepted_program_recommendations
+        && typeof currentPreferences.accepted_program_recommendations === "object"
+          ? currentPreferences.accepted_program_recommendations
+          : {};
+      const nextAcceptedRecommendations = { ...currentAcceptedRecommendations };
+
+      if (
+        PROFILE_ACCEPTED_RECOMMENDATION_PENDING
+        && PROFILE_ACCEPTED_RECOMMENDATION_PENDING.domain === "strength"
+        && PROFILE_ACCEPTED_RECOMMENDATION_PENDING.program_id
+        && PROFILE_ACCEPTED_RECOMMENDATION_PENDING.program_id === selectedStrength
+      ){
+        nextAcceptedRecommendations.strength = selectedStrength;
+      } else {
+        delete nextAcceptedRecommendations.strength;
+      }
+
+      if (
+        PROFILE_ACCEPTED_RECOMMENDATION_PENDING
+        && PROFILE_ACCEPTED_RECOMMENDATION_PENDING.domain === "run"
+        && PROFILE_ACCEPTED_RECOMMENDATION_PENDING.program_id
+        && PROFILE_ACCEPTED_RECOMMENDATION_PENDING.program_id === selectedRun
+      ){
+        nextAcceptedRecommendations.run = selectedRun;
+      } else {
+        delete nextAcceptedRecommendations.run;
+      }
+
+      if (Object.keys(nextAcceptedRecommendations).length){
+        nextPreferences.accepted_program_recommendations = nextAcceptedRecommendations;
+      } else {
+        delete nextPreferences.accepted_program_recommendations;
+      }
+
       const payload = {
         ...currentSettings,
         preferences: nextPreferences
@@ -2573,6 +2612,7 @@ function renderProfileEquipmentCard(){
 
       const res = await apiPost("/api/user-settings", payload);
       STATE.userSettings = res?.item && typeof res.item === "object" ? res.item : payload;
+      PROFILE_ACCEPTED_RECOMMENDATION_PENDING = null;
 
       const todayPlanRes = await apiGet("/api/today-plan");
       STATE.currentTodayPlan = todayPlanRes?.item || null;
@@ -6767,6 +6807,7 @@ const AUTH_RETURN_TO = "https://strength.innosocia.dk";
 let AUTH_USER = null;
 let PROFILE_PROGRAM_SWITCH_STATUS = null;
 let PROFILE_PROGRAM_SWITCH_STATUS_TIMEOUT = null;
+let PROFILE_ACCEPTED_RECOMMENDATION_PENDING = null;
 
 function showAuthMessage(msg){
   const statusEl = document.getElementById("status");

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -736,5 +736,6 @@
   "profile.recommended_program_suggested_label": "Appen anbefaler",
   "profile.recommended_current_strength_program_value": "{value}",
   "profile.recommended_current_strength_program_missing": "Der er ikke valgt et aktivt styrkeprogram endnu",
-  "profile.recommended_program_switch_success": "Styrkeprogram opdateret til: {value}"
+  "profile.recommended_program_switch_success": "Styrkeprogram opdateret til: {value}",
+  "profile.active_program_accepted_recommendation": "Accepteret anbefaling"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -720,5 +720,6 @@
   "profile.recommended_program_suggested_label": "The app recommends",
   "profile.recommended_current_strength_program_value": "{value}",
   "profile.recommended_current_strength_program_missing": "No active strength program is selected yet",
-  "profile.recommended_program_switch_success": "Strength program updated to: {value}"
+  "profile.recommended_program_switch_success": "Strength program updated to: {value}",
+  "profile.active_program_accepted_recommendation": "Accepted recommendation"
 }


### PR DESCRIPTION
## Summary
The profile currently labels both manual dropdown selections and app-recommended program switches as if they were chosen directly by the user.

This issue should distinguish between:
- manual program changes made through the dropdown
- program changes made by clicking the app’s recommended switch button

## Problem
When the user accepts a recommended program from the recommendation card, the active program is still shown as "Valgt af dig" / manual override in the profile.

That blurs an important semantic difference:
- a manual override means the user explicitly chose a program from the selector
- an accepted recommendation means the app suggested a switch and the user approved it

These are not the same thing, and the profile should reflect that clearly.

## Expected behavior
After a manual dropdown save:
- the active program status should remain "Valgt af dig"

After clicking the recommendation button:
- the active program status should show "Accepteret anbefaling"

## Scope
This should include the full path from save to display:
- persist accepted recommendation state in user settings
- make backend active program status generation recognize that state
- expose the correct selection source in API responses
- render the correct label in the frontend

## Notes
Be careful to preserve the existing distinction for:
- automatically assigned programs
- ordinary manual overrides

The change should be semantic only:
it should not change which active program is selected, only how the source of that selection is represented.