### PR TITLE
Simplify library exercise browsing by removing duplicate lists

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6591,7 +6591,6 @@ STATE.workouts = Array.isArray(workoutsApi && workoutsApi.items) ? workoutsApi.i
   renderWorkouts(STATE.workouts);
   renderLoadMetrics(sessionResultsApi && sessionResultsApi.load_metrics ? sessionResultsApi.load_metrics : null, todayPlanApi && todayPlanApi.item ? todayPlanApi.item.recovery_state : null);
   renderSessionHistory(STATE.sessionResults);
-  renderExercises(STATE.exercises);
   renderExerciseLibrary();
   renderRecovery(recoveryApi.items || []);
   renderReadiness(latestRecoveryApi.item || null);

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1365,7 +1365,6 @@
           <div class="small" id="exerciseMeta"></div>
         </div>
         <div id="exerciseLibrary"></div>
-        <ul id="exercisesList" style="margin-top:12px"></ul>
       </section>
 
       <section class="card">


### PR DESCRIPTION
## Summary

This PR simplifies the new Library exercise browsing experience by removing the duplicate flat exercise list.

## What changed

- Removed the extra `exercisesList` markup from the Library section
- Stopped calling `renderExercises(STATE.exercises)` in `refreshAll()`
- Kept the grouped exercise-library rendering as the single exercise browsing view

## Why

The Library was showing exercises twice:

- once via the grouped exercise library view
- once again via a flat exercise list

This created unnecessary noise, especially on mobile, and made the Library feel confusing and repetitive.

## Result

- exercises are now shown only once in the Library
- the exercise browsing experience is cleaner and easier to scan
- the Library better matches its intended role as a reference area

## Validation

- Removed duplicate exercise list markup from `index.html`
- Removed duplicate exercise render call from `app.js`
- Frontend sanity check:
  - `node --check app/frontend/app.js`

## Scope

This PR is a focused cleanup of duplicate exercise browsing in the Library.
It does not yet add search, tabs, or filters.