### PR TITLE
Lock beginner gym 3x selector coverage for existing foundation programs

### DIFF
--- a/tests/test_first_auto_assigned_program_matrix.py
+++ b/tests/test_first_auto_assigned_program_matrix.py
@@ -369,3 +369,13 @@ def test_select_strength_program_novice_hybrid_home_2x_prefers_minimalist_path()
         strength_starting_profile="novice",
     )
     assert backend_app.select_strength_program(PROGRAMS, settings, 2) == "minimalist_strength_2x"
+
+def test_select_strength_program_beginner_gym_3x():
+    settings = make_user_settings(
+        training_types={"strength_weights": True},
+        weekly_target_sessions=3,
+        available_equipment={"barbell": True, "bench": True},
+        strength_starting_profile="beginner",
+    )
+    assert backend_app.select_strength_program(PROGRAMS, settings, 3) == "starter_strength_gym_3x"
+


### PR DESCRIPTION
## Summary

This PR adds explicit regression coverage for the beginner gym 3x selector case and closes the remaining validation gap around issue #399.

The catalog and selector logic for beginner gym foundation programs were already present. The missing piece was a direct test confirming that a beginner gym user with 3 weekly sessions is matched to the intended foundation path.

## What changed

Added one backend selector test:

- `test_select_strength_program_beginner_gym_3x`

This verifies that a beginner gym user with:

- gym equipment
- 3 weekly sessions
- beginner starting profile

is matched to:

- `starter_strength_gym_3x`

## Why

Issue #399 described a need for beginner-focused gym foundation programs for:

- 2x/week
- 3x/week

On inspection, both program definitions already existed:

- `starter_strength_gym_2x`
- `starter_strength_gym_3x`

And selector logic already referenced them.

So the real remaining gap was not missing implementation, but missing explicit regression coverage for the 3x case.

## Validation

Manual validation run during implementation:

- `RESULT passed=26 failed=0`

## Scope

This PR is test-only.

It does **not** change selector logic or program catalog content.
It confirms that the existing beginner gym 3x foundation path is already implemented and selectable.