### PR TITLE
Unify Python dependency definitions across root and backend requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Primary files:
 ### Backend
 Python Flask API served via Gunicorn and systemd from:
 
+Python dependencies are defined authoritatively in `app/backend/requirements.txt`.
+The top-level `requirements.txt` is only a thin convenience wrapper that references the backend file.
+
+
 `/opt/sovereign-strength-api/app.py`
 
 ### Data

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -1,2 +1,2 @@
-Flask==3.0.3
+Flask==3.1.3
 gunicorn==22.0.0

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,6 +6,8 @@ SovereignStrength is documented as a self-hosted local-first application with:
 
 - static frontend files
 - Flask API backend
+- Python dependencies are installed from `app/backend/requirements.txt`
+- The repository root `requirements.txt` is only a wrapper to that authoritative backend file
 - local JSON storage
 - Gunicorn
 - systemd

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-Flask==3.1.3
-gunicorn==21.2.0
+-r app/backend/requirements.txt


### PR DESCRIPTION
## Summary

This PR removes Python dependency drift between the repository root and backend requirements files.

The backend dependency set is now defined authoritatively in `app/backend/requirements.txt`, while the top-level `requirements.txt` is reduced to a thin wrapper that references that backend file.

## What changed

- aligned Flask and gunicorn dependency definitions
- made `app/backend/requirements.txt` the authoritative backend dependency file
- changed the repository root `requirements.txt` to:
  - `-r app/backend/requirements.txt`
- added a short explicit note in:
  - `README.md`
  - `docs/deployment.md`

## Why

Previously the repo defined conflicting Python versions across two requirements files:

- `requirements.txt`
- `app/backend/requirements.txt`

That created ambiguity around which dependency file should be used for:

- local setup
- deploy
- production runtime expectations

This PR removes that ambiguity and makes the dependency strategy explicit.

## Final dependency strategy

- `app/backend/requirements.txt` is the source of truth for backend Python dependencies
- `requirements.txt` exists only as a convenience wrapper

## Scope

This PR is a dependency/configuration cleanup.

It does **not** change product behavior or backend logic.

## Validation

Validated by confirming that:

- root requirements now reference backend requirements directly
- Flask version drift is removed
- gunicorn version drift is removed
- repository documentation now points to the correct dependency source