### PR TITLE
Add intermediate gym 4x strength paths and selector support

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2682,11 +2682,16 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
     equipment_profile = infer_equipment_profile(settings)
     target_sessions = int(weekly_target_sessions or 2)
     strength_starting_profile = str(preferences.get("strength_starting_profile", "beginner") or "beginner").strip()
-    if strength_starting_profile not in ("conservative_beginner", "beginner", "novice"):
+    if strength_starting_profile not in ("conservative_beginner", "beginner", "novice", "intermediate"):
         strength_starting_profile = "beginner"
 
     training_goal = get_training_goal(settings)
-    target_level = "novice" if strength_starting_profile == "novice" else "beginner"
+    if strength_starting_profile == "intermediate":
+        target_level = "intermediate"
+    elif strength_starting_profile == "novice":
+        target_level = "novice"
+    else:
+        target_level = "beginner"
 
     candidates = []
     for program in programs:
@@ -2705,7 +2710,16 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
         preferred_ids.append("reentry_strength_2x")
 
     if equipment_profile in ("gym_basic", "full_gym"):
-        if training_goal == "fat_loss" and target_level != "novice":
+        if target_level == "intermediate":
+            if target_sessions >= 4:
+                if training_goal in ("hypertrophy", "fat_loss"):
+                    preferred_ids.append("intermediate_hypertrophy_4x")
+                if training_goal in ("strength", "mixed", "general_health"):
+                    preferred_ids.append("intermediate_upper_lower_4x")
+            if target_sessions == 2:
+                preferred_ids.append("base_strength_a")
+
+        if training_goal == "fat_loss" and target_level == "beginner":
             if target_sessions >= 3:
                 preferred_ids.append("starter_strength_gym_3x")
             if target_sessions == 2:
@@ -2718,7 +2732,7 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
                 preferred_ids.append("base_strength_gym_3x")
             if target_sessions == 2:
                 preferred_ids.append("base_strength_a")
-        else:
+        elif target_level == "beginner":
             if target_sessions >= 3:
                 preferred_ids.append("starter_strength_gym_3x")
             if target_sessions == 2:
@@ -5322,7 +5336,7 @@ def post_user_settings():
         clean_preferences = {k: v for k, v in clean_preferences.items() if k != "auto_assigned_programs"}
 
     strength_starting_profile = str(clean_preferences.get("strength_starting_profile", "beginner") or "beginner").strip()
-    if strength_starting_profile not in {"conservative_beginner", "beginner", "novice"}:
+    if strength_starting_profile not in {"conservative_beginner", "beginner", "novice", "intermediate"}:
         strength_starting_profile = "beginner"
 
     run_starting_profile = str(clean_preferences.get("run_starting_profile", "beginner") or "beginner").strip()

--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -1712,5 +1712,283 @@
       "3x",
       "hypertrophy_friendly"
     ]
