### PR TITLE
Title: Use starter capacity profile in first cardio recommendations because early cardio entry should match realistic starting ability

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2840,6 +2840,10 @@ def select_endurance_program(programs, user_settings, weekly_target_sessions, pr
     if run_starting_profile not in ("conservative_beginner", "beginner", "novice"):
         run_starting_profile = "beginner"
 
+    starter_capacity_profile = str(preferences.get("starter_capacity_profile", "general_beginner") or "general_beginner").strip().lower()
+    if starter_capacity_profile not in ("very_low_capacity", "low_capacity", "general_beginner", "loaded_beginner"):
+        starter_capacity_profile = "general_beginner"
+
     running_enabled = bool(prefs.get("running", True))
     strength_enabled = bool(prefs.get("strength_weights", True)) or bool(prefs.get("bodyweight", True))
 
@@ -2847,6 +2851,15 @@ def select_endurance_program(programs, user_settings, weekly_target_sessions, pr
         return None
 
     preferred_ids = []
+
+    if starter_capacity_profile in ("very_low_capacity", "low_capacity"):
+        if target_sessions == 2:
+            preferred_ids.append("reentry_run_2x")
+        elif target_sessions == 3:
+            preferred_ids.append("starter_run_3x_beginner")
+    elif starter_capacity_profile == "loaded_beginner":
+        if not strength_enabled and target_sessions == 3 and run_starting_profile == "beginner":
+            preferred_ids.append("base_run_3x")
 
     if running_enabled and strength_enabled:
         if target_sessions >= 3:

--- a/tests/test_first_auto_assigned_program_matrix.py
+++ b/tests/test_first_auto_assigned_program_matrix.py
@@ -153,6 +153,50 @@ def test_select_endurance_program_beginner_run_2x():
     assert backend_app.select_endurance_program(PROGRAMS, settings, 2, prefs) == "starter_run_2x"
 
 
+def test_select_endurance_program_very_low_capacity_beginner_2x_biases_to_reentry():
+    settings = make_user_settings(
+        training_types={"running": True, "strength_weights": False, "bodyweight": False},
+        weekly_target_sessions=2,
+        run_starting_profile="beginner",
+        starter_capacity_profile="very_low_capacity",
+    )
+    prefs = backend_app.get_training_type_preferences(settings)
+    assert backend_app.select_endurance_program(PROGRAMS, settings, 2, prefs) == "reentry_run_2x"
+
+
+def test_select_endurance_program_low_capacity_beginner_2x_biases_to_reentry():
+    settings = make_user_settings(
+        training_types={"running": True, "strength_weights": False, "bodyweight": False},
+        weekly_target_sessions=2,
+        run_starting_profile="beginner",
+        starter_capacity_profile="low_capacity",
+    )
+    prefs = backend_app.get_training_type_preferences(settings)
+    assert backend_app.select_endurance_program(PROGRAMS, settings, 2, prefs) == "reentry_run_2x"
+
+
+def test_select_endurance_program_general_beginner_3x_keeps_starter_path():
+    settings = make_user_settings(
+        training_types={"running": True, "strength_weights": False, "bodyweight": False},
+        weekly_target_sessions=3,
+        run_starting_profile="beginner",
+        starter_capacity_profile="general_beginner",
+    )
+    prefs = backend_app.get_training_type_preferences(settings)
+    assert backend_app.select_endurance_program(PROGRAMS, settings, 3, prefs) == "starter_run_3x_beginner"
+
+
+def test_select_endurance_program_loaded_beginner_3x_can_bias_to_easy_run_base():
+    settings = make_user_settings(
+        training_types={"running": True, "strength_weights": False, "bodyweight": False},
+        weekly_target_sessions=3,
+        run_starting_profile="beginner",
+        starter_capacity_profile="loaded_beginner",
+    )
+    prefs = backend_app.get_training_type_preferences(settings)
+    assert backend_app.select_endurance_program(PROGRAMS, settings, 3, prefs) == "base_run_3x"
+
+
 def test_select_endurance_program_novice_run_3x():
     settings = make_user_settings(
         training_types={"running": True, "strength_weights": False, "bodyweight": False},


### PR DESCRIPTION
Description:
## Summary

This PR applies `starter_capacity_profile` to early cardio recommendation behavior so first cardio matches become more realistic across different onboarding situations.

The goal is to improve the first cardio entry path without introducing fuzzy scoring or broad selector redesign.

## What changed

### Backend
- `select_endurance_program(...)` now reads and normalizes `preferences.starter_capacity_profile`
- allowed values:
  - `very_low_capacity`
  - `low_capacity`
  - `general_beginner`
  - `loaded_beginner`
- invalid or missing values fall back to:
  - `general_beginner`

### Cardio recommendation behavior
The first cardio program recommendation now changes meaningfully for early onboarding cases:

- `very_low_capacity`
  - 2x cardio starts prefer `reentry_run_2x`
  - 3x cardio starts prefer `starter_run_3x_beginner`
- `low_capacity`
  - 2x cardio starts prefer `reentry_run_2x`
  - 3x cardio starts prefer `starter_run_3x_beginner`
- `general_beginner`
  - keeps the standard beginner cardio entry path
- `loaded_beginner`
  - 3x run-only beginner cases can bias toward `base_run_3x`
  - does not automatically imply aggressive cardio progression

This remains deterministic and explainable because the change only adjusts simple preferred program ordering.

## Tests
Extended the existing first-program matrix tests to cover starter capacity behavior for cardio selection.

Added coverage for:
- very low capacity beginner 2x
- low capacity beginner 2x
- general beginner 3x
- loaded beginner 3x
- comparison between conservative entry and easier run-base entry behavior

## Validation

Validated with:

- `python3 -m py_compile app/backend/app.py tests/test_first_auto_assigned_program_matrix.py`
- `python3 -m pytest -q tests/test_first_auto_assigned_program_matrix.py`
- `python3 -m pytest -q tests/test_first_auto_assigned_program_matrix.py tests/test_auto_assigned_program_validation.py`

Result:
- `50 passed`

## Scope note

This PR intentionally covers **cardio only**.

It does **not** change:
- strength starting behavior
- recovery/restitution paths
- broader selector architecture beyond first cardio matching

Those remain separate follow-up steps so each behavior change stays small, deterministic, and easy to validate.