### PR TITLE
Update strength program recommendation logic to use richer catalog metadata

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2587,16 +2587,53 @@ def _program_recommended_levels(program):
     return [str(x).strip().lower() for x in levels if str(x).strip()]
 
 
-def _sort_strength_candidates(candidates, target_level, preferred_ids):
+def _sort_strength_candidates(candidates, target_level, preferred_ids, strength_starting_profile=None, running_enabled=False):
     preferred_order = {pid: idx for idx, pid in enumerate(preferred_ids)}
     target = str(target_level or "").strip().lower()
+    starting_profile = str(strength_starting_profile or "").strip().lower()
+
+    def metadata_penalty(program):
+        penalty = 0
+
+        good_for_reentry = bool(program.get("good_for_reentry", False))
+        good_for_concurrent_running = bool(program.get("good_for_concurrent_running", False))
+        training_style = str(program.get("training_style", "")).strip().lower()
+        program_family = str(program.get("program_family", "")).strip().lower()
+        fatigue_profile = str(program.get("fatigue_profile", "")).strip().lower()
+        complexity = str(program.get("complexity", "")).strip().lower()
+        sessions = program.get("supported_weekly_sessions", []) or []
+
+        if starting_profile == "conservative_beginner":
+            penalty += 0 if good_for_reentry else 50
+
+        if running_enabled:
+            penalty += 0 if good_for_concurrent_running else 20
+
+        if target == "beginner":
+            if training_style == "full_body_foundation":
+                penalty -= 8
+            if complexity == "low":
+                penalty -= 6
+            elif complexity == "moderate":
+                penalty -= 2
+
+        if target == "novice":
+            if program_family in {"base_strength", "base_strength_gym"}:
+                penalty -= 8
+            if training_style == "upper_lower_split" and 4 in sessions:
+                penalty -= 10
+            if fatigue_profile in {"moderate", "moderate_to_high"}:
+                penalty -= 2
+
+        return penalty
 
     def key(program):
         pid = str(program.get("id", "")).strip()
         levels = _program_recommended_levels(program)
         level_match = 0 if target and target in levels else 1
         preferred_rank = preferred_order.get(pid, 999)
-        return (level_match, preferred_rank, pid)
+        meta_penalty = metadata_penalty(program)
+        return (level_match, preferred_rank, meta_penalty, pid)
 
     return sorted(candidates, key=key)
 
@@ -2673,7 +2710,14 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
         if target_sessions == 2:
             preferred_ids.append("starter_strength_2x")
 
-    sorted_candidates = _sort_strength_candidates(candidates, target_level, preferred_ids)
+    running_enabled = bool(prefs.get("running", False))
+    sorted_candidates = _sort_strength_candidates(
+        candidates,
+        target_level,
+        preferred_ids,
+        strength_starting_profile=strength_starting_profile,
+        running_enabled=running_enabled,
+    )
     if sorted_candidates:
         return str(sorted_candidates[0].get("id"))
 

--- a/tests/test_first_auto_assigned_program_matrix.py
+++ b/tests/test_first_auto_assigned_program_matrix.py
@@ -302,3 +302,32 @@ def test_build_active_program_status_reports_accepted_recommendation_source():
     assert status["strength"]["selection_source"] == "accepted_recommendation"
     assert status["run"]["program_id"] == "starter_run_2x"
     assert status["run"]["selection_source"] == "accepted_recommendation"
+
+def test_select_strength_program_conservative_beginner_prefers_reentry_program():
+    settings = make_user_settings(
+        training_types={"strength_weights": True},
+        weekly_target_sessions=2,
+        available_equipment={"bodyweight": True, "dumbbell": True},
+        strength_starting_profile="conservative_beginner",
+    )
+    assert backend_app.select_strength_program(PROGRAMS, settings, 2) == "reentry_strength_2x"
+
+
+def test_select_strength_program_beginner_hybrid_gym_prefers_concurrent_running_friendly_option():
+    settings = make_user_settings(
+        training_types={"running": True, "strength_weights": True},
+        weekly_target_sessions=2,
+        available_equipment={"barbell": True, "bench": True},
+        strength_starting_profile="beginner",
+    )
+    assert backend_app.select_strength_program(PROGRAMS, settings, 2) == "starter_strength_gym_2x"
+
+
+def test_select_strength_program_novice_gym_3x_prefers_base_path():
+    settings = make_user_settings(
+        training_types={"strength_weights": True},
+        weekly_target_sessions=3,
+        available_equipment={"barbell": True, "bench": True},
+        strength_starting_profile="novice",
+    )
+    assert backend_app.select_strength_program(PROGRAMS, settings, 3) == "base_strength_gym_3x"


### PR DESCRIPTION
## Summary

This PR updates the strength program recommendation logic so it can use the richer catalog metadata introduced in the strength program seed definitions.

The goal is to improve recommendation quality while preserving the product's core principle: recommendations should become more appropriate, not more mysterious.

## What changed

### Metadata-aware strength candidate sorting
Updated `_sort_strength_candidates(...)` to consider compact strength metadata in addition to the existing deterministic inputs.

The selector now still respects:

- level match
- explicit preferred IDs
- deterministic fallback order

But it also applies metadata-aware ranking signals for:

- `good_for_reentry`
- `good_for_concurrent_running`
- `training_style`
- `program_family`
- `fatigue_profile`
- `complexity`

### Selector integration
Updated `select_strength_program(...)` to pass the currently available selector signals into metadata-aware candidate sorting:

- `strength_starting_profile`
- whether running is enabled alongside strength

## Why

After the catalog metadata expansion, the selector was still mainly matching on:

- weekly sessions
- equipment profile
- level
- hardcoded preferred IDs

That meant the richer metadata existed, but recommendation logic was not actually using it yet.

This PR closes that gap with a minimal, explainable extension rather than a full selector rewrite.

## Behavior preserved

The existing simple cases remain stable.

The selector still behaves deterministically and keeps its existing structure:

- override and auto-assigned precedence remain unchanged
- supported sessions and equipment filtering remain unchanged
- explicit preferred IDs still influence ordering
- fallback behavior remains deterministic

## New behavior covered by tests

Added coverage for:

- conservative beginner profile preferring `reentry_strength_2x`
- beginner hybrid gym case preferring a concurrent-running-friendly strength option
- novice gym 3x case preferring the base progression path

Manual validation run during implementation:

- `RESULT passed=21 failed=0`

## Scope

This PR updates strength recommendation logic only.

It does **not** introduce new opaque recommendation behavior, and it does **not** attempt to use signals that the selector does not currently have access to, such as direct time-budget or fatigue inputs.

## Notes

This is intentionally a small step.

The recommendation logic is now more informed by catalog metadata, but still remains readable, deterministic, and test-covered.