### PR TITLE
Expand strength catalog coverage for novice home base paths

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2705,6 +2705,11 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
                 preferred_ids.append("starter_strength_gym_2x")
 
     if equipment_profile in ("minimal_home", "dumbbell_home"):
+        if target_level == "novice" and equipment_profile == "dumbbell_home":
+            if target_sessions >= 3:
+                preferred_ids.append("base_strength_home_3x")
+            if target_sessions == 2:
+                preferred_ids.append("base_strength_home_2x")
         if target_sessions >= 3:
             preferred_ids.append("strength_full_body_3x_beginner")
         if target_sessions == 2:

--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -1308,5 +1308,206 @@
     "equipment_profiles": [
       "hybrid_home"
     ]
+  },
+  {
+    "id": "base_strength_home_2x",
+    "name": "Base home (2 days/week)",
+    "name_en": "Base home (2 days/week)",
+    "kind": "strength",
+    "recommended_levels": [
+      "novice"
+    ],
+    "supported_goals": [
+      "strength",
+      "general_health",
+      "mixed"
+    ],
+    "supported_weekly_sessions": [
+      2
+    ],
+    "equipment_profiles": [
+      "dumbbell_home"
+    ],
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "incline_push_ups",
+            "sets": 3,
+            "reps": "8-12"
+          },
+          {
+            "exercise_id": "dumbbell_row",
+            "sets": 3,
+            "reps": "8/side"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 3,
+            "reps": "30-40 sec"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "romanian_deadlift",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "overhead_press",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "lunges",
+            "sets": 3,
+            "reps": "8/leg"
+          },
+          {
+            "exercise_id": "dead_bug",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      }
+    ],
+    "training_style": "full_body_base",
+    "session_duration_min": 30,
+    "session_duration_max": 45,
+    "fatigue_profile": "moderate",
+    "complexity": "moderate",
+    "good_for_reentry": false,
+    "good_for_concurrent_running": true,
+    "program_family": "base_strength_home",
+    "progression_model": "linear_load_then_reps",
+    "tags": [
+      "home",
+      "dumbbell",
+      "novice",
+      "base",
+      "mixed_friendly"
+    ]
+  },
+  {
+    "id": "base_strength_home_3x",
+    "name": "Base home (3 days/week)",
+    "name_en": "Base home (3 days/week)",
+    "kind": "strength",
+    "recommended_levels": [
+      "novice"
+    ],
+    "supported_goals": [
+      "strength",
+      "general_health",
+      "mixed"
+    ],
+    "supported_weekly_sessions": [
+      3
+    ],
+    "equipment_profiles": [
+      "dumbbell_home"
+    ],
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "incline_push_ups",
+            "sets": 3,
+            "reps": "8-12"
+          },
+          {
+            "exercise_id": "dumbbell_row",
+            "sets": 3,
+            "reps": "8/side"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 3,
+            "reps": "30-40 sec"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "romanian_deadlift",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "overhead_press",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "lunges",
+            "sets": 3,
+            "reps": "8/leg"
+          },
+          {
+            "exercise_id": "dead_bug",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      },
+      {
+        "label": "Day C",
+        "exercises": [
+          {
+            "exercise_id": "glute_bridge",
+            "sets": 3,
+            "reps": "10-12"
+          },
+          {
+            "exercise_id": "push_ups",
+            "sets": 3,
+            "reps": "6-10"
+          },
+          {
+            "exercise_id": "dumbbell_row",
+            "sets": 3,
+            "reps": "10/side"
+          },
+          {
+            "exercise_id": "bird_dog",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      }
+    ],
+    "training_style": "full_body_base",
+    "session_duration_min": 35,
+    "session_duration_max": 50,
+    "fatigue_profile": "moderate_to_high",
+    "complexity": "moderate",
+    "good_for_reentry": false,
+    "good_for_concurrent_running": true,
+    "program_family": "base_strength_home",
+    "progression_model": "linear_load_then_reps",
+    "tags": [
+      "home",
+      "dumbbell",
+      "novice",
+      "3x",
+      "mixed_friendly"
+    ]
   }
 ]

--- a/tests/test_first_auto_assigned_program_matrix.py
+++ b/tests/test_first_auto_assigned_program_matrix.py
@@ -331,3 +331,22 @@ def test_select_strength_program_novice_gym_3x_prefers_base_path():
         strength_starting_profile="novice",
     )
     assert backend_app.select_strength_program(PROGRAMS, settings, 3) == "base_strength_gym_3x"
+
+def test_select_strength_program_novice_home_2x_prefers_base_home_path():
+    settings = make_user_settings(
+        training_types={"strength_weights": True},
+        weekly_target_sessions=2,
+        available_equipment={"bodyweight": True, "dumbbell": True},
+        strength_starting_profile="novice",
+    )
+    assert backend_app.select_strength_program(PROGRAMS, settings, 2) == "base_strength_home_2x"
+
+
+def test_select_strength_program_novice_home_3x_prefers_base_home_path():
+    settings = make_user_settings(
+        training_types={"strength_weights": True},
+        weekly_target_sessions=3,
+        available_equipment={"bodyweight": True, "dumbbell": True},
+        strength_starting_profile="novice",
+    )
+    assert backend_app.select_strength_program(PROGRAMS, settings, 3) == "base_strength_home_3x"


### PR DESCRIPTION
## Summary

This PR takes a focused first step on the broader strength catalog coverage issue by expanding support for novice home users.

The current selector and metadata model had become good enough to distinguish more practical matches, but the strength catalog still lacked credible base-path recommendations for novice users training at home with dumbbells. In practice, those users risked being pushed toward beginner or re-entry paths because no real novice home base programs existed.

## What changed

### New strength programs
Added two new home-based novice strength programs:

- `base_strength_home_2x`
- `base_strength_home_3x`

These programs provide a real base progression path for novice dumbbell-home users.

### Selector preference update
Updated the strength selector so novice users with `dumbbell_home` equipment now prefer the new home base paths when weekly frequency matches:

- 2x/week → `base_strength_home_2x`
- 3x/week → `base_strength_home_3x`

The update is intentionally small and stays within the existing deterministic selector structure.

### Test coverage
Extended backend selector tests with explicit coverage for:

- novice home 2x preferring `base_strength_home_2x`
- novice home 3x preferring `base_strength_home_3x`

Manual validation result during implementation:

- `RESULT passed=23 failed=0`

## Why

This is a catalog coverage problem, not just a selector problem.

Before this change, novice home users had a weak recommendation space:

- 2x/week was effectively covered only through re-entry or beginner-adjacent paths
- 3x/week had no proper novice base home path

That limited recommendation credibility even when selector logic itself was otherwise working.

This PR closes that gap for a user profile the product can already identify today.

## Scope

This PR is a focused catalog expansion step within the broader coverage-matrix direction.

It does **not** attempt to complete the full strength catalog epic.
It adds the smallest new set of programs that materially improves real-world recommendation quality for novice home users.

## Notes

This is a coverage-based expansion, not a catalog explosion.

The aim is to improve recommendation quality with a compact, maintainable addition that fits the current selector and metadata model.