+  },
+  {
+    "id": "intermediate_upper_lower_4x",
+    "name": "Intermediate upper/lower (4 days/week)",
+    "name_en": "Intermediate upper/lower (4 days/week)",
+    "kind": "strength",
+    "recommended_levels": [
+      "intermediate"
+    ],
+    "supported_goals": [
+      "strength",
+      "hypertrophy",
+      "mixed"
+    ],
+    "supported_weekly_sessions": [
+      4
+    ],
+    "equipment_profiles": [
+      "gym_basic",
+      "full_gym"
+    ],
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "bench_press",
+            "sets": 4,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "barbell_row",
+            "sets": 4,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "overhead_press",
+            "sets": 3,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 3,
+            "reps": "40 sec"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 4,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "romanian_deadlift",
+            "sets": 4,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "lunges",
+            "sets": 3,
+            "reps": "8/leg"
+          },
+          {
+            "exercise_id": "dead_bug",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      },
+      {
+        "label": "Day C",
+        "exercises": [
+          {
+            "exercise_id": "bench_press",
+            "sets": 4,
+            "reps": "8-10"
+          },
+          {
+            "exercise_id": "dumbbell_row",
+            "sets": 4,
+            "reps": "10/side"
+          },
+          {
+            "exercise_id": "push_ups",
+            "sets": 3,
+            "reps": "8-12"
+          },
+          {
+            "exercise_id": "bird_dog",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      },
+      {
+        "label": "Day D",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 4,
+            "reps": "8-10"
+          },
+          {
+            "exercise_id": "split_squat",
+            "sets": 3,
+            "reps": "8/leg"
+          },
+          {
+            "exercise_id": "glute_bridge",
+            "sets": 3,
+            "reps": "10-12"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 3,
+            "reps": "40 sec"
+          }
+        ]
+      }
+    ],
+    "training_style": "upper_lower_split",
+    "session_duration_min": 45,
+    "session_duration_max": 60,
+    "fatigue_profile": "moderate_to_high",
+    "complexity": "moderate",
+    "good_for_reentry": false,
+    "good_for_concurrent_running": false,
+    "program_family": "intermediate_strength_gym",
+    "progression_model": "intermediate_upper_lower_linear",
+    "tags": [
+      "intermediate",
+      "gym",
+      "4x",
+      "upper_lower",
+      "strength_hypertrophy"
+    ]
+  },
+  {
+    "id": "intermediate_hypertrophy_4x",
+    "name": "Intermediate hypertrophy (4 days/week)",
+    "name_en": "Intermediate hypertrophy (4 days/week)",
+    "kind": "strength",
+    "recommended_levels": [
+      "intermediate"
+    ],
+    "supported_goals": [
+      "hypertrophy",
+      "fat_loss",
+      "mixed"
+    ],
+    "supported_weekly_sessions": [
+      4
+    ],
+    "equipment_profiles": [
+      "gym_basic",
+      "full_gym"
+    ],
+    "days": [
+      {
+        "label": "Day A",
+        "exercises": [
+          {
+            "exercise_id": "bench_press",
+            "sets": 4,
+            "reps": "8-10"
+          },
+          {
+            "exercise_id": "barbell_row",
+            "sets": 4,
+            "reps": "8-10"
+          },
+          {
+            "exercise_id": "overhead_press",
+            "sets": 3,
+            "reps": "8-10"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 3,
+            "reps": "40 sec"
+          }
+        ]
+      },
+      {
+        "label": "Day B",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 4,
+            "reps": "8-10"
+          },
+          {
+            "exercise_id": "romanian_deadlift",
+            "sets": 4,
+            "reps": "8-10"
+          },
+          {
+            "exercise_id": "lunges",
+            "sets": 3,
+            "reps": "10/leg"
+          },
+          {
+            "exercise_id": "dead_bug",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      },
+      {
+        "label": "Day C",
+        "exercises": [
+          {
+            "exercise_id": "bench_press",
+            "sets": 4,
+            "reps": "10-12"
+          },
+          {
+            "exercise_id": "dumbbell_row",
+            "sets": 4,
+            "reps": "10/side"
+          },
+          {
+            "exercise_id": "push_ups",
+            "sets": 3,
+            "reps": "10-15"
+          },
+          {
+            "exercise_id": "bird_dog",
+            "sets": 3,
+            "reps": "8/side"
+          }
+        ]
+      },
+      {
+        "label": "Day D",
+        "exercises": [
+          {
+            "exercise_id": "squat",
+            "sets": 4,
+            "reps": "10-12"
+          },
+          {
+            "exercise_id": "split_squat",
+            "sets": 3,
+            "reps": "10/leg"
+          },
+          {
+            "exercise_id": "glute_bridge",
+            "sets": 3,
+            "reps": "12-15"
+          },
+          {
+            "exercise_id": "plank",
+            "sets": 3,
+            "reps": "40 sec"
+          }
+        ]
+      }
+    ],
+    "training_style": "upper_lower_split",
+    "session_duration_min": 50,
+    "session_duration_max": 65,
+    "fatigue_profile": "high",
+    "complexity": "moderate",
+    "good_for_reentry": false,
+    "good_for_concurrent_running": false,
+    "program_family": "intermediate_hypertrophy_gym",
+    "progression_model": "intermediate_hypertrophy_volume",
+    "tags": [
+      "intermediate",
+      "gym",
+      "4x",
+      "upper_lower",
+      "hypertrophy"
+    ]
   }
 ]

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2322,6 +2322,7 @@ function renderProfileEquipmentCard(){
       const value = String(preferences.strength_starting_profile || "beginner").trim() || "beginner";
       if (value === "conservative_beginner") return tr("profile.strength_starting_profile_conservative");
       if (value === "novice") return tr("profile.strength_starting_profile_novice");
+      if (value === "intermediate") return tr("profile.strength_starting_profile_intermediate");
       return tr("profile.strength_starting_profile_beginner");
     }
     const value = String(preferences.run_starting_profile || "beginner").trim() || "beginner";

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -720,7 +720,7 @@
   "profile.active_program_selected_automatically": "Valgt automatisk",
   "profile.active_program_auto_assigned": "Valgt automatisk fra start",
   "profile.strength_starting_profile_help": "Vælg hvor roligt eller ambitiøst styrkedelen skal starte. Det påvirker dit første programvalg.",
