### PR TITLE
Add library tabs for separate exercise and program browsing

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6600,6 +6600,7 @@ STATE.workouts = Array.isArray(workoutsApi && workoutsApi.items) ? workoutsApi.i
   renderProfileEquipmentCard();
     renderTodayPlan(todayPlanApi.item || null);
   renderPrograms(STATE.programs, STATE.exercises);
+  renderLibraryTabs();
   renderPendingEntries();
 
   const dailyUiState = deriveDailyUiState(todayPlanApi.item || null, latestRecoveryApi.item || null, sessionResultsApi.items || []);
@@ -7425,6 +7426,43 @@ function getWizardStepLabel(step){
 }
 
 let CURRENT_STEP = "";
+let CURRENT_LIBRARY_TAB = "exercises";
+
+function renderLibraryTabs(){
+  const exercisesBtn = document.getElementById("libraryTabExercises");
+  const programsBtn = document.getElementById("libraryTabPrograms");
+  const exercisesPanel = document.getElementById("libraryExercisesPanel");
+  const programsPanel = document.getElementById("libraryProgramsPanel");
+
+  if (!exercisesBtn || !programsBtn || !exercisesPanel || !programsPanel) return;
+
+  const activeTab = CURRENT_LIBRARY_TAB === "programs" ? "programs" : "exercises";
+  exercisesPanel.style.display = activeTab === "exercises" ? "" : "none";
+  programsPanel.style.display = activeTab === "programs" ? "" : "none";
+
+  exercisesBtn.classList.toggle("secondary", activeTab !== "exercises");
+  programsBtn.classList.toggle("secondary", activeTab !== "programs");
+  exercisesBtn.disabled = activeTab === "exercises";
+  programsBtn.disabled = activeTab === "programs";
+
+  if (exercisesBtn.dataset.tabsBound !== "true"){
+    exercisesBtn.dataset.tabsBound = "true";
+    exercisesBtn.addEventListener("click", () => {
+      CURRENT_LIBRARY_TAB = "exercises";
+      renderLibraryTabs();
+    });
+  }
+
+  if (programsBtn.dataset.tabsBound !== "true"){
+    programsBtn.dataset.tabsBound = "true";
+    programsBtn.addEventListener("click", () => {
+      CURRENT_LIBRARY_TAB = "programs";
+      renderLibraryTabs();
+    });
+  }
+}
+
+
 
 function getWizardSections(){
   return {

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -787,5 +787,7 @@
   "profile.starter_capacity_profile_general": "Almindelig begynder",
   "profile.starter_capacity_profile_loaded": "Robust begynder",
   "profile.starter_capacity_profile_help": "Vælg hvor let eller robust din samlede opstartskapacitet er lige nu. Det bruges som et tidligt planlægningssignal.",
-  "profile.starter_capacity_profile_help_levels": "Meget lav kapacitet = meget rolig opstart med lav tærskel · Lav kapacitet = forsigtig opstart med enkel belastning · Almindelig begynder = normal begynderopstart · Robust begynder = ny, men klar til en mere direkte start."
+  "profile.starter_capacity_profile_help_levels": "Meget lav kapacitet = meget rolig opstart med lav tærskel · Lav kapacitet = forsigtig opstart med enkel belastning · Almindelig begynder = normal begynderopstart · Robust begynder = ny, men klar til en mere direkte start.",
+  "library.tab_exercises": "Øvelser",
+  "library.tab_programs": "Programmer"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -771,5 +771,7 @@
   "profile.starter_capacity_profile_general": "General beginner",
   "profile.starter_capacity_profile_loaded": "Loaded beginner",
   "profile.starter_capacity_profile_help": "Choose how light or robust your overall starting capacity is right now. This is used as an early planning signal.",
-  "profile.starter_capacity_profile_help_levels": "Very low capacity = very gentle start with a low threshold · Low capacity = cautious start with simple loading · General beginner = normal beginner starting point · Loaded beginner = new, but ready for a more direct start."
+  "profile.starter_capacity_profile_help_levels": "Very low capacity = very gentle start with a low threshold · Low capacity = cautious start with simple loading · General beginner = normal beginner starting point · Loaded beginner = new, but ready for a more direct start.",
+  "library.tab_exercises": "Exercises",
+  "library.tab_programs": "Programs"
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1358,8 +1358,18 @@
       </section>
     </div>
 
-    <div class="two-col wizard-step-hidden" id="librarySection" style="margin-top:18px; display:none">
+    <div class="wizard-step-hidden" id="librarySection" style="margin-top:18px; display:none">
       <section class="card">
+        <div class="row">
+          <h2 data-i18n="wizard.library">Bibliotek</h2>
+        </div>
+        <div class="btn-row" id="libraryTabs" style="margin-top:12px">
+          <button type="button" id="libraryTabExercises" data-i18n="library.tab_exercises">Øvelser</button>
+          <button type="button" id="libraryTabPrograms" class="secondary" data-i18n="library.tab_programs">Programmer</button>
+        </div>
+      </section>
+
+      <section class="card" id="libraryExercisesPanel" style="margin-top:14px">
         <div class="row">
           <h2 data-i18n="history.exercise_library">Øvelsesbibliotek</h2>
           <div class="small" id="exerciseMeta"></div>
@@ -1367,7 +1377,7 @@
         <div id="exerciseLibrary"></div>
       </section>
 
-      <section class="card">
+      <section class="card" id="libraryProgramsPanel" style="margin-top:14px; display:none">
         <div class="row">
           <h2 data-i18n="programs.title">Programmer</h2>
           <div class="small" id="programMeta"></div>


### PR DESCRIPTION
## Summary

This PR improves the Library experience by adding simple tabs for separate exercise and program browsing.

## What changed

- Added a Library header card with two tabs:
  - Exercises
  - Programs
- Added a small frontend tab state:
  - `CURRENT_LIBRARY_TAB`
  - `renderLibraryTabs()`
- Shows only one Library panel at a time
- Moved tab labels into i18n:
  - `library.tab_exercises`
  - `library.tab_programs`

## Why

After moving reference content out of History, the Library still showed both exercises and programs at the same time.

That worked structurally, but it was still noisy and less clear than it should be, especially on smaller screens.

Tabs make the Library easier to scan and align better with its role as a browsing area.

## Validation

- Frontend tab state added and wired into refresh
- Library panels now switch between exercises and programs
- Tab labels moved into Danish and English i18n
- Frontend sanity check:
  - `node --check app/frontend/app.js`
- i18n JSON validation:
  - `app/frontend/i18n/da.json`
  - `app/frontend/i18n/en.json`

## Scope

This PR adds lightweight frontend tabs only.

It does not yet add search, filters, or favorites.