### PR TITLE
Add dedicated library area for exercises and programs

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6591,6 +6591,8 @@ STATE.workouts = Array.isArray(workoutsApi && workoutsApi.items) ? workoutsApi.i
   renderWorkouts(STATE.workouts);
   renderLoadMetrics(sessionResultsApi && sessionResultsApi.load_metrics ? sessionResultsApi.load_metrics : null, todayPlanApi && todayPlanApi.item ? todayPlanApi.item.recovery_state : null);
   renderSessionHistory(STATE.sessionResults);
+  renderExercises(STATE.exercises);
+  renderExerciseLibrary();
   renderRecovery(recoveryApi.items || []);
   renderReadiness(latestRecoveryApi.item || null);
   renderForecastHero(todayPlanApi.item || null, latestRecoveryApi.item || null);
@@ -6598,6 +6600,7 @@ STATE.workouts = Array.isArray(workoutsApi && workoutsApi.items) ? workoutsApi.i
     renderOverviewStatus(todayPlanApi.item || null, latestRecoveryApi.item || null, workoutsApi.items || []);
   renderProfileEquipmentCard();
     renderTodayPlan(todayPlanApi.item || null);
+  renderPrograms(STATE.programs, STATE.exercises);
   renderPendingEntries();
 
   const dailyUiState = deriveDailyUiState(todayPlanApi.item || null, latestRecoveryApi.item || null, sessionResultsApi.items || []);
@@ -7389,6 +7392,7 @@ const WIZARD_STEPS = [
   { id: "review", labelKey: "wizard.review" },
   { id: "manual", labelKey: "wizard.manual" },
   { id: "history", labelKey: "wizard.history" },
+  { id: "library", labelKey: "wizard.library" },
 ];
 
 function getWizardStepLabel(step){
@@ -7404,7 +7408,8 @@ function getWizardStepLabel(step){
       "wizard.plan": "Dagens plan",
       "wizard.review": "Efter træning",
       "wizard.manual": "Manuel træning",
-      "wizard.history": "Historik"
+      "wizard.history": "Historik",
+      "wizard.library": "Bibliotek"
     },
     en: {
       "wizard.overview": "Overview",
@@ -7412,7 +7417,8 @@ function getWizardStepLabel(step){
       "wizard.plan": "Today's plan",
       "wizard.review": "After training",
       "wizard.manual": "Manual workout",
-      "wizard.history": "History"
+      "wizard.history": "History",
+      "wizard.library": "Library"
     }
   };
 
@@ -7442,6 +7448,9 @@ function getWizardSections(){
       document.getElementById("historyTopSection"),
       document.getElementById("historyBottomSection"),
     ],
+    library: [
+      document.getElementById("librarySection"),
+    ],
   };
 }
 
@@ -7454,6 +7463,7 @@ function renderUtilityNav(){
     { id: "profile", label: tr("overview.profile_equipment") },
     { id: "manual", label: getWizardStepLabel({ labelKey: "wizard.manual" }) },
     { id: "history", label: getWizardStepLabel({ labelKey: "wizard.history" }) },
+    { id: "library", label: getWizardStepLabel({ labelKey: "wizard.library" }) },
   ];
 
   root.innerHTML = items.map(item => `

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1358,6 +1358,25 @@
       </section>
     </div>
 
+    <div class="two-col wizard-step-hidden" id="librarySection" style="margin-top:18px; display:none">
+      <section class="card">
+        <div class="row">
+          <h2 data-i18n="history.exercise_library">Øvelsesbibliotek</h2>
+          <div class="small" id="exerciseMeta"></div>
+        </div>
+        <div id="exerciseLibrary"></div>
+        <ul id="exercisesList" style="margin-top:12px"></ul>
+      </section>
+
+      <section class="card">
+        <div class="row">
+          <h2 data-i18n="programs.title">Programmer</h2>
+          <div class="small" id="programMeta"></div>
+        </div>
+        <div id="programsRoot"></div>
+      </section>
+    </div>
+
     <section class="card" id="systemStatusCard" style="margin-top:18px">
       <h2 data-i18n="system.status">Status</h2>
       <div class="card" style="margin-top:16px">


### PR DESCRIPTION
## Summary

This PR introduces a dedicated Library area for exercise and program reference content.

## What changed

### New utility step
Added a new `library` utility step in the frontend navigation.

### Moved reference content out of History
The following reference sections now live in the new Library area instead of the History view:

- Exercise library
- Program catalog

### Rendering
Restored and routed the existing reference renderers to the new Library section:

- `renderExercises(STATE.exercises)`
- `renderExerciseLibrary()`
- `renderPrograms(STATE.programs, STATE.exercises)`

### Navigation and step handling
Updated:
- `WIZARD_STEPS`
- step label fallbacks
- `getWizardSections()`
- utility navigation items

## Why

History should act as a personal training log.

Exercise and program browsing are reference concerns and should live in a separate destination. This improves information architecture and makes both areas clearer:

- History = what the user has done
- Library = what the user can browse

## Validation

- Added `library` step to utility navigation
- Added dedicated `librarySection` markup
- Restored exercise/program rendering for the new section
- Frontend sanity check:
  - `node --check app/frontend/app.js`

## Scope

This PR creates the structural library area only.

It does not yet redesign the library UI with search, filters, or richer browsing tools.