### PR TITLE
Extend strength program metadata to improve selector quality

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -70,6 +70,21 @@
     "equipment_profiles": [
       "minimal_home",
       "dumbbell_home"
+    ],
+    "training_style": "full_body_foundation",
+    "session_duration_min": 20,
+    "session_duration_max": 35,
+    "fatigue_profile": "low_to_moderate",
+    "complexity": "low",
+    "good_for_reentry": true,
+    "good_for_concurrent_running": true,
+    "program_family": "starter_strength",
+    "progression_model": "beginner_linear",
+    "tags": [
+      "beginner",
+      "home",
+      "simple",
+      "low_barrier"
     ]
   },
   {
@@ -143,6 +158,21 @@
     "equipment_profiles": [
       "gym_basic",
       "full_gym"
+    ],
+    "training_style": "full_body_base",
+    "session_duration_min": 35,
+    "session_duration_max": 50,
+    "fatigue_profile": "moderate",
+    "complexity": "moderate",
+    "good_for_reentry": false,
+    "good_for_concurrent_running": false,
+    "program_family": "base_strength",
+    "progression_model": "linear_load_then_reps",
+    "tags": [
+      "gym",
+      "barbell",
+      "base",
+      "strength_priority"
     ]
   },
   {
@@ -450,6 +480,21 @@
           }
         ]
       }
+    ],
+    "training_style": "full_body_foundation",
+    "session_duration_min": 30,
+    "session_duration_max": 45,
+    "fatigue_profile": "moderate",
+    "complexity": "low",
+    "good_for_reentry": false,
+    "good_for_concurrent_running": true,
+    "program_family": "starter_strength",
+    "progression_model": "beginner_linear",
+    "tags": [
+      "beginner",
+      "home",
+      "3x",
+      "mixed_friendly"
     ]
   },
   {
@@ -593,6 +638,21 @@
           }
         ]
       }
+    ],
+    "training_style": "full_body_foundation",
+    "session_duration_min": 30,
+    "session_duration_max": 45,
+    "fatigue_profile": "moderate",
+    "complexity": "moderate",
+    "good_for_reentry": true,
+    "good_for_concurrent_running": true,
+    "program_family": "starter_strength_gym",
+    "progression_model": "beginner_linear",
+    "tags": [
+      "beginner",
+      "gym",
+      "foundation",
+      "mixed_friendly"
     ]
   },
   {
@@ -691,6 +751,21 @@
           }
         ]
       }
+    ],
+    "training_style": "full_body_foundation",
+    "session_duration_min": 35,
+    "session_duration_max": 50,
+    "fatigue_profile": "moderate",
+    "complexity": "moderate",
+    "good_for_reentry": false,
+    "good_for_concurrent_running": true,
+    "program_family": "starter_strength_gym",
+    "progression_model": "beginner_linear",
+    "tags": [
+      "beginner",
+      "gym",
+      "3x",
+      "mixed_friendly"
     ]
   },
   {
@@ -766,6 +841,21 @@
           }
         ]
       }
+    ],
+    "training_style": "reentry_full_body",
+    "session_duration_min": 20,
+    "session_duration_max": 35,
+    "fatigue_profile": "low",
+    "complexity": "low",
+    "good_for_reentry": true,
+    "good_for_concurrent_running": true,
+    "program_family": "reentry_strength",
+    "progression_model": "reentry_conservative",
+    "tags": [
+      "reentry",
+      "low_fatigue",
+      "simple",
+      "recovery_friendly"
     ]
   },
   {
@@ -863,6 +953,21 @@
           }
         ]
       }
+    ],
+    "training_style": "full_body_base",
+    "session_duration_min": 40,
+    "session_duration_max": 55,
+    "fatigue_profile": "moderate_to_high",
+    "complexity": "moderate",
+    "good_for_reentry": false,
+    "good_for_concurrent_running": false,
+    "program_family": "base_strength_gym",
+    "progression_model": "linear_load_then_reps",
+    "tags": [
+      "gym",
+      "novice",
+      "3x",
+      "strength_priority"
     ]
   },
   {
@@ -986,6 +1091,21 @@
           }
         ]
       }
