### PR TITLE
Fix legacy user settings migration into nested profile and preferences

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -5468,13 +5468,6 @@ def _get_bodyweight_kg_for_session(session_item):
                     except Exception:
                         pass
 
-                # fallback for legacy flat structure
-                try:
-                    val = float(settings.get("bodyweight_kg", 0) or 0)
-                    if val > 0:
-                        return val
-                except Exception:
-                    pass
 
     return 0.0
 

--- a/app/backend/storage.py
+++ b/app/backend/storage.py
@@ -9,6 +9,90 @@ from db import init_db
 logger = logging.getLogger(__name__)
 
 
+LEGACY_PROFILE_FIELD_NAMES = {
+    "bodyweight_kg",
+    "height_cm",
+    "age",
+    "sex",
+    "gender",
+    "equipment_profile",
+}
+
+LEGACY_PREFERENCE_FIELD_NAMES = {
+    "training_types",
+    "training_days",
+    "weekly_target_sessions",
+    "planning_mode",
+    "strength_starting_profile",
+    "run_starting_profile",
+    "active_program_overrides",
+    "accepted_program_recommendations",
+    "auto_assigned_programs",
+    "default_phone_region",
+}
+
+
+def normalize_user_settings_shape(user_id, settings):
+    source = dict(settings or {}) if isinstance(settings, dict) else {}
+
+    clean = dict(source)
+    clean["user_id"] = user_id
+
+    profile = dict(clean.get("profile") or {}) if isinstance(clean.get("profile"), dict) else {}
+    preferences = dict(clean.get("preferences") or {}) if isinstance(clean.get("preferences"), dict) else {}
+
+    for field_name in LEGACY_PROFILE_FIELD_NAMES:
+        if field_name in clean and field_name not in profile:
+            profile[field_name] = clean[field_name]
+
+    for field_name in LEGACY_PREFERENCE_FIELD_NAMES:
+        if field_name in clean and field_name not in preferences:
+            preferences[field_name] = clean[field_name]
+
+    clean["profile"] = profile
+    clean["preferences"] = preferences
+
+    for field_name in LEGACY_PROFILE_FIELD_NAMES:
+        clean.pop(field_name, None)
+
+    for field_name in LEGACY_PREFERENCE_FIELD_NAMES:
+        clean.pop(field_name, None)
+
+    equipment_increments = clean.get("equipment_increments", {})
+    available_equipment = clean.get("available_equipment", {})
+    local_protection_holds = clean.get("local_protection_holds", {})
+
+    clean["equipment_increments"] = equipment_increments if isinstance(equipment_increments, dict) else {}
+    clean["available_equipment"] = available_equipment if isinstance(available_equipment, dict) else {}
+    clean["local_protection_holds"] = local_protection_holds if isinstance(local_protection_holds, dict) else {}
+
+    return clean
+
+
+
+def is_legacy_user_settings_payload(value):
+    if not isinstance(value, dict):
+        return False
+
+    known_top_level = {
+        "equipment_increments",
+        "available_equipment",
+        "profile",
+        "preferences",
+        "local_protection_holds",
+    }
+
+    if any(key in value for key in known_top_level):
+        return True
+
+    if any(key in value for key in LEGACY_PROFILE_FIELD_NAMES):
+        return True
+
+    if any(key in value for key in LEGACY_PREFERENCE_FIELD_NAMES):
+        return True
+
+    return False
+
 class JSONStorage:
     def __init__(self, data_dir):
         self.data_dir = Path(data_dir)
@@ -253,25 +337,21 @@ class JSONStorage:
 
         top_user_id = raw.get("user_id")
         if top_user_id == user_id:
-            return raw
+            return normalize_user_settings_shape(user_id, raw)
 
         users_map = raw.get("users")
         if isinstance(users_map, dict):
             candidate = users_map.get(str(user_id)) or users_map.get(user_id)
             if isinstance(candidate, dict):
-                merged = dict(candidate)
-                merged.setdefault("user_id", user_id)
-                return merged
+                return normalize_user_settings_shape(user_id, candidate)
 
         if isinstance(users_map, list):
             for item in users_map:
                 if isinstance(item, dict) and item.get("user_id") == user_id:
-                    return item
+                    return normalize_user_settings_shape(user_id, item)
 
-        if "equipment_increments" in raw or "available_equipment" in raw or "profile" in raw or "preferences" in raw:
-            merged = dict(raw)
-            merged.setdefault("user_id", user_id)
-            return merged
+        if is_legacy_user_settings_payload(raw):
+            return normalize_user_settings_shape(user_id, raw)
 
         return {}
 
@@ -284,17 +364,12 @@ class JSONStorage:
 
             if "users" not in raw or not isinstance(raw.get("users"), dict):
                 legacy = {}
-                if raw and ("equipment_increments" in raw or "available_equipment" in raw or "profile" in raw or "preferences" in raw):
+                if is_legacy_user_settings_payload(raw):
                     legacy_user_id = raw.get("user_id", 1)
-                    legacy[str(legacy_user_id)] = dict(raw)
+                    legacy[str(legacy_user_id)] = normalize_user_settings_shape(legacy_user_id, raw)
                 raw = {"users": legacy}
 
-            clean = dict(settings or {})
-            clean["user_id"] = user_id
-            if not isinstance(clean.get("profile"), dict):
-                clean["profile"] = {}
-            if not isinstance(clean.get("preferences"), dict):
-                clean["preferences"] = {}
+            clean = normalize_user_settings_shape(user_id, settings)
             raw["users"][str(user_id)] = clean
             self._write_object("user_settings", raw)
             return clean
@@ -484,29 +559,18 @@ class SQLiteStorage:
         if not row:
             return {}
 
-        return {
+        return normalize_user_settings_shape(user_id, {
             "user_id": row["user_id"],
             "equipment_increments": json.loads(row["equipment_increments"] or "{}"),
             "available_equipment": json.loads(row["available_equipment"] or "{}"),
             "profile": json.loads(row["profile"] or "{}") if "profile" in row.keys() else {},
             "preferences": json.loads(row["preferences"] or "{}") if "preferences" in row.keys() else {},
-        }
+        })
 
     def save_user_settings_for(self, user_id, settings):
         self._ensure_user_row(user_id)
 