-  "profile.strength_starting_profile_help_levels": "Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig træning · Let øvet = mere vane og lidt højere belastningstolerance.",
+  "profile.strength_starting_profile_help_levels": "Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig træning · Let øvet = mere vane og lidt højere belastningstolerance · Øvet = solid træningsvane og behov for mere krævende programmatch.",
   "profile.run_starting_profile_help": "Vælg hvor roligt eller ambitiøst løbedelen skal starte. Det påvirker dit første programvalg.",
   "profile.run_starting_profile_help_levels": "Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig løbetræning · Let øvet = mere vane og lidt højere kapacitet.",
   "onboarding.first_run.section.planning_level_hint": "Dit startniveau hjælper appen med at vælge, hvor forsigtig eller ambitiøs den første programanbefaling skal være.",
@@ -779,5 +779,6 @@
   "profile.training_goal_hypertrophy": "Muskelopbygning",
   "profile.training_goal_mixed": "Blandet mål",
   "profile.training_goal_performance": "Performance",
-  "profile.training_goal_help": "Bruges til at vælge mere relevante programmer, når kataloget understøtter målet."
+  "profile.training_goal_help": "Bruges til at vælge mere relevante programmer, når kataloget understøtter målet.",
+  "profile.strength_starting_profile_intermediate": "Øvet"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -704,7 +704,7 @@
   "profile.active_program_selected_automatically": "Chosen automatically",
   "profile.active_program_auto_assigned": "Auto-assigned initially",
   "profile.strength_starting_profile_help": "Choose how gently or ambitiously the strength side should start. This affects your first program choice.",
-  "profile.strength_starting_profile_help_levels": "Conservative / re-entry = start gently or return after a break · Beginner = new or only a little recent training · Novice = more habit and slightly higher load tolerance.",
+  "profile.strength_starting_profile_help_levels": "Conservative / re-entry = calm restart or return after a break · Beginner = new or only recently training · Novice = more habit and somewhat higher load tolerance · Intermediate = solid training habit and need for more demanding program matching.",
   "profile.run_starting_profile_help": "Choose how gently or ambitiously the running side should start. This affects your first program choice.",
   "profile.run_starting_profile_help_levels": "Conservative / re-entry = start gently or return after a break · Beginner = new or only a little recent running · Novice = more habit and slightly higher capacity.",
   "onboarding.first_run.section.planning_level_hint": "Your starting level helps the app choose how conservative or ambitious the first program recommendation should be.",
@@ -763,5 +763,6 @@
   "profile.training_goal_hypertrophy": "Muscle gain",
   "profile.training_goal_mixed": "Mixed goal",
   "profile.training_goal_performance": "Performance",
-  "profile.training_goal_help": "Used to choose more relevant programs when the catalog supports the goal."
+  "profile.training_goal_help": "Used to choose more relevant programs when the catalog supports the goal.",
+  "profile.strength_starting_profile_intermediate": "Intermediate"
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -541,9 +541,10 @@
                 <option value="conservative_beginner" data-i18n="profile.strength_starting_profile_conservative">Forsigtig / genopstart</option>
                 <option value="beginner" selected data-i18n="profile.strength_starting_profile_beginner">Begynder</option>
                 <option value="novice" data-i18n="profile.strength_starting_profile_novice">Let øvet</option>
+                <option value="intermediate" data-i18n="profile.strength_starting_profile_intermediate">Øvet</option>
               </select>
               <div class="small" style="margin-top:6px" data-i18n="profile.strength_starting_profile_help">Vælg hvor roligt eller ambitiøst styrkedelen skal starte. Det påvirker dit første programvalg.</div>
-              <div class="small" style="margin-top:6px; margin-bottom:14px" data-i18n="profile.strength_starting_profile_help_levels">Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig træning · Let øvet = mere vane og lidt højere belastningstolerance.</div>
+              <div class="small" style="margin-top:6px; margin-bottom:14px" data-i18n="profile.strength_starting_profile_help_levels">Forsigtig / genopstart = rolig opstart eller tilbage efter pause · Begynder = ny eller lidt nylig træning · Let øvet = mere vane og lidt højere belastningstolerance · Øvet = solid træningsvane og behov for mere krævende programmatch.</div>
             </label>
 
             <label>

