### PR TITLE
Add starter capacity profile normalization because first-plan matching needs a stable onboarding signal

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -5343,6 +5343,10 @@ def post_user_settings():
     if run_starting_profile not in {"conservative_beginner", "beginner", "novice"}:
         run_starting_profile = "beginner"
 
+    starter_capacity_profile = str(clean_preferences.get("starter_capacity_profile", "general_beginner") or "general_beginner").strip().lower()
+    if starter_capacity_profile not in {"very_low_capacity", "low_capacity", "general_beginner", "loaded_beginner"}:
+        starter_capacity_profile = "general_beginner"
+
     training_goal = str(clean_preferences.get("training_goal", "general_health") or "general_health").strip().lower()
     if training_goal not in {"general_health", "strength", "fat_loss", "hypertrophy", "mixed", "performance"}:
         training_goal = "general_health"
@@ -5351,6 +5355,7 @@ def post_user_settings():
         **clean_preferences,
         "strength_starting_profile": strength_starting_profile,
         "run_starting_profile": run_starting_profile,
+        "starter_capacity_profile": starter_capacity_profile,
         "training_goal": training_goal,
     }
 

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2804,6 +2804,7 @@ function populateEquipmentEditor(){
     ? preferences.training_days
     : {};
   const weeklyTargetSessions = Number(preferences.weekly_target_sessions || 3) || 3;
+  const starterCapacityProfile = String(preferences.starter_capacity_profile || "general_beginner").trim() || "general_beginner";
   const strengthStartingProfile = String(preferences.strength_starting_profile || "beginner").trim() || "beginner";
   const runStartingProfile = String(preferences.run_starting_profile || "beginner").trim() || "beginner";
   const trainingGoal = String(preferences.training_goal || "general_health").trim() || "general_health";
@@ -2841,6 +2842,7 @@ function populateEquipmentEditor(){
   setChecked("day_sat", trainingDays.sat !== false);
   setChecked("day_sun", trainingDays.sun !== false);
   setVal("weekly_target_sessions", weeklyTargetSessions);
+  setVal("starter_capacity_profile", starterCapacityProfile);
   setVal("strength_starting_profile", strengthStartingProfile);
   setVal("run_starting_profile", runStartingProfile);
   setVal("training_goal", trainingGoal);
@@ -3024,6 +3026,7 @@ async function handleEquipmentSettingsSubmit(ev){
         sun: readChecked("day_sun"),
       },
       weekly_target_sessions: Number(document.getElementById("weekly_target_sessions")?.value || 3),
+      starter_capacity_profile: String(document.getElementById("starter_capacity_profile")?.value || "general_beginner").trim() || "general_beginner",
       strength_starting_profile: String(document.getElementById("strength_starting_profile")?.value || "beginner").trim() || "beginner",
       run_starting_profile: String(document.getElementById("run_starting_profile")?.value || "beginner").trim() || "beginner",
       training_goal: String(document.getElementById("training_goal")?.value || "general_health").trim() || "general_health"

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -780,5 +780,12 @@
   "profile.training_goal_mixed": "Blandet mål",
   "profile.training_goal_performance": "Performance",
   "profile.training_goal_help": "Bruges til at vælge mere relevante programmer, når kataloget understøtter målet.",
-  "profile.strength_starting_profile_intermediate": "Øvet"
+  "profile.strength_starting_profile_intermediate": "Øvet",
+  "profile.starter_capacity_profile": "Startkapacitet",
+  "profile.starter_capacity_profile_very_low": "Meget lav kapacitet",
+  "profile.starter_capacity_profile_low": "Lav kapacitet",
+  "profile.starter_capacity_profile_general": "Almindelig begynder",
+  "profile.starter_capacity_profile_loaded": "Robust begynder",
+  "profile.starter_capacity_profile_help": "Vælg hvor let eller robust din samlede opstartskapacitet er lige nu. Det bruges som et tidligt planlægningssignal.",
+  "profile.starter_capacity_profile_help_levels": "Meget lav kapacitet = meget rolig opstart med lav tærskel · Lav kapacitet = forsigtig opstart med enkel belastning · Almindelig begynder = normal begynderopstart · Robust begynder = ny, men klar til en mere direkte start."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -764,5 +764,12 @@
   "profile.training_goal_mixed": "Mixed goal",
   "profile.training_goal_performance": "Performance",
   "profile.training_goal_help": "Used to choose more relevant programs when the catalog supports the goal.",
-  "profile.strength_starting_profile_intermediate": "Intermediate"
+  "profile.strength_starting_profile_intermediate": "Intermediate",
+  "profile.starter_capacity_profile": "Starter capacity",
+  "profile.starter_capacity_profile_very_low": "Very low capacity",
+  "profile.starter_capacity_profile_low": "Low capacity",
+  "profile.starter_capacity_profile_general": "General beginner",
+  "profile.starter_capacity_profile_loaded": "Loaded beginner",
+  "profile.starter_capacity_profile_help": "Choose how light or robust your overall starting capacity is right now. This is used as an early planning signal.",
+  "profile.starter_capacity_profile_help_levels": "Very low capacity = very gentle start with a low threshold · Low capacity = cautious start with simple loading · General beginner = normal beginner starting point · Loaded beginner = new, but ready for a more direct start."
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -536,6 +536,18 @@
             </label>
 
             <label>
+              <span data-i18n="profile.starter_capacity_profile">Startkapacitet</span>
+              <select id="starter_capacity_profile" name="starter_capacity_profile">
+                <option value="very_low_capacity" data-i18n="profile.starter_capacity_profile_very_low">Meget lav kapacitet</option>
+                <option value="low_capacity" data-i18n="profile.starter_capacity_profile_low">Lav kapacitet</option>
+                <option value="general_beginner" selected data-i18n="profile.starter_capacity_profile_general">Almindelig begynder</option>
+                <option value="loaded_beginner" data-i18n="profile.starter_capacity_profile_loaded">Robust begynder</option>
+              </select>
+              <div class="small" style="margin-top:6px" data-i18n="profile.starter_capacity_profile_help">Vælg hvor let eller robust din samlede opstartskapacitet er lige nu. Det bruges som et tidligt planlægningssignal.</div>
+              <div class="small" style="margin-top:6px; margin-bottom:14px" data-i18n="profile.starter_capacity_profile_help_levels">Meget lav kapacitet = meget rolig opstart med lav tærskel · Lav kapacitet = forsigtig opstart med enkel belastning · Almindelig begynder = normal begynderopstart · Robust begynder = ny, men klar til en mere direkte start.</div>
+            </label>
+
+            <label>
               <span data-i18n="profile.strength_starting_profile">Styrke-startniveau</span>
               <select id="strength_starting_profile" name="strength_starting_profile">
                 <option value="conservative_beginner" data-i18n="profile.strength_starting_profile_conservative">Forsigtig / genopstart</option>

--- a/tests/test_starter_capacity_profile_normalization.py
+++ b/tests/test_starter_capacity_profile_normalization.py
@@ -1,0 +1,91 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND_DIR = ROOT / "app" / "backend"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+import app as app_module
+
+
+def _make_client(monkeypatch):
+    monkeypatch.setattr(
+        app_module,
+        "require_auth_user",
+        lambda: ({"user_id": "u1"}, None),
+    )
+
+    saved_items = []
+
+    def fake_get_user_settings_for(user_id):
+        return {
+            "user_id": user_id,
+            "profile": {},
+            "preferences": {},
+            "available_equipment": {},
+            "equipment_increments": {},
+            "local_protection_holds": {},
+        }
+
+    def fake_save_user_settings_for(user_id, item):
+        saved = {
+            **item,
+            "user_id": user_id,
+        }
+        saved_items.append(saved)
+        return saved
+
+    monkeypatch.setattr(app_module, "get_user_settings_for", fake_get_user_settings_for)
+    monkeypatch.setattr(app_module, "save_user_settings_for", fake_save_user_settings_for)
+
+    return app_module.app.test_client(), saved_items
+
+
+def test_starter_capacity_profile_defaults_when_missing(monkeypatch):
+    client, saved_items = _make_client(monkeypatch)
+
+    response = client.post(
+        "/api/user-settings",
+        json={
+            "preferences": {},
+        },
+    )
+
+    assert response.status_code == 200
+    assert saved_items
+    assert saved_items[-1]["preferences"]["starter_capacity_profile"] == "general_beginner"
+
+
+def test_starter_capacity_profile_preserves_valid_value(monkeypatch):
+    client, saved_items = _make_client(monkeypatch)
+
+    response = client.post(
+        "/api/user-settings",
+        json={
+            "preferences": {
+                "starter_capacity_profile": "low_capacity",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert saved_items
+    assert saved_items[-1]["preferences"]["starter_capacity_profile"] == "low_capacity"
+
+
+def test_starter_capacity_profile_falls_back_for_invalid_value(monkeypatch):
+    client, saved_items = _make_client(monkeypatch)
+
+    response = client.post(
+        "/api/user-settings",
+        json={
+            "preferences": {
+                "starter_capacity_profile": "banana_mode",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert saved_items
+    assert saved_items[-1]["preferences"]["starter_capacity_profile"] == "general_beginner"


### PR DESCRIPTION
## Summary

This PR introduces a new internal `starter_capacity_profile` preference field and normalizes it in user settings.

The purpose is to establish a deterministic onboarding-based signal that later recommendation logic can use across first-plan matching, without changing recommendation behavior in this PR.

## What changed

### Backend
- added normalization for `preferences.starter_capacity_profile` in `POST /api/user-settings`
- allowed values:
  - `very_low_capacity`
  - `low_capacity`
  - `general_beginner`
  - `loaded_beginner`
- invalid or missing values now fall back to:
  - `general_beginner`

### Frontend
- added `starter_capacity_profile` to settings load/save flow
- added a minimal profile/setup select field in the equipment/settings editor
- added Danish and English i18n labels and help text

### Tests
- added backend endpoint tests covering:
  - missing value → default fallback
  - valid value → preserved
  - invalid value → normalized to safe default

## Why this stays separate

This PR only introduces the persistence and normalization layer.

It does **not** yet change first strength, running, or recovery recommendations.

That behavior will be implemented in follow-up issues so the system remains easy to reason about and each change can be validated independently.

## Validation

Validated with:

- `python3 -m py_compile app/backend/app.py`
- `node --check app/frontend/app.js`
- `python3 -m pytest -q tests/test_user_settings_goal_normalization.py tests/test_user_settings_migration.py tests/test_starter_capacity_profile_normalization.py`

Result:
- `12 passed`

## Scope note

This PR is intentionally small and foundational.

It adds a stable onboarding signal now, so later recommendation work can use it without mixing persistence changes and selection behavior into one larger change.