### PR TITLE
Improve fat-loss strength matching for existing catalog paths

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2598,7 +2598,10 @@ def _program_recommended_levels(program):
 
 
 def _sort_strength_candidates(candidates, target_level, preferred_ids, strength_starting_profile=None, running_enabled=False):
-    preferred_order = {pid: idx for idx, pid in enumerate(preferred_ids)}
+    preferred_order = {}
+    for idx, pid in enumerate(preferred_ids):
+        if pid not in preferred_order:
+            preferred_order[pid] = idx
     target = str(target_level or "").strip().lower()
     starting_profile = str(strength_starting_profile or "").strip().lower()
 
@@ -2702,6 +2705,12 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
         preferred_ids.append("reentry_strength_2x")
 
     if equipment_profile in ("gym_basic", "full_gym"):
+        if training_goal == "fat_loss" and target_level != "novice":
+            if target_sessions >= 3:
+                preferred_ids.append("starter_strength_gym_3x")
+            if target_sessions == 2:
+                preferred_ids.append("starter_strength_gym_2x")
+
         if target_level == "novice":
             if target_sessions >= 4:
                 preferred_ids.append("base_strength_gym_4x")
@@ -2716,8 +2725,19 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
                 preferred_ids.append("starter_strength_gym_2x")
 
     if equipment_profile in ("minimal_home", "dumbbell_home"):
-        if training_goal == "fat_loss" and target_sessions == 2:
-            preferred_ids.append("minimalist_strength_2x")
+        if training_goal == "fat_loss":
+            if target_level == "novice" and equipment_profile == "dumbbell_home":
+                if target_sessions >= 3:
+                    preferred_ids.append("base_strength_home_3x")
+                if target_sessions == 2:
+                    preferred_ids.append("base_strength_home_2x")
+                    preferred_ids.append("minimalist_strength_2x")
+            else:
+                if target_sessions == 2:
+                    preferred_ids.append("minimalist_strength_2x")
+                if target_sessions >= 3:
+                    preferred_ids.append("strength_full_body_3x_beginner")
+
         if bool(prefs.get("running", False)) and target_sessions == 2:
             preferred_ids.append("minimalist_strength_2x")
         if target_level == "novice" and equipment_profile == "dumbbell_home":

