### PR TITLE
Add explicit training goal preference for goal-aware program matching

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -1183,6 +1183,16 @@ def get_weekly_target_sessions(user_settings):
     return val
 
 
+def get_training_goal(user_settings):
+    settings = user_settings if isinstance(user_settings, dict) else {}
+    preferences = settings.get("preferences", {})
+    if not isinstance(preferences, dict):
+        preferences = {}
+
+    goal = str(preferences.get("training_goal", "general_health") or "general_health").strip().lower()
+    if goal not in {"general_health", "strength", "fat_loss", "hypertrophy", "mixed", "performance"}:
+        return "general_health"
+    return goal
 
 
 def get_local_load_targets_for_exercise(exercise_id, exercises=None):
@@ -2672,6 +2682,7 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
     if strength_starting_profile not in ("conservative_beginner", "beginner", "novice"):
         strength_starting_profile = "beginner"
 
+    training_goal = get_training_goal(settings)
     target_level = "novice" if strength_starting_profile == "novice" else "beginner"
 
     candidates = []
@@ -2705,6 +2716,8 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
                 preferred_ids.append("starter_strength_gym_2x")
 
     if equipment_profile in ("minimal_home", "dumbbell_home"):
+        if training_goal == "fat_loss" and target_sessions == 2:
+            preferred_ids.append("minimalist_strength_2x")
         if bool(prefs.get("running", False)) and target_sessions == 2:
             preferred_ids.append("minimalist_strength_2x")
         if target_level == "novice" and equipment_profile == "dumbbell_home":
@@ -5296,10 +5309,15 @@ def post_user_settings():
     if run_starting_profile not in {"conservative_beginner", "beginner", "novice"}:
         run_starting_profile = "beginner"
 
