### PR TITLE
Harden deploy and catalog reset flow for runtime program data

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -89,11 +89,32 @@ Do not use broad `--delete` sync against `/var/www/sovereign-strength/`.
 Backend deploy should update the live backend entry point directly:
 
 - source: `app/backend/app.py`
-- target: `/opt/sovereign-strength-api/app.py`
+- target: `/opt/sovereign-strength-api/app/backend/app.py`
 
 Then restart:
 
 - `sovereign-strength-api.service`
+
+
+### Runtime catalog sync/reset
+
+Runtime catalog files must stay aligned with seed files used by selector logic.
+
+Primary operational sync path:
+- `python3 scripts/init_catalog_from_seed.py`
+
+This script:
+- copies `app/data/seed/programs.json` into `/var/www/sovereign-strength/data/programs.json`
+- copies `app/data/seed/exercises.json` into `/var/www/sovereign-strength/data/exercises.json`
+- creates timestamped backups of existing live catalog files before overwrite
+- verifies that live `programs.json` contains required selector metadata for strength programs
+
+Available admin alternative:
+- `POST /api/admin/reset-catalog`
+
+Use the script for normal server-side maintenance and deploy recovery.
+Use the admin endpoint only when an authenticated operational reset through the running app is explicitly intended.
+
 
 ### Minimum post-deploy checks
 
@@ -102,6 +123,7 @@ After deploy, verify at minimum:
 - frontend files are present in the expected live locations
 - i18n files are present under `/var/www/sovereign-strength/i18n/`
 - runtime data still exists under `/var/www/sovereign-strength/data/`
+- live `programs.json` contains selector metadata keys such as `supported_weekly_sessions` and `equipment_profiles`
 - backend service is active
 - `GET /api/health` returns healthy
 - at least one core user flow still works

--- a/scripts/init_catalog_from_seed.py
+++ b/scripts/init_catalog_from_seed.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 from pathlib import Path
+import json
 import shutil
 import sys
+from datetime import datetime
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SEED_DIR = REPO_ROOT / "app" / "data" / "seed"
@@ -12,9 +14,41 @@ FILES = {
     "programs": ("programs.json", "catalog"),
 }
 
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def verify_program_catalog_shape(path: Path) -> tuple[bool, str]:
+    try:
+        data = load_json(path)
+    except Exception as exc:
+        return False, f"Could not parse JSON: {exc}"
+
+    if not isinstance(data, list) or not data:
+        return False, "Program catalog is empty or not a list"
+
+    strength_programs = [
+        item for item in data
+        if isinstance(item, dict) and str(item.get("kind", "")).strip().lower() == "strength"
+    ]
+    if not strength_programs:
+        return False, "No strength programs found in runtime catalog"
+
+    required_keys = {"supported_weekly_sessions", "equipment_profiles"}
+    for item in strength_programs:
+        missing = [key for key in required_keys if key not in item]
+        if missing:
+            pid = str(item.get("id", "")).strip() or "<unknown>"
+            return False, f"Strength program {pid} missing required keys: {', '.join(missing)}"
+
+    return True, f"Verified {len(strength_programs)} strength programs with required metadata"
+
+
 def main() -> int:
     missing = []
-    for key, (filename, _) in FILES.items():
+    for _, (filename, _) in FILES.items():
         seed = SEED_DIR / filename
         if not seed.exists():
             missing.append(str(seed))
@@ -25,21 +59,29 @@ def main() -> int:
         return 1
 
     LIVE_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
 
     for key, (filename, kind) in FILES.items():
         seed = SEED_DIR / filename
         live = LIVE_DIR / filename
-        backup = LIVE_DIR / f"{filename}.bak.seedinit"
+        backup = LIVE_DIR / f"{filename}.bak.{timestamp}"
 
         if live.exists():
             shutil.copy2(live, backup)
             print(f"Backup: {live} -> {backup}")
 
         shutil.copy2(seed, live)
-        print(f"Init {kind}: {seed} -> {live}")
+        print(f"Sync {kind}: {seed} -> {live}")
 
-    print("Done. Catalog data initialized from seed.")
+    ok, message = verify_program_catalog_shape(LIVE_DIR / "programs.json")
+    if not ok:
+        print(f"Verification failed: {message}")
+        return 1
+
+    print(message)
+    print("Done. Runtime catalog data refreshed from seed.")
     return 0
+
 
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR hardens the deploy and catalog reset flow around runtime program data.

The root problem was not selector logic itself, but runtime catalog drift: backend code and seed catalog had been updated while live runtime `programs.json` still used an older shape. That made selector behavior degrade even though the code path itself was correct.

## What changed

### Deployment documentation
Updated `docs/deployment.md` to reflect the actual backend runtime target:

- source: `app/backend/app.py`
- target: `/opt/sovereign-strength-api/app/backend/app.py`

### Runtime catalog sync/reset flow
Expanded the documented operational flow for keeping runtime catalog files aligned with seed data.

Documented primary sync path:

- `python3 scripts/init_catalog_from_seed.py`

Documented admin alternative:

- `POST /api/admin/reset-catalog`

The deployment guide now makes clear when the script should be used versus when an authenticated admin reset endpoint is appropriate.

### Catalog sync script hardening
Improved `scripts/init_catalog_from_seed.py` so it now:

- creates timestamped backups of existing live catalog files before overwrite
- syncs seed `programs.json` and `exercises.json` into the live runtime data directory
- verifies that live `programs.json` contains selector-critical metadata for strength programs:
  - `supported_weekly_sessions`
  - `equipment_profiles`

### Post-deploy verification
Added an explicit deployment check that live `programs.json` still contains the metadata expected by selector logic.

## Why

The project depends on runtime catalog files under:

- `/var/www/sovereign-strength/data/programs.json`
- `/var/www/sovereign-strength/data/exercises.json`

If those drift from the current seed/catalog shape, selector behavior can silently degrade and fall back incorrectly. This PR reduces that risk by making the reset/sync path explicit, documented, and verifiable.

## Scope

This PR focuses on:

- deployment documentation
- runtime catalog sync/reset procedure
- post-deploy verification
- operational hardening of the existing seed-init script

It does **not** redesign selector logic.

## Validation

Validated by reviewing the updated deployment flow and confirming that:

- the documented backend runtime path matches operational reality
- catalog sync now creates timestamped backups
- runtime catalog verification checks selector-critical metadata after sync
- deployment documentation now includes a concrete, repeatable catalog refresh path