-        equipment_increments = settings.get("equipment_increments", {})
-        available_equipment = settings.get("available_equipment", {})
-        profile = settings.get("profile", {})
-        preferences = settings.get("preferences", {})
-
-        clean = {
-            "user_id": user_id,
-            "equipment_increments": equipment_increments if isinstance(equipment_increments, dict) else {},
-            "available_equipment": available_equipment if isinstance(available_equipment, dict) else {},
-            "profile": profile if isinstance(profile, dict) else {},
-            "preferences": preferences if isinstance(preferences, dict) else {},
-        }
+        clean = normalize_user_settings_shape(user_id, settings)
 
         with self._conn() as conn:
             conn.execute(

--- a/tests/test_user_settings_migration.py
+++ b/tests/test_user_settings_migration.py
@@ -1,0 +1,217 @@
+import json
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND_DIR = ROOT / "app" / "backend"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from storage import JSONStorage, SQLiteStorage, normalize_user_settings_shape
+
+
+def test_normalize_user_settings_shape_moves_legacy_fields_into_nested_structure():
+    raw = {
+        "user_id": "u1",
+        "bodyweight_kg": 92,
+        "training_types": {"running": True, "strength_weights": False},
+        "training_days": {"mon": True, "wed": True},
+        "weekly_target_sessions": 3,
+        "planning_mode": "autoplan",
+        "equipment_increments": {"barbell": 2.5},
+        "available_equipment": {"barbell": True},
+    }
+
+    normalized = normalize_user_settings_shape("u1", raw)
+
+    assert normalized["user_id"] == "u1"
+    assert normalized["profile"]["bodyweight_kg"] == 92
+    assert normalized["preferences"]["training_types"] == {"running": True, "strength_weights": False}
+    assert normalized["preferences"]["training_days"] == {"mon": True, "wed": True}
+    assert normalized["preferences"]["weekly_target_sessions"] == 3
+    assert normalized["preferences"]["planning_mode"] == "autoplan"
+    assert normalized["equipment_increments"] == {"barbell": 2.5}
+    assert normalized["available_equipment"] == {"barbell": True}
+
+    assert "bodyweight_kg" not in normalized
+    assert "training_types" not in normalized
+    assert "training_days" not in normalized
+    assert "weekly_target_sessions" not in normalized
+    assert "planning_mode" not in normalized
+
+
+def test_normalize_user_settings_shape_is_idempotent():
+    raw = {
+        "user_id": "u1",
+        "profile": {"bodyweight_kg": 85},
+        "preferences": {
+            "training_types": {"running": False, "strength_weights": True},
+            "weekly_target_sessions": 4,
+        },
+        "available_equipment": {"dumbbell": True},
+    }
+
+    once = normalize_user_settings_shape("u1", raw)
+    twice = normalize_user_settings_shape("u1", once)
+
+    assert twice == once
+
+
+def test_json_storage_get_user_settings_migrates_flat_legacy_root_object():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        storage = JSONStorage(tmp_path)
+
+        legacy = {
+            "user_id": "u1",
+            "bodyweight_kg": 90,
+            "training_types": {"running": True, "strength_weights": True},
+            "training_days": {"tue": True, "thu": True},
+            "weekly_target_sessions": 2,
+            "planning_mode": "fixed",
+            "available_equipment": {"dumbbell": True},
+        }
+        (tmp_path / "user_settings.json").write_text(
+            json.dumps(legacy, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        result = storage.get_user_settings_for("u1")
+
+        assert result["user_id"] == "u1"
+        assert result["profile"]["bodyweight_kg"] == 90
+        assert result["preferences"]["training_types"]["running"] is True
+        assert result["preferences"]["training_days"] == {"tue": True, "thu": True}
+        assert result["preferences"]["weekly_target_sessions"] == 2
+        assert result["preferences"]["planning_mode"] == "fixed"
+        assert "bodyweight_kg" not in result
+        assert "training_types" not in result
+
+
+def test_json_storage_save_user_settings_normalizes_and_persists_under_users_map():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        storage = JSONStorage(tmp_path)
+
+        legacy_input = {
+            "bodyweight_kg": 88,
+            "training_types": {"running": False, "strength_weights": True, "bodyweight": True},
+            "weekly_target_sessions": 4,
+            "planning_mode": "autoplan",
+            "profile": {"height_cm": 182},
+        }
+
+        saved = storage.save_user_settings_for("u7", legacy_input)
+
+        assert saved["user_id"] == "u7"
+        assert saved["profile"]["bodyweight_kg"] == 88
+        assert saved["profile"]["height_cm"] == 182
+        assert saved["preferences"]["weekly_target_sessions"] == 4
+        assert saved["preferences"]["planning_mode"] == "autoplan"
+        assert saved["preferences"]["training_types"]["bodyweight"] is True
+        assert "bodyweight_kg" not in saved
+        assert "weekly_target_sessions" not in saved
+
+        persisted_raw = json.loads((tmp_path / "user_settings.json").read_text(encoding="utf-8"))
+        assert "users" in persisted_raw
+        assert "u7" in persisted_raw["users"]
+
+        persisted_user = persisted_raw["users"]["u7"]
+        assert persisted_user["profile"]["bodyweight_kg"] == 88
+        assert persisted_user["preferences"]["weekly_target_sessions"] == 4
+        assert "bodyweight_kg" not in persisted_user
+        assert "weekly_target_sessions" not in persisted_user
+
+
+def test_json_storage_save_user_settings_migrates_existing_top_level_legacy_blob_into_users_map():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        storage = JSONStorage(tmp_path)
+
+        existing_legacy = {
+            "user_id": "legacy-user",
+            "bodyweight_kg": 101,
+            "training_days": {"mon": True},
+            "weekly_target_sessions": 2,
+        }
+        (tmp_path / "user_settings.json").write_text(
+            json.dumps(existing_legacy, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        storage.save_user_settings_for(
+            "new-user",
+            {
+                "bodyweight_kg": 77,
+                "training_types": {"running": True},
+            },
+        )
+
+        persisted_raw = json.loads((tmp_path / "user_settings.json").read_text(encoding="utf-8"))
+        assert "users" in persisted_raw
+
+        legacy_user = persisted_raw["users"]["legacy-user"]
+        assert legacy_user["profile"]["bodyweight_kg"] == 101
+        assert legacy_user["preferences"]["training_days"] == {"mon": True}
+        assert legacy_user["preferences"]["weekly_target_sessions"] == 2
+
+        new_user = persisted_raw["users"]["new-user"]
+        assert new_user["profile"]["bodyweight_kg"] == 77
+        assert new_user["preferences"]["training_types"] == {"running": True}
+
+
+def test_sqlite_storage_save_and_get_user_settings_normalize_legacy_fields():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        db_path = tmp_path / "test_storage.db"
+
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            """
+            CREATE TABLE users (
+                user_id TEXT PRIMARY KEY,
+                created_at TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE user_settings (
+                user_id TEXT PRIMARY KEY,
+                equipment_increments TEXT,
+                available_equipment TEXT,
+                profile TEXT,
+                preferences TEXT,
+                updated_at TEXT
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        storage = SQLiteStorage.__new__(SQLiteStorage)
+        storage.db_path = db_path
+
+        saved = storage.save_user_settings_for(
+            "u9",
+            {
+                "bodyweight_kg": 83,
+                "training_days": {"fri": True},
+                "weekly_target_sessions": 3,
+                "available_equipment": {"barbell": True},
+            },
+        )
+
+        assert saved["profile"]["bodyweight_kg"] == 83
+        assert saved["preferences"]["training_days"] == {"fri": True}
+        assert saved["preferences"]["weekly_target_sessions"] == 3
+        assert "bodyweight_kg" not in saved
+        assert "training_days" not in saved
+
+        loaded = storage.get_user_settings_for("u9")
+        assert loaded["profile"]["bodyweight_kg"] == 83
+        assert loaded["preferences"]["training_days"] == {"fri": True}
+        assert loaded["preferences"]["weekly_target_sessions"] == 3
+        assert loaded["available_equipment"] == {"barbell": True}


### PR DESCRIPTION
## Summary

This PR adds an explicit migration path for legacy flat user settings into the current nested `profile` and `preferences` structure.

Previously, old settings could still be read through fallback behavior, but that was not a real migration path. This PR makes the upgrade path deterministic, centralized, and test-covered.

## What changed

- added `normalize_user_settings_shape(...)` in `app/backend/storage.py`
- added explicit legacy field maps for:
  - `profile`
  - `preferences`
- added `is_legacy_user_settings_payload(...)` to detect older flat settings payloads
- normalized legacy settings on both:
  - read
  - save
- applied the same normalization logic in both:
  - `JSONStorage`
  - `SQLiteStorage`
- removed the legacy flat root fallback for `bodyweight_kg` in `app/backend/app.py`
- added targeted migration tests in `tests/test_user_settings_migration.py`

## Why

The backend now expects a clearer nested settings model, especially for planning-related fields such as:

- `training_types`
- `training_days`
- `weekly_target_sessions`
- `planning_mode`

Without an explicit migration step, older user data could remain half-legacy and half-current, which makes future maintenance harder and can create inconsistent behavior across users.

This PR makes the current structure the actual source of truth instead of relying on compatibility drift.

## Behavior after this PR

Legacy root-level settings are now migrated into:

- `profile`
- `preferences`

The normalized output is:

- stable
- idempotent
- consistent across storage backends

The old flat structure is no longer kept alive through ad hoc runtime fallback for `bodyweight_kg`.

## Validation

Validated with targeted migration tests covering:

- flat legacy root settings
- already nested settings
- idempotent normalization
- JSON storage migration on read
- JSON storage migration on save
- migration of existing top-level legacy blobs into the `users` map
- SQLite normalization on save and read

Manual test result during implementation:

- `RESULT passed=6 failed=0`

## Scope

This PR does **not** redesign the user settings model.

It only makes the existing nested structure safe and explicit as the upgrade target.