--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -62,7 +62,8 @@
     "supported_goals": [
       "strength",
       "general_health",
-      "mixed"
+      "mixed",
+      "fat_loss"
     ],
     "supported_weekly_sessions": [
       2
@@ -395,7 +396,8 @@
     "supported_goals": [
       "strength",
       "general_health",
-      "mixed"
+      "mixed",
+      "fat_loss"
     ],
     "supported_weekly_sessions": [
       3
@@ -578,7 +580,8 @@
     "supported_goals": [
       "strength",
       "general_health",
-      "mixed"
+      "mixed",
+      "fat_loss"
     ],
     "supported_weekly_sessions": [
       2
@@ -666,7 +669,8 @@
     "supported_goals": [
       "strength",
       "general_health",
-      "mixed"
+      "mixed",
+      "fat_loss"
     ],
     "supported_weekly_sessions": [
       3
@@ -1320,7 +1324,8 @@
     "supported_goals": [
       "strength",
       "general_health",
-      "mixed"
+      "mixed",
+      "fat_loss"
     ],
     "supported_weekly_sessions": [
       2
@@ -1408,7 +1413,8 @@
     "supported_goals": [
       "strength",
       "general_health",
-      "mixed"
+      "mixed",
+      "fat_loss"
     ],
     "supported_weekly_sessions": [
       3
@@ -1523,7 +1529,8 @@
     "supported_goals": [
       "strength",
       "general_health",
-      "mixed"
+      "mixed",
+      "fat_loss"
     ],
     "supported_weekly_sessions": [
       2

--- a/tests/test_first_auto_assigned_program_matrix.py
+++ b/tests/test_first_auto_assigned_program_matrix.py
@@ -390,3 +390,58 @@ def test_select_strength_program_fat_loss_home_2x_prefers_minimalist_path():
     )
     settings["preferences"]["training_goal"] = "fat_loss"
     assert backend_app.select_strength_program(PROGRAMS, settings, 2) == "minimalist_strength_2x"
+
+
+def test_select_strength_program_fat_loss_beginner_gym_2x_prefers_starter_gym_path():
+    settings = make_user_settings(
+        training_types={"running": False, "strength_weights": True},
+        weekly_target_sessions=2,
+        available_equipment={"barbell": True, "bench": True},
+        strength_starting_profile="beginner",
+    )
+    settings["preferences"]["training_goal"] = "fat_loss"
+    assert backend_app.select_strength_program(PROGRAMS, settings, 2) == "starter_strength_gym_2x"
+
+
+def test_select_strength_program_fat_loss_beginner_gym_3x_prefers_starter_gym_path():
+    settings = make_user_settings(
+        training_types={"running": False, "strength_weights": True},
+        weekly_target_sessions=3,
+        available_equipment={"barbell": True, "bench": True},
+        strength_starting_profile="beginner",
+    )
+    settings["preferences"]["training_goal"] = "fat_loss"
+    assert backend_app.select_strength_program(PROGRAMS, settings, 3) == "starter_strength_gym_3x"
+
+
+def test_select_strength_program_fat_loss_beginner_home_3x_prefers_foundation_path():
+    settings = make_user_settings(
+        training_types={"running": False, "strength_weights": True},
+        weekly_target_sessions=3,
+        available_equipment={"bodyweight": True, "dumbbell": True},
+        strength_starting_profile="beginner",
+    )
+    settings["preferences"]["training_goal"] = "fat_loss"
+    assert backend_app.select_strength_program(PROGRAMS, settings, 3) == "strength_full_body_3x_beginner"
+
+
+def test_select_strength_program_fat_loss_novice_home_2x_prefers_base_home_path():
+    settings = make_user_settings(
+        training_types={"running": False, "strength_weights": True},
+        weekly_target_sessions=2,
+        available_equipment={"bodyweight": True, "dumbbell": True},
+        strength_starting_profile="novice",
+    )
+    settings["preferences"]["training_goal"] = "fat_loss"
+    assert backend_app.select_strength_program(PROGRAMS, settings, 2) == "base_strength_home_2x"
+
+
+def test_select_strength_program_fat_loss_novice_home_3x_prefers_base_home_path():
+    settings = make_user_settings(
+        training_types={"running": False, "strength_weights": True},
+        weekly_target_sessions=3,
+        available_equipment={"bodyweight": True, "dumbbell": True},
+        strength_starting_profile="novice",
+    )
+    settings["preferences"]["training_goal"] = "fat_loss"
+    assert backend_app.select_strength_program(PROGRAMS, settings, 3) == "base_strength_home_3x"


### PR DESCRIPTION
## Summary

This PR improves strength-program matching for users with the `fat_loss` training goal by using existing catalog paths more deliberately instead of introducing a parallel fat-loss-only strength catalog.

## What changed

### Catalog metadata
Added `fat_loss` to `supported_goals` for strength programs that are realistic fits for fat-loss / body-recomposition contexts:

- `starter_strength_2x`
- `strength_full_body_3x_beginner`
- `starter_strength_gym_2x`
- `starter_strength_gym_3x`
- `base_strength_home_2x`
- `base_strength_home_3x`
- `minimalist_strength_2x`

### Selector behavior
Updated `select_strength_program(...)` so fat-loss matching behaves more intentionally:

- beginner gym 2x prefers `starter_strength_gym_2x`
- beginner gym 3x prefers `starter_strength_gym_3x`
- beginner home 3x prefers `strength_full_body_3x_beginner`
- novice dumbbell-home 2x prefers `base_strength_home_2x`
- novice dumbbell-home 3x prefers `base_strength_home_3x`
- low-friction 2x home fat-loss cases can still prefer `minimalist_strength_2x`

### Sorting fix
Fixed `_sort_strength_candidates(...)` so the **first** preferred program occurrence wins.

Previously, duplicate IDs in `preferred_ids` could let later entries overwrite earlier priority, which produced incorrect selector outcomes.

### Tests
Extended selector matrix coverage for fat-loss strength cases, including:

- beginner gym 2x
- beginner gym 3x
- beginner home 3x
- novice home 2x
- novice home 3x

## Why

Fat-loss strength matching did not need a separate duplicate catalog yet.

The existing catalog already contains realistic low-friction and base-path strength options for fat-loss contexts, but the selector was not using them explicitly enough.

This PR improves matching quality while keeping the catalog compact and deterministic.

## Validation

Validated with:
- backend compile check
- targeted selector regression tests

Result:
- `RESULT passed=35 failed=0`

## Scope

This PR does **not** introduce new dedicated fat-loss strength templates.

It improves matching for the current catalog and makes future goal-aware expansion safer if new templates are later needed.