### PR TITLE
Title: Use starter capacity profile in first strength recommendations because early onboarding should produce more realistic entry paths

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2685,6 +2685,10 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
     if strength_starting_profile not in ("conservative_beginner", "beginner", "novice", "intermediate"):
         strength_starting_profile = "beginner"
 
+    starter_capacity_profile = str(preferences.get("starter_capacity_profile", "general_beginner") or "general_beginner").strip().lower()
+    if starter_capacity_profile not in ("very_low_capacity", "low_capacity", "general_beginner", "loaded_beginner"):
+        starter_capacity_profile = "general_beginner"
+
     training_goal = get_training_goal(settings)
     if strength_starting_profile == "intermediate":
         target_level = "intermediate"
@@ -2705,6 +2709,19 @@ def select_strength_program(programs, user_settings, weekly_target_sessions):
             candidates.append(program)
 
     preferred_ids = []
+
+    if starter_capacity_profile == "very_low_capacity":
+        if target_sessions == 2:
+            preferred_ids.append("reentry_strength_2x")
+        elif equipment_profile in ("minimal_home", "dumbbell_home"):
+            preferred_ids.append("strength_full_body_3x_beginner")
+        else:
+            preferred_ids.append("starter_strength_gym_3x")
+    elif starter_capacity_profile == "low_capacity":
+        if equipment_profile in ("minimal_home", "dumbbell_home") and target_sessions == 2:
+            preferred_ids.append("minimalist_strength_2x")
+        elif target_sessions == 2:
+            preferred_ids.append("reentry_strength_2x")
 
     if strength_starting_profile == "conservative_beginner":
         preferred_ids.append("reentry_strength_2x")

--- a/tests/test_first_auto_assigned_program_matrix.py
+++ b/tests/test_first_auto_assigned_program_matrix.py
@@ -22,6 +22,7 @@ def make_user_settings(
     weekly_target_sessions=3,
     available_equipment=None,
     strength_starting_profile="beginner",
+    starter_capacity_profile="general_beginner",
     run_starting_profile="beginner",
     active_program_overrides=None,
     auto_assigned_programs=None,
@@ -32,6 +33,7 @@ def make_user_settings(
             "training_types": training_types or {},
             "weekly_target_sessions": weekly_target_sessions,
             "strength_starting_profile": strength_starting_profile,
+            "starter_capacity_profile": starter_capacity_profile,
             "run_starting_profile": run_starting_profile,
             **(
                 {"active_program_overrides": active_program_overrides}
@@ -85,6 +87,50 @@ def test_select_strength_program_novice_gym_2x():
         strength_starting_profile="novice",
     )
     assert backend_app.select_strength_program(PROGRAMS, settings, 2) == "base_strength_a"
+
+
+def test_select_strength_program_very_low_capacity_home_2x_biases_to_reentry():
+    settings = make_user_settings(
+        training_types={"strength_weights": True},
+        weekly_target_sessions=2,
+        available_equipment={"bodyweight": True, "dumbbell": True},
+        strength_starting_profile="beginner",
+        starter_capacity_profile="very_low_capacity",
+    )
+    assert backend_app.select_strength_program(PROGRAMS, settings, 2) == "reentry_strength_2x"
+
+
+def test_select_strength_program_low_capacity_home_2x_biases_to_minimalist():
+    settings = make_user_settings(
+        training_types={"strength_weights": True},
+        weekly_target_sessions=2,
+        available_equipment={"bodyweight": True, "dumbbell": True},
+        strength_starting_profile="beginner",
+        starter_capacity_profile="low_capacity",
+    )
+    assert backend_app.select_strength_program(PROGRAMS, settings, 2) == "minimalist_strength_2x"
+
+
+def test_select_strength_program_general_beginner_gym_2x_keeps_standard_starter():
+    settings = make_user_settings(
+        training_types={"strength_weights": True},
+        weekly_target_sessions=2,
+        available_equipment={"barbell": True, "bench": True},
+        strength_starting_profile="beginner",
+        starter_capacity_profile="general_beginner",
+    )
+    assert backend_app.select_strength_program(PROGRAMS, settings, 2) == "starter_strength_gym_2x"
+
+
+def test_select_strength_program_loaded_beginner_gym_3x_biases_to_proper_gym_starter():
+    settings = make_user_settings(
+        training_types={"strength_weights": True},
+        weekly_target_sessions=3,
+        available_equipment={"barbell": True, "bench": True},
+        strength_starting_profile="beginner",
+        starter_capacity_profile="loaded_beginner",
+    )
+    assert backend_app.select_strength_program(PROGRAMS, settings, 3) == "starter_strength_gym_3x"
 
 
 def test_select_strength_program_novice_gym_4x():


### PR DESCRIPTION
Description:
## Summary

This PR applies `starter_capacity_profile` to early strength recommendation behavior so first strength matches become more realistic across different onboarding situations.

The goal is not to redesign the full strength selector. It is to add a deterministic early-stage bias for first strength program selection based on the new normalized starter capacity field introduced in #460.

## What changed

### Backend
- `select_strength_program(...)` now reads and normalizes `preferences.starter_capacity_profile`
- allowed values:
  - `very_low_capacity`
  - `low_capacity`
  - `general_beginner`
  - `loaded_beginner`
- invalid or missing values fall back to:
  - `general_beginner`

### Strength recommendation behavior
The first strength program recommendation now changes meaningfully for early onboarding cases:

- `very_low_capacity`
  - biases strongly toward more accessible entry paths
  - 2x strength starts prefer `reentry_strength_2x`
- `low_capacity`
  - biases toward conservative low-friction paths
  - 2x home starts prefer `minimalist_strength_2x`
  - 2x non-home cases prefer `reentry_strength_2x`
- `general_beginner`
  - keeps standard beginner starter behavior
- `loaded_beginner`
  - keeps the proper beginner strength path where equipment and weekly structure already support it

This remains deterministic and explainable because the change only adjusts preferred candidate ordering rather than introducing opaque scoring logic.

## Tests
Extended the existing first-program matrix tests to cover starter capacity behavior for strength selection.

Added coverage for:
- very low capacity home beginner
- low capacity home beginner
- general beginner gym
- loaded beginner gym

## Validation

Validated with:

- `python3 -m py_compile app/backend/app.py tests/test_first_auto_assigned_program_matrix.py`
- `python3 -m pytest -q tests/test_first_auto_assigned_program_matrix.py`
- `python3 -m pytest -q tests/test_first_auto_assigned_program_matrix.py tests/test_auto_assigned_program_validation.py`

Result:
- `46 passed`

## Scope note

This PR intentionally covers **strength only**.

It does **not** yet change:
- cardio starting behavior
- recovery/restitution paths
- broader selector architecture beyond first strength matching

Those remain separate follow-up steps so each behavior change stays small, testable, and easy to reason about.