### PR TITLE
Refocus history as a personal training log

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6591,8 +6591,6 @@ STATE.workouts = Array.isArray(workoutsApi && workoutsApi.items) ? workoutsApi.i
   renderWorkouts(STATE.workouts);
   renderLoadMetrics(sessionResultsApi && sessionResultsApi.load_metrics ? sessionResultsApi.load_metrics : null, todayPlanApi && todayPlanApi.item ? todayPlanApi.item.recovery_state : null);
   renderSessionHistory(STATE.sessionResults);
-  renderExercises(STATE.exercises);
-  renderExerciseLibrary();
   renderRecovery(recoveryApi.items || []);
   renderReadiness(latestRecoveryApi.item || null);
   renderForecastHero(todayPlanApi.item || null, latestRecoveryApi.item || null);
@@ -6600,7 +6598,6 @@ STATE.workouts = Array.isArray(workoutsApi && workoutsApi.items) ? workoutsApi.i
     renderOverviewStatus(todayPlanApi.item || null, latestRecoveryApi.item || null, workoutsApi.items || []);
   renderProfileEquipmentCard();
     renderTodayPlan(todayPlanApi.item || null);
-  renderPrograms(STATE.programs, STATE.exercises);
   renderPendingEntries();
 
   const dailyUiState = deriveDailyUiState(todayPlanApi.item || null, latestRecoveryApi.item || null, sessionResultsApi.items || []);

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1346,15 +1346,6 @@
         </div>
         <ul id="workoutsList"></ul>
       </section>
-
-      <section class="card">
-        <div class="row">
-          <h2 data-i18n="history.exercise_library">Øvelsesbibliotek</h2>
-          <div id="exerciseLibrary"></div>
-          <div class="small" id="exerciseMeta"></div>
-        </div>
-        <ul id="exercisesList"></ul>
-      </section>
     </div>
 
     <div class="two-col" id="historyBottomSection">
@@ -1364,14 +1355,6 @@
           <div class="small" id="recoveryMeta"></div>
         </div>
         <ul id="recoveryList"></ul>
-      </section>
-
-      <section class="card">
-        <div class="row">
-          <h2 data-i18n="programs.title">Programmer</h2>
-          <div class="small" id="programMeta"></div>
-        </div>
-        <div id="programsRoot"></div>
       </section>
     </div>
 


### PR DESCRIPTION
## Summary

This PR refocuses the History step so it behaves as a personal training log rather than a mixed container for both personal data and reference content.

## What changed

### Removed from History
- Exercise library
- Program catalog

### Kept in History
- Recent workouts / sessions
- Recent recovery / check-ins

### Frontend cleanup
- Removed exercise-library rendering from the History refresh flow
- Removed program-catalog rendering from the History refresh flow
- Simplified the History markup so it only contains personal history sections

## Why

The History view should help users reflect on what they have done.

Reference browsing such as exercise and program catalogs belongs elsewhere and adds noise when placed inside the same step.

This change improves information architecture and makes the History step feel more like a real log and less like a catch-all page.

## Validation

- Removed non-history cards from `index.html`
- Removed unused History-step render calls from `refreshAll()`
- Frontend sanity check:
  - `node --check app/frontend/app.js`

## Scope

This PR is an information architecture cleanup for the existing History step.
It does not redesign the broader navigation structure.