### PR TITLE
Add intermediate home 3x strength program to complete home catalog progression

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -1592,5 +1592,118 @@
       "mixed_friendly",
       "adherence_friendly"
     ]
+  },
+  {
+    "id": "intermediate_home_3x",
+    "name": "Intermediate home (3 days/week)",
+    "name_en": "Intermediate home (3 days/week)",
+    "kind": "strength",
+    "recommended_levels": [
+      "intermediate"
+    ],
+    "supported_goals": [
+      "strength",
+      "hypertrophy",
+      "mixed"
+    ],
+    "supported_weekly_sessions": [
+      3
+    ],
+    "equipment_profiles": [
+      "dumbbell_home"
+    ],
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 4,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "push_ups",
+            "sets": 4,
+            "reps": "8-12"
+          },
+          {
+            "exercise_id": "dumbbell_row",
+            "sets": 4,
+            "reps": "8/side"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 3,
+            "reps": "40 sec"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "romanian_deadlift",
+            "sets": 4,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "overhead_press",
+            "sets": 4,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "lunges",
+            "sets": 4,
+            "reps": "8/leg"
+          },
+          {
+            "exercise_id": "dead_bug",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      },
+      {
+        "label": "Day C",
+        "exercises": [
+          {
+            "exercise_id": "glute_bridge",
+            "sets": 4,
+            "reps": "10-12"
+          },
+          {
+            "exercise_id": "push_ups",
+            "sets": 4,
+            "reps": "10-15"
+          },
+          {
+            "exercise_id": "dumbbell_row",
+            "sets": 4,
+            "reps": "10/side"
+          },
+          {
+            "exercise_id": "bird_dog",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      }
+    ],
+    "training_style": "full_body_base",
+    "session_duration_min": 40,
+    "session_duration_max": 55,
+    "fatigue_profile": "moderate_to_high",
+    "complexity": "moderate",
+    "good_for_reentry": false,
+    "good_for_concurrent_running": false,
+    "program_family": "intermediate_strength_home",
+    "progression_model": "linear_load_then_reps",
+    "tags": [
+      "home",
+      "dumbbell",
+      "intermediate",
+      "3x",
+      "hypertrophy_friendly"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

This PR adds a dedicated intermediate home strength program for 3 weekly sessions.

The home strength catalog already covered:

- beginner home paths
- novice home 2x
- novice home 3x
- minimalist low-friction home use cases

But it still lacked a true intermediate dumbbell-home progression path.

## What changed

Added one new strength program to `app/data/seed/programs.json`:

- `intermediate_home_3x`

### Program characteristics
- `equipment_profiles`: `dumbbell_home`
- `recommended_levels`: `intermediate`
- `supported_goals`: `strength`, `hypertrophy`, `mixed`
- `supported_weekly_sessions`: `3`
- `training_style`: `full_body_base`
- `fatigue_profile`: `moderate_to_high`
- `complexity`: `moderate`
- `program_family`: `intermediate_strength_home`

## Why

Home users are not only onboarding users.

The catalog already had stronger coverage for beginners and novice home users, but intermediate dumbbell-home users still lacked a dedicated 3x program. This meant home progression paths were still incomplete beyond novice level.

This PR closes that catalog gap.

## Validation

Validated with:

- `python3 scripts/audit_program_model.py`

Result:

- `OK: validated 21 program entries against the program model contract`

## Scope

This PR is a catalog expansion step.

It does **not** yet claim that first-program selector logic can actively choose this program, because current selector-level input still only distinguishes:

- `conservative_beginner`
- `beginner`
- `novice`

So this PR completes the catalog side of the gap, while selector-level support for intermediate first-program matching should be handled separately.