+    ],
+    "training_style": "upper_lower_split",
+    "session_duration_min": 45,
+    "session_duration_max": 60,
+    "fatigue_profile": "high",
+    "complexity": "moderate",
+    "good_for_reentry": false,
+    "good_for_concurrent_running": false,
+    "program_family": "base_strength_gym",
+    "progression_model": "linear_split_progression",
+    "tags": [
+      "gym",
+      "4x",
+      "upper_lower",
+      "hypertrophy_friendly"
     ]
   },
   {

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -30,6 +30,18 @@ Common documented fields include:
 - `equipment_profiles`
 - `days`
 
+Strength programs may also include compact selector-oriented metadata such as:
+- `training_style`
+- `session_duration_min`
+- `session_duration_max`
+- `fatigue_profile`
+- `complexity`
+- `good_for_reentry`
+- `good_for_concurrent_running`
+- `program_family`
+- `progression_model`
+- `tags`
+
 Each `days` entry typically contains:
 
 - `label`
@@ -52,6 +64,18 @@ Important clarification:
 
 The program layer is no longer only a list of day labels with exercises.
 It now also carries lightweight metadata about who a program is for, which is intended to support deterministic program selection later.
+
+This metadata should stay compact and practical.
+It is meant to improve program matching quality, not to turn the catalog into an overengineered ontology.
+
+Practical interpretation:
+- `training_style` describes the broad session structure
+- `session_duration_min` / `session_duration_max` describe realistic session demand
+- `fatigue_profile` and `complexity` provide practical fit signals
+- `good_for_reentry` and `good_for_concurrent_running` support conservative matching
+- `program_family` groups related templates
+- `progression_model` describes the intended progression pattern at a high level
+- `tags` support lightweight future filtering without making the core schema unreadable
 
 ---
 

--- a/scripts/audit_program_model.py
+++ b/scripts/audit_program_model.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+DEFAULT_DATA_PATH = Path("app/data/seed/programs.json")
+
+REQUIRED_PROGRAM_FIELDS = {
+    "id",
+    "name",
+    "name_en",
+    "kind",
+    "recommended_levels",
+    "supported_goals",
+    "supported_weekly_sessions",
+    "equipment_profiles",
+    "days",
+}
+
+REQUIRED_STRENGTH_METADATA_FIELDS = {
+    "training_style",
+    "session_duration_min",
+    "session_duration_max",
+    "fatigue_profile",
+    "complexity",
+    "good_for_reentry",
+    "good_for_concurrent_running",
+    "program_family",
+    "progression_model",
+    "tags",
+}
+
+OPTIONAL_COMMON_FIELDS = set()
+
+ALLOWED_TRAINING_STYLES = {
+    "full_body_foundation",
+    "full_body_base",
+    "reentry_full_body",
+    "upper_lower_split",
+}
+
+ALLOWED_FATIGUE_PROFILES = {
+    "low",
+    "low_to_moderate",
+    "moderate",
+    "moderate_to_high",
+    "high",
+}
+
+ALLOWED_COMPLEXITY = {
+    "low",
+    "moderate",
+    "high",
+}
+
+
+def fail(msg: str) -> None:
+    print(f"ERROR: {msg}")
+    sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate program JSON against the SovereignStrength program model contract.")
+    parser.add_argument("--input", default=str(DEFAULT_DATA_PATH), help="Path to programs JSON file")
+    args = parser.parse_args()
+
+    data_path = Path(args.input)
+    if not data_path.exists():
+        fail(f"Missing file: {data_path}")
+
+    try:
+        items = json.loads(data_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        fail(f"Could not parse JSON: {exc}")
+
+    if not isinstance(items, list):
+        fail("Program data must be a top-level list")
+
+    seen_ids: set[str] = set()
+
+    for idx, item in enumerate(items, start=1):
+        if not isinstance(item, dict):
+            fail(f"Entry #{idx} is not an object")
+
+        item_id = str(item.get("id", "")).strip() or f"<missing-id-#{idx}>"
+        missing = sorted(field for field in REQUIRED_PROGRAM_FIELDS if field not in item)
+        if missing:
+            fail(f"{item_id}: missing required fields: {', '.join(missing)}")
+
+        if item_id in seen_ids:
+            fail(f"{item_id}: duplicate id")
+        seen_ids.add(item_id)
+
+        if not isinstance(item["recommended_levels"], list) or not item["recommended_levels"]:
+            fail(f"{item_id}: recommended_levels must be a non-empty list")
+        if not isinstance(item["supported_goals"], list) or not item["supported_goals"]:
+            fail(f"{item_id}: supported_goals must be a non-empty list")
+        if not isinstance(item["supported_weekly_sessions"], list) or not item["supported_weekly_sessions"]:
+            fail(f"{item_id}: supported_weekly_sessions must be a non-empty list")
+        if not isinstance(item["equipment_profiles"], list) or not item["equipment_profiles"]:
+            fail(f"{item_id}: equipment_profiles must be a non-empty list")
+        if not isinstance(item["days"], list) or not item["days"]:
+            fail(f"{item_id}: days must be a non-empty list")
+
+        kind = str(item.get("kind", "")).strip().lower()
+        if kind == "strength":
+            missing_strength = sorted(field for field in REQUIRED_STRENGTH_METADATA_FIELDS if field not in item)
+            if missing_strength:
+                fail(f"{item_id}: missing required strength metadata fields: {', '.join(missing_strength)}")
+
+            if item["training_style"] not in ALLOWED_TRAINING_STYLES:
+                fail(f"{item_id}: invalid training_style: {item['training_style']}")
+            if item["fatigue_profile"] not in ALLOWED_FATIGUE_PROFILES:
+                fail(f"{item_id}: invalid fatigue_profile: {item['fatigue_profile']}")
+            if item["complexity"] not in ALLOWED_COMPLEXITY:
+                fail(f"{item_id}: invalid complexity: {item['complexity']}")
+            if not isinstance(item["session_duration_min"], int) or not isinstance(item["session_duration_max"], int):
+                fail(f"{item_id}: session_duration_min/max must be integers")
+            if item["session_duration_min"] <= 0 or item["session_duration_max"] < item["session_duration_min"]:
+                fail(f"{item_id}: invalid session duration range")
+            if not isinstance(item["good_for_reentry"], bool):
+                fail(f"{item_id}: good_for_reentry must be boolean")
+            if not isinstance(item["good_for_concurrent_running"], bool):
+                fail(f"{item_id}: good_for_concurrent_running must be boolean")
+            if not isinstance(item["program_family"], str) or not item["program_family"].strip():
+                fail(f"{item_id}: program_family must be a non-empty string")
+            if not isinstance(item["progression_model"], str) or not item["progression_model"].strip():
+                fail(f"{item_id}: progression_model must be a non-empty string")
+            if not isinstance(item["tags"], list) or not item["tags"] or not all(isinstance(x, str) and x.strip() for x in item["tags"]):
+                fail(f"{item_id}: tags must be a non-empty list of strings")
+
+    print(f"OK: validated {len(items)} program entries against the program model contract")
+    print(f"Source: {data_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR extends the strength program seed metadata so future selector logic can match programs based on practical fit, not only broad tags such as weekly sessions and equipment profile.

The goal is to improve selector quality without turning program metadata into an overengineered ontology.

## What changed

### Strength program metadata
Added compact selector-oriented metadata to all strength program definitions in `app/data/seed/programs.json`:

- `training_style`
- `session_duration_min`
- `session_duration_max`
- `fatigue_profile`
- `complexity`
- `good_for_reentry`
- `good_for_concurrent_running`
- `program_family`
- `progression_model`
- `tags`

These fields were added across the current strength catalog:

- `starter_strength_2x`
- `base_strength_a`
- `strength_full_body_3x_beginner`
- `starter_strength_gym_2x`
- `starter_strength_gym_3x`
- `reentry_strength_2x`
- `base_strength_gym_3x`
- `base_strength_gym_4x`

### Program model audit
Added a new audit script:

- `scripts/audit_program_model.py`

This validates:

- required core program fields
- required strength metadata fields
- allowed enum-like values for compact metadata
- basic duration and type checks
- non-empty tag lists
- duplicate program IDs

### Documentation
Extended `docs/data-model.md` to document the new lightweight strength program metadata and explain its intended purpose and limits.

## Why

The previous strength program metadata was enough for coarse matching, but too limited for better real-world program selection when multiple programs technically fit.

The added fields create room for future selector improvements based on practical suitability signals such as:

- time demand
- fatigue cost
- complexity
- re-entry suitability
- concurrent running suitability
- family/progression grouping

## Scope

This PR updates:

- seed program metadata
- program audit/validation
- data-model documentation

It does **not** redesign selector logic yet.

## Validation

Validated by running:

- `python3 scripts/audit_program_model.py`

Which confirmed:

- `OK: validated 17 program entries against the program model contract`

## Notes

The metadata was intentionally kept compact and practical.

This is meant to support better matching later, not to turn `programs.json` into a taxonomy hobby project.