### PR TITLE
Validate auto-assigned program IDs before persisting active program state

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2769,6 +2769,45 @@ def select_endurance_program(programs, user_settings, weekly_target_sessions, pr
     return None
 
 
+
+
+def is_valid_program_id_for_domain(programs, program_id, domain):
+    pid = str(program_id or "").strip()
+    dom = str(domain or "").strip().lower()
+    if not pid or dom not in {"strength", "run"}:
+        return False
+
+    allowed_kinds_by_domain = {
+        "strength": {"strength"},
+        "run": {"run", "løb", "running"},
+    }
+
+    allowed_kinds = allowed_kinds_by_domain.get(dom, set())
+
+    for program in programs or []:
+        if not isinstance(program, dict):
+            continue
+        if str(program.get("id", "")).strip() != pid:
+            continue
+        kind = str(program.get("kind", "")).strip().lower()
+        return kind in allowed_kinds
+
+    return False
+
+
+def sanitize_auto_assigned_program_ids(programs, auto_assigned):
+    raw = auto_assigned if isinstance(auto_assigned, dict) else {}
+    clean = {}
+
+    for domain in ("strength", "run"):
+        candidate_id = str(raw.get(domain, "") or "").strip()
+        if not candidate_id:
+            continue
+        if is_valid_program_id_for_domain(programs, candidate_id, domain):
+            clean[domain] = candidate_id
+
+    return clean
+
 def build_active_programs_by_domain(programs, user_settings):
     settings = user_settings if isinstance(user_settings, dict) else {}
     prefs = get_training_type_preferences(settings)
@@ -2798,25 +2837,25 @@ def ensure_initial_auto_assigned_programs(programs, user_settings):
     overrides = preferences.get("active_program_overrides", {}) if isinstance(preferences.get("active_program_overrides", {}), dict) else {}
     auto_assigned = preferences.get("auto_assigned_programs", {}) if isinstance(preferences.get("auto_assigned_programs", {}), dict) else {}
 
-    next_auto_assigned = dict(auto_assigned)
-    changed = False
+    next_auto_assigned = sanitize_auto_assigned_program_ids(programs, auto_assigned)
+    changed = next_auto_assigned != auto_assigned
 
     if (bool(prefs.get("strength_weights", True)) or bool(prefs.get("bodyweight", True))):
         override_strength = str(overrides.get("strength", "")).strip()
-        auto_strength = str(auto_assigned.get("strength", "")).strip()
+        auto_strength = str(next_auto_assigned.get("strength", "")).strip()
         if not override_strength and not auto_strength:
             selected_strength = select_strength_program(
                 programs=programs,
                 user_settings=settings,
                 weekly_target_sessions=weekly_target_sessions,
             )
-            if selected_strength:
+            if selected_strength and is_valid_program_id_for_domain(programs, selected_strength, "strength"):
                 next_auto_assigned["strength"] = selected_strength
                 changed = True
 
     if bool(prefs.get("running", True)):
         override_run = str(overrides.get("run", "")).strip()
-        auto_run = str(auto_assigned.get("run", "")).strip()
+        auto_run = str(next_auto_assigned.get("run", "")).strip()
         if not override_run and not auto_run:
             selected_run = select_endurance_program(
                 programs=programs,
@@ -2824,17 +2863,19 @@ def ensure_initial_auto_assigned_programs(programs, user_settings):
                 weekly_target_sessions=weekly_target_sessions,
                 prefs=prefs,
             )
-            if selected_run:
+            if selected_run and is_valid_program_id_for_domain(programs, selected_run, "run"):
                 next_auto_assigned["run"] = selected_run
                 changed = True
 
     if not changed:
         return settings, False
 
-    next_preferences = {
-        **preferences,
-        "auto_assigned_programs": next_auto_assigned,
-    }
+    next_preferences = dict(preferences)
+    if next_auto_assigned:
+        next_preferences["auto_assigned_programs"] = next_auto_assigned
+    else:
+        next_preferences.pop("auto_assigned_programs", None)
+
     next_settings = {
         **settings,
         "preferences": next_preferences,

--- a/tests/test_auto_assigned_program_validation.py
+++ b/tests/test_auto_assigned_program_validation.py
@@ -1,0 +1,117 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND_DIR = ROOT / "app" / "backend"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from app import (
+    ensure_initial_auto_assigned_programs,
+    is_valid_program_id_for_domain,
+    sanitize_auto_assigned_program_ids,
+)
+
+
+def make_programs():
+    return [
+        {"id": "starter_strength_2x", "kind": "strength", "supported_weekly_sessions": [2], "equipment_profiles": ["minimal_home", "dumbbell_home"]},
+        {"id": "strength_full_body_3x_beginner", "kind": "strength", "supported_weekly_sessions": [3], "equipment_profiles": ["minimal_home", "dumbbell_home"]},
+        {"id": "starter_run_2x", "kind": "run", "supported_weekly_sessions": [2], "equipment_profiles": ["minimal_home", "dumbbell_home", "gym_basic", "full_gym"]},
+        {"id": "starter_run_3x_beginner", "kind": "run", "supported_weekly_sessions": [3], "equipment_profiles": ["minimal_home", "dumbbell_home", "gym_basic", "full_gym"]},
+    ]
+
+
+def make_settings(*, weekly_target_sessions=2, running=True, strength_weights=True, bodyweight=True, auto_assigned=None, overrides=None):
+    return {
+        "available_equipment": {"dumbbell": True},
+        "preferences": {
+            "weekly_target_sessions": weekly_target_sessions,
+            "training_types": {
+                "running": running,
+                "strength_weights": strength_weights,
+                "bodyweight": bodyweight,
+                "mobility": False,
+            },
+            "auto_assigned_programs": auto_assigned if isinstance(auto_assigned, dict) else {},
+            "active_program_overrides": overrides if isinstance(overrides, dict) else {},
+        },
+    }
+
+
+def test_is_valid_program_id_for_domain_accepts_matching_program_kind():
+    programs = make_programs()
+    assert is_valid_program_id_for_domain(programs, "starter_strength_2x", "strength") is True
+    assert is_valid_program_id_for_domain(programs, "starter_run_2x", "run") is True
+
+
+def test_is_valid_program_id_for_domain_rejects_missing_or_wrong_domain():
+    programs = make_programs()
+    assert is_valid_program_id_for_domain(programs, "missing_program", "strength") is False
+    assert is_valid_program_id_for_domain(programs, "starter_run_2x", "strength") is False
+    assert is_valid_program_id_for_domain(programs, "starter_strength_2x", "run") is False
+
+
+def test_sanitize_auto_assigned_program_ids_keeps_only_valid_entries():
+    programs = make_programs()
+    cleaned = sanitize_auto_assigned_program_ids(
+        programs,
+        {
+            "strength": "starter_strength_2x",
+            "run": "missing_run_program",
+        },
+    )
+    assert cleaned == {"strength": "starter_strength_2x"}
+
+
+def test_ensure_initial_auto_assigned_programs_persists_valid_selected_ids():
+    programs = make_programs()
+    settings = make_settings(
+        weekly_target_sessions=2,
+        auto_assigned={},
+    )
+
+    next_settings, changed = ensure_initial_auto_assigned_programs(programs, settings)
+
+    assert changed is True
+    auto_assigned = next_settings["preferences"]["auto_assigned_programs"]
+    assert auto_assigned["strength"] == "starter_strength_2x"
+    assert auto_assigned["run"] == "starter_run_2x"
+
+
+def test_ensure_initial_auto_assigned_programs_removes_invalid_existing_auto_assigned_ids():
+    programs = make_programs()
+    settings = make_settings(
+        weekly_target_sessions=2,
+        auto_assigned={
+            "strength": "missing_strength_program",
+            "run": "starter_run_2x",
+        },
+    )
+
+    next_settings, changed = ensure_initial_auto_assigned_programs(programs, settings)
+
+    assert changed is True
+    auto_assigned = next_settings["preferences"]["auto_assigned_programs"]
+    assert auto_assigned["strength"] == "starter_strength_2x"
+    assert auto_assigned["run"] == "starter_run_2x"
+
+
+def test_ensure_initial_auto_assigned_programs_does_not_persist_invalid_new_selection():
+    programs = [
+        {"id": "starter_strength_2x", "kind": "strength", "supported_weekly_sessions": [2], "equipment_profiles": ["minimal_home", "dumbbell_home"]},
+    ]
+    settings = make_settings(
+        weekly_target_sessions=2,
+        running=True,
+        strength_weights=True,
+        bodyweight=True,
+        auto_assigned={},
+    )
+
+    next_settings, changed = ensure_initial_auto_assigned_programs(programs, settings)
+
+    assert changed is True
+    auto_assigned = next_settings["preferences"]["auto_assigned_programs"]
+    assert auto_assigned["strength"] == "starter_strength_2x"
+    assert "run" not in auto_assigned


### PR DESCRIPTION
## Summary

This PR adds defensive validation for auto-assigned program IDs before they are persisted into user settings.

Initial auto-assignment should not blindly trust selector output. If runtime catalog state and selector output drift apart, invalid program references must not be saved as active program state.

## What changed

- added `is_valid_program_id_for_domain(...)`
- added `sanitize_auto_assigned_program_ids(...)`
- validated selected auto-assigned program IDs before persisting them
- removed invalid existing `auto_assigned_programs` entries during initial auto-assignment normalization
- only persisted program IDs that exist in the current runtime catalog and match the expected domain
- added targeted tests for:
  - valid domain/program matches
  - invalid or cross-domain program IDs
  - sanitizing existing invalid auto-assigned state
  - persisting valid selected IDs
  - refusing to persist invalid new selections

## Why

Auto-assigned program IDs are persisted user state.

That means selector output should be treated as untrusted at the persistence boundary. If a selected ID is missing from the current catalog, saving it creates invalid state and can cause confusing fallback behavior or degraded today-plan generation later.

This PR makes that boundary explicit and defensive.

## Behavior after this PR

- existing invalid `auto_assigned_programs` entries are removed
- new auto-assigned IDs are only saved if they are valid for:
  - the current runtime catalog
  - the expected domain (`strength` or `run`)
- empty invalid auto-assigned state is not preserved unnecessarily

## Scope

This PR does **not** redesign selector logic.

It only validates selector output before it becomes persisted active program state.

## Validation

Validated with targeted tests covering:

- valid program/domain combinations
- missing program IDs
- wrong-domain program IDs
- sanitizing invalid existing auto-assigned state
- persisting valid new selections
- refusing invalid new selections

Manual validation result during implementation:

- `RESULT passed=12 failed=0`