--- a/tests/test_first_auto_assigned_program_matrix.py
+++ b/tests/test_first_auto_assigned_program_matrix.py
@@ -445,3 +445,47 @@ def test_select_strength_program_fat_loss_novice_home_3x_prefers_base_home_path(
     )
     settings["preferences"]["training_goal"] = "fat_loss"
     assert backend_app.select_strength_program(PROGRAMS, settings, 3) == "base_strength_home_3x"
+
+
+def test_select_strength_program_intermediate_gym_4x_strength_prefers_upper_lower_path():
+    settings = make_user_settings(
+        training_types={"running": False, "strength_weights": True},
+        weekly_target_sessions=4,
+        available_equipment={"barbell": True, "bench": True},
+        strength_starting_profile="intermediate",
+    )
+    settings["preferences"]["training_goal"] = "strength"
+    assert backend_app.select_strength_program(PROGRAMS, settings, 4) == "intermediate_upper_lower_4x"
+
+
+def test_select_strength_program_intermediate_gym_4x_mixed_prefers_upper_lower_path():
+    settings = make_user_settings(
+        training_types={"running": False, "strength_weights": True},
+        weekly_target_sessions=4,
+        available_equipment={"barbell": True, "bench": True},
+        strength_starting_profile="intermediate",
+    )
+    settings["preferences"]["training_goal"] = "mixed"
+    assert backend_app.select_strength_program(PROGRAMS, settings, 4) == "intermediate_upper_lower_4x"
+
+
+def test_select_strength_program_intermediate_gym_4x_hypertrophy_prefers_hypertrophy_path():
+    settings = make_user_settings(
+        training_types={"running": False, "strength_weights": True},
+        weekly_target_sessions=4,
+        available_equipment={"barbell": True, "bench": True},
+        strength_starting_profile="intermediate",
+    )
+    settings["preferences"]["training_goal"] = "hypertrophy"
+    assert backend_app.select_strength_program(PROGRAMS, settings, 4) == "intermediate_hypertrophy_4x"
+
+
+def test_select_strength_program_intermediate_gym_4x_fat_loss_prefers_hypertrophy_path():
+    settings = make_user_settings(
+        training_types={"running": False, "strength_weights": True},
+        weekly_target_sessions=4,
+        available_equipment={"barbell": True, "bench": True},
+        strength_starting_profile="intermediate",
+    )
+    settings["preferences"]["training_goal"] = "fat_loss"
+    assert backend_app.select_strength_program(PROGRAMS, settings, 4) == "intermediate_hypertrophy_4x"


### PR DESCRIPTION
## Summary

This PR adds explicit intermediate gym-based 4x strength paths and updates selector logic so those programs can actually be chosen.

## What changed

### Catalog
Added two new strength programs:

- `intermediate_upper_lower_4x`
- `intermediate_hypertrophy_4x`

These provide explicit intermediate-level gym paths for:
- `strength`
- `hypertrophy`
- `mixed`
- selected `fat_loss` contexts

### Backend selector
Updated strength selector handling so:

- `strength_starting_profile` now accepts `intermediate`
- `intermediate + gym + 4x + hypertrophy/fat_loss` prefers `intermediate_hypertrophy_4x`
- `intermediate + gym + 4x + strength/mixed/general_health` prefers `intermediate_upper_lower_4x`

### Frontend
Added `intermediate` as a visible strength starting profile option in the profile/settings UI and updated display labels and helper text.

### Tests
Extended selector coverage with explicit tests for:

- intermediate gym 4x + strength
- intermediate gym 4x + mixed
- intermediate gym 4x + hypertrophy
- intermediate gym 4x + fat_loss

## Why

The catalog had become strong enough to support more goal-aware program matching, but it still lacked realistic intermediate gym 4x paths.

This PR closes that gap without adding unnecessary complexity to the selector model.

## Validation

Validated with:
- program model audit
- backend compile checks
- frontend i18n JSON validation
- selector regression tests

Result:
- `RESULT passed=39 failed=0`

## Scope

This PR focuses on intermediate gym 4x coverage and selector support.
It does not redesign the broader progression system.