+    training_goal = str(clean_preferences.get("training_goal", "general_health") or "general_health").strip().lower()
+    if training_goal not in {"general_health", "strength", "fat_loss", "hypertrophy", "mixed", "performance"}:
+        training_goal = "general_health"
+
     clean_preferences = {
         **clean_preferences,
         "strength_starting_profile": strength_starting_profile,
         "run_starting_profile": run_starting_profile,
+        "training_goal": training_goal,
     }
 
     allowed_regions = {"ankle_calf", "knee", "hip", "low_back", "shoulder", "elbow", "wrist"}

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2805,6 +2805,7 @@ function populateEquipmentEditor(){
   const weeklyTargetSessions = Number(preferences.weekly_target_sessions || 3) || 3;
   const strengthStartingProfile = String(preferences.strength_starting_profile || "beginner").trim() || "beginner";
   const runStartingProfile = String(preferences.run_starting_profile || "beginner").trim() || "beginner";
+  const trainingGoal = String(preferences.training_goal || "general_health").trim() || "general_health";
   const available = settings.available_equipment && typeof settings.available_equipment === "object"
     ? settings.available_equipment
     : {};
@@ -2841,6 +2842,7 @@ function populateEquipmentEditor(){
   setVal("weekly_target_sessions", weeklyTargetSessions);
   setVal("strength_starting_profile", strengthStartingProfile);
   setVal("run_starting_profile", runStartingProfile);
+  setVal("training_goal", trainingGoal);
 
   setVal("eq_barbell_enabled", available.barbell === false ? "false" : "true");
   setVal("eq_dumbbell_enabled", available.dumbbell === false ? "false" : "true");
@@ -3022,7 +3024,8 @@ async function handleEquipmentSettingsSubmit(ev){
       },
       weekly_target_sessions: Number(document.getElementById("weekly_target_sessions")?.value || 3),
       strength_starting_profile: String(document.getElementById("strength_starting_profile")?.value || "beginner").trim() || "beginner",
-      run_starting_profile: String(document.getElementById("run_starting_profile")?.value || "beginner").trim() || "beginner"
+      run_starting_profile: String(document.getElementById("run_starting_profile")?.value || "beginner").trim() || "beginner",
+      training_goal: String(document.getElementById("training_goal")?.value || "general_health").trim() || "general_health"
     },
     available_equipment: {
       barbell: readBool("eq_barbell_enabled"),

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -771,5 +771,13 @@
   "review.saved_summary.failure_markers_count": "Failure-markører: {count}",
   "review.summary_hold_times_label": "Tid pr. sæt",
   "review.summary_total_hold_time_label": "Samlet holdtid",
-  "progress_flag.exercise_failure": "{exercise} ikke fuldført"
+  "progress_flag.exercise_failure": "{exercise} ikke fuldført",
+  "profile.training_goal": "Primært træningsmål",
+  "profile.training_goal_general_health": "Generel sundhed",
+  "profile.training_goal_strength": "Styrke",
+  "profile.training_goal_fat_loss": "Fedttab med muskelbevarelse",
+  "profile.training_goal_hypertrophy": "Muskelopbygning",
+  "profile.training_goal_mixed": "Blandet mål",
+  "profile.training_goal_performance": "Performance",
+  "profile.training_goal_help": "Bruges til at vælge mere relevante programmer, når kataloget understøtter målet."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -755,5 +755,13 @@
   "review.saved_summary.failure_markers_count": "Failure markers: {count}",
   "review.summary_hold_times_label": "Time per set",
   "review.summary_total_hold_time_label": "Total hold time",
-  "progress_flag.exercise_failure": "{exercise} not completed"
+  "progress_flag.exercise_failure": "{exercise} not completed",
+  "profile.training_goal": "Primary training goal",
+  "profile.training_goal_general_health": "General health",
+  "profile.training_goal_strength": "Strength",
+  "profile.training_goal_fat_loss": "Fat loss with muscle retention",
+  "profile.training_goal_hypertrophy": "Muscle gain",
+  "profile.training_goal_mixed": "Mixed goal",
+  "profile.training_goal_performance": "Performance",
+  "profile.training_goal_help": "Used to choose more relevant programs when the catalog supports the goal."
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -547,6 +547,19 @@
             </label>
 
             <label>
+              <span data-i18n="profile.training_goal">Primært træningsmål</span>
+              <select id="training_goal" name="training_goal">
+                <option value="general_health" selected data-i18n="profile.training_goal_general_health">Generel sundhed</option>
+                <option value="strength" data-i18n="profile.training_goal_strength">Styrke</option>
+                <option value="fat_loss" data-i18n="profile.training_goal_fat_loss">Fedttab med muskelbevarelse</option>
+                <option value="hypertrophy" data-i18n="profile.training_goal_hypertrophy">Muskelopbygning</option>
+                <option value="mixed" data-i18n="profile.training_goal_mixed">Blandet mål</option>
+                <option value="performance" data-i18n="profile.training_goal_performance">Performance</option>
+              </select>
+              <div class="small" style="margin-top:6px; margin-bottom:14px" data-i18n="profile.training_goal_help">Bruges til at vælge mere relevante programmer, når kataloget understøtter målet.</div>
+            </label>
+
+            <label>
               <span data-i18n="profile.run_starting_profile">Løbe-startniveau</span>
               <select id="run_starting_profile" name="run_starting_profile">
                 <option value="conservative_beginner" data-i18n="profile.run_starting_profile_conservative">Forsigtig / genopstart</option>

--- a/tests/test_first_auto_assigned_program_matrix.py
+++ b/tests/test_first_auto_assigned_program_matrix.py
@@ -379,3 +379,14 @@ def test_select_strength_program_beginner_gym_3x():
     )
     assert backend_app.select_strength_program(PROGRAMS, settings, 3) == "starter_strength_gym_3x"
 
+
+
+def test_select_strength_program_fat_loss_home_2x_prefers_minimalist_path():
+    settings = make_user_settings(
+        training_types={"running": False, "strength_weights": True},
+        weekly_target_sessions=2,
+        available_equipment={"bodyweight": True, "dumbbell": True},
+        strength_starting_profile="beginner",
+    )
+    settings["preferences"]["training_goal"] = "fat_loss"
+    assert backend_app.select_strength_program(PROGRAMS, settings, 2) == "minimalist_strength_2x"

--- a/tests/test_user_settings_goal_normalization.py
+++ b/tests/test_user_settings_goal_normalization.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND_DIR = ROOT / "app" / "backend"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from app import get_training_goal
+
+
+def test_get_training_goal_returns_valid_explicit_goal():
+    settings = {"preferences": {"training_goal": "fat_loss"}}
+    assert get_training_goal(settings) == "fat_loss"
+
+
+def test_get_training_goal_falls_back_for_invalid_value():
+    settings = {"preferences": {"training_goal": "banana_mode"}}
+    assert get_training_goal(settings) == "general_health"
+
+
+def test_get_training_goal_defaults_when_missing():
+    settings = {"preferences": {}}
+    assert get_training_goal(settings) == "general_health"


### PR DESCRIPTION
## Summary

This PR adds an explicit `training_goal` preference to the user settings flow so program selection can begin using a stable goal signal.

## What changed

### Frontend
Added a new profile/onboarding field:

- `training_goal`

Supported values:
- `general_health`
- `strength`
- `fat_loss`
- `hypertrophy`
- `mixed`
- `performance`

The field is now:
- shown in the settings UI
- loaded from saved settings
- persisted through the existing user-settings submit flow

### Backend
Extended `/api/user-settings` normalization to accept and sanitize:

- `preferences.training_goal`

Invalid or missing values fall back to:

- `general_health`

Added helper:

- `get_training_goal(user_settings)`

### Selector
Added the first narrow goal-aware selector behavior:

- for `fat_loss`
- home/dumbbell-home style setup
- 2 sessions/week

the strength selector can now prefer:

- `minimalist_strength_2x`

This is intentionally scoped and conservative.

### Tests
Added coverage for:
- training-goal normalization
- fat-loss home 2x selector behavior

## Why

Goal-specific catalog work cannot be matched reliably unless the app has an explicit user goal signal flowing through profile/settings and selector inputs.

This PR establishes that signal without over-expanding selector complexity.

## Validation

Validated with:
- `node --check app/frontend/app.js`
- backend compile checks
- targeted regression test run

Result:
- `RESULT passed=30 failed=0`

## Scope

This PR does **not** make all selectors fully goal-aware.

It introduces the goal signal end-to-end and applies it in one controlled selector path so future goal-aware catalog work can build on a stable foundation.