### PR TITLE
Add backend test coverage for first auto-assigned program selection matrix

### DIFF
--- a/tests/test_first_auto_assigned_program_matrix.py
+++ b/tests/test_first_auto_assigned_program_matrix.py
@@ -265,3 +265,40 @@ if __name__ == "__main__":
     print("first auto-assigned program matrix tests passed")
 
 
+
+def test_build_active_program_status_reports_automatic_recommendation_source():
+    settings = make_user_settings(
+        training_types={"running": True, "strength_weights": True},
+        weekly_target_sessions=2,
+        available_equipment={"barbell": True, "bench": True},
+    )
+
+    status = backend_app.build_active_program_status_by_domain(PROGRAMS, settings)
+
+    assert status["strength"]["program_id"] == "starter_strength_gym_2x"
+    assert status["strength"]["selection_source"] == "automatic_recommendation"
+    assert status["run"]["program_id"] == "hybrid_run_strength_2x_beginner"
+    assert status["run"]["selection_source"] == "automatic_recommendation"
+
+
+def test_build_active_program_status_reports_accepted_recommendation_source():
+    settings = make_user_settings(
+        training_types={"running": True, "strength_weights": True},
+        weekly_target_sessions=2,
+        available_equipment={"barbell": True, "bench": True},
+        active_program_overrides={
+            "strength": "base_strength_a",
+            "run": "starter_run_2x",
+        },
+    )
+    settings["preferences"]["accepted_program_recommendations"] = {
+        "strength": "base_strength_a",
+        "run": "starter_run_2x",
+    }
+
+    status = backend_app.build_active_program_status_by_domain(PROGRAMS, settings)
+
+    assert status["strength"]["program_id"] == "base_strength_a"
+    assert status["strength"]["selection_source"] == "accepted_recommendation"
+    assert status["run"]["program_id"] == "starter_run_2x"
+    assert status["run"]["selection_source"] == "accepted_recommendation"


### PR DESCRIPTION
## Summary

This PR extends backend test coverage for the first auto-assigned program selection matrix introduced under #386.

The selector and status logic already appeared correct in manual validation, but the behavior was still missing explicit coverage for some selection-source paths. This PR locks that in without changing production logic.

## What changed

Extended `tests/test_first_auto_assigned_program_matrix.py` with explicit coverage for:

- `automatic_recommendation` selection source
- `accepted_recommendation` selection source

The existing test file already covered most of the first-program matrix, including:

- strength-only first selection cases
- run-only first selection cases
- hybrid run-side selection
- initial auto-assignment persistence
- manual override precedence
- empty training-type edge cases

This PR fills the remaining gaps in status-source coverage.

## Why

The first-program path depends on a combination of:

- training types
- weekly target sessions
- available equipment
- starting profiles
- persisted auto-assigned state
- manual overrides
- accepted recommendations

That makes it easy to regress the selection-source behavior unless it is explicitly covered by tests.

## Scope

This PR is test-only.

It does **not** change selector or persistence logic.

## Validation

Manual test run during implementation:

- `RESULT passed=18 failed=0`

## Notes

The goal here is to preserve already-correct behavior with durable test coverage, not to redesign the selection model.