### PR TITLE
Add calm atmosphere layer without hurting readability

### DIFF
--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -11,6 +11,12 @@
   --success:#9fd3a8;
   --caution:#e7c27d;
 
+  --atmo-top:rgba(214, 211, 201, 0.08);
+  --atmo-mid:rgba(126, 145, 170, 0.05);
+  --atmo-bottom:rgba(255, 255, 255, 0.02);
+  --surface-glow:rgba(255, 255, 255, 0.025);
+  --card-shadow:0 10px 30px rgba(0, 0, 0, 0.22);
+
   --space-1:6px;
   --space-2:10px;
   --space-3:16px;
@@ -35,8 +41,20 @@
 }
 
 body{
-  background:var(--bg);
+  background-color:var(--bg);
+  background-image:
+    radial-gradient(circle at top left, var(--atmo-top), transparent 42%),
+    radial-gradient(circle at 85% 18%, var(--atmo-mid), transparent 36%),
+    linear-gradient(180deg, rgba(255,255,255,0.015), transparent 28%),
+    linear-gradient(180deg, #161616 0%, var(--bg) 26%, #101010 100%);
+  background-attachment:fixed;
   color:var(--text-primary);
+}
+
+body.workout-mode-active{
+  background-image:
+    radial-gradient(circle at top left, rgba(214, 211, 201, 0.035), transparent 30%),
+    linear-gradient(180deg, #141414 0%, #101010 100%);
 }
 
 .wrap{
@@ -51,14 +69,19 @@ li{
 }
 
 .card{
-  background:var(--surface-2);
+  background:
+    linear-gradient(180deg, var(--surface-glow), transparent 38%),
+    var(--surface-2);
   border-radius:var(--radius-lg);
   padding:var(--space-3);
+  box-shadow:var(--card-shadow);
 }
 
 .entry-box,
 li{
-  background:var(--surface-3);
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.018), transparent 34%),
+    var(--surface-3);
   border-radius:var(--radius-md);
 }
 


### PR DESCRIPTION
## Summary
Add a subtle atmosphere layer to the frontend so SovereignStrength feels more intentional and cohesive without becoming visually noisy or harder to read.

## What changed
- added new atmosphere tokens in `app/frontend/styles.css` for:
  - soft ambient background tones
  - surface glow
  - card shadow
- updated `body` background to use layered gradients instead of a flat background
- added a toned-down `body.workout-mode-active` background so workout-related screens keep focus
- added subtle surface depth to:
  - `.card`
  - `.entry-box`
  - `li`

## Why
Issue #320 is about giving the app a calmer and more deliberate visual atmosphere across the product.

Before this change:
- the app had a solid dark background and clear structure
- but the visual environment still felt flat and a bit too raw
- the UI lacked a shared sense of ambient depth and tone

This PR adds that atmosphere in a restrained way:
- no decorative hero graphics
- no busy textures
- no aggressive visual effects
- no reduction in readability

## Scope
This PR only adjusts the shared visual atmosphere layer in CSS.

It does not:
- change app logic
- restructure frontend markup
- redesign individual flows in depth
- introduce illustrations or screen-specific art direction

## Product effect
The app now feels more cohesive across:
- overview
- check-in
- today plan
- history
- profile-related screens

At the same time, workout-related screens remain visually calmer through the dedicated `workout-mode-active` variant.

## Validation
Checked in live frontend views across key screens.

Observed outcome:
- stronger visual cohesion
- more depth in cards and surfaces
- better product feel without sacrificing clarity
- workout and plan screens still remain focused and readable

## Outcome
SovereignStrength now has a subtle atmosphere layer that supports the product direction from the UI epic without pushing the interface into visual clutter.