### PR TITLE
Add exercise search to the library

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -5344,17 +5344,50 @@ function getExerciseLibraryCardCopy(item){
 
 function renderExerciseLibrary(){
   const root = document.getElementById("exerciseLibrary");
+  const searchInput = document.getElementById("libraryExerciseSearchInput");
   if (!root) return;
+
+  if (searchInput && searchInput.dataset.boundSearch !== "true"){
+    searchInput.dataset.boundSearch = "true";
+    searchInput.addEventListener("input", () => {
+      CURRENT_LIBRARY_EXERCISE_QUERY = String(searchInput.value || "").trim();
+      renderExerciseLibrary();
+    });
+  }
+
+  if (searchInput && searchInput.value !== CURRENT_LIBRARY_EXERCISE_QUERY){
+    searchInput.value = CURRENT_LIBRARY_EXERCISE_QUERY;
+  }
 
   const items = Array.isArray(STATE.exercises) ? STATE.exercises.slice() : [];
   if (!items.length){
     root.innerHTML = `<div class="small">${esc(tr("exercise.none_loaded_yet"))}</div>`;
+    setText("exerciseMeta", tr("common.items_count", { count: 0 }));
+    return;
+  }
+
+  const query = String(CURRENT_LIBRARY_EXERCISE_QUERY || "").trim().toLowerCase();
+  const filteredItems = items.filter(item => {
+    if (!item || typeof item !== "object") return false;
+    if (!query) return true;
+    const copy = getExerciseLibraryCardCopy(item);
+    const haystack = [
+      String(item.id || ""),
+      String(copy.name || ""),
+      String(copy.notes || ""),
+      String(item.category || "")
+    ].join(" ").toLowerCase();
+    return haystack.includes(query);
+  });
+
+  if (!filteredItems.length){
+    root.innerHTML = `<div class="small">${esc(tr("library.exercise_search_empty"))}</div>`;
+    setText("exerciseMeta", tr("common.items_count", { count: 0 }));
     return;
   }
 
   const grouped = {};
-  for (const item of items){
-    if (!item || typeof item !== "object") continue;
+  for (const item of filteredItems){
     const category = String(item.category || "andet").trim() || "andet";
     if (!grouped[category]) grouped[category] = [];
     grouped[category].push(item);
@@ -5401,6 +5434,7 @@ function renderExerciseLibrary(){
     `;
   }).join("");
 
+  setText("exerciseMeta", tr("common.items_count", { count: filteredItems.length }));
   bindExerciseViewer();
 }
 
@@ -7427,6 +7461,7 @@ function getWizardStepLabel(step){
 
 let CURRENT_STEP = "";
 let CURRENT_LIBRARY_TAB = "exercises";
+let CURRENT_LIBRARY_EXERCISE_QUERY = "";
 
 function renderLibraryTabs(){
   const exercisesBtn = document.getElementById("libraryTabExercises");

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -789,5 +789,8 @@
   "profile.starter_capacity_profile_help": "Vælg hvor let eller robust din samlede opstartskapacitet er lige nu. Det bruges som et tidligt planlægningssignal.",
   "profile.starter_capacity_profile_help_levels": "Meget lav kapacitet = meget rolig opstart med lav tærskel · Lav kapacitet = forsigtig opstart med enkel belastning · Almindelig begynder = normal begynderopstart · Robust begynder = ny, men klar til en mere direkte start.",
   "library.tab_exercises": "Øvelser",
-  "library.tab_programs": "Programmer"
+  "library.tab_programs": "Programmer",
+  "library.exercise_search_label": "Søg i øvelser",
+  "library.exercise_search_placeholder": "Fx squat eller hofte",
+  "library.exercise_search_empty": "Ingen øvelser matcher din søgning."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -773,5 +773,8 @@
   "profile.starter_capacity_profile_help": "Choose how light or robust your overall starting capacity is right now. This is used as an early planning signal.",
   "profile.starter_capacity_profile_help_levels": "Very low capacity = very gentle start with a low threshold · Low capacity = cautious start with simple loading · General beginner = normal beginner starting point · Loaded beginner = new, but ready for a more direct start.",
   "library.tab_exercises": "Exercises",
-  "library.tab_programs": "Programs"
+  "library.tab_programs": "Programs",
+  "library.exercise_search_label": "Search exercises",
+  "library.exercise_search_placeholder": "For example squat or hip",
+  "library.exercise_search_empty": "No exercises match your search."
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1374,6 +1374,10 @@
           <h2 data-i18n="history.exercise_library">Øvelsesbibliotek</h2>
           <div class="small" id="exerciseMeta"></div>
         </div>
+        <label style="margin-top:12px">
+          <span data-i18n="library.exercise_search_label">Søg i øvelser</span>
+          <input id="libraryExerciseSearchInput" type="search" placeholder="Fx squat eller hofte" data-i18n-placeholder="library.exercise_search_placeholder">
+        </label>
         <div id="exerciseLibrary"></div>
       </section>
 


### PR DESCRIPTION
## Summary

This PR adds a simple exercise search to the Library.

## What changed

- Added a search input to the Library exercise panel
- Added lightweight frontend state for the current exercise query:
  - `CURRENT_LIBRARY_EXERCISE_QUERY`
- Filters exercise cards before grouping and rendering
- Matches against:
  - exercise id
  - localized exercise name
  - localized notes
  - category
- Updates the exercise count based on filtered results
- Shows a dedicated empty-state message when no exercises match
- Added Danish and English i18n strings for the new search UI

## Why

After separating Library from History and adding tabs, exercise browsing was clearer, but long lists still required too much scrolling.

A simple search field makes the exercise library faster to use without adding backend complexity.

## Validation

- Frontend sanity check:
  - `node --check app/frontend/app.js`
- JSON validation:
  - `app/frontend/i18n/da.json`
  - `app/frontend/i18n/en.json`

## Scope

This PR adds search only for the exercise side of the Library.

It does not yet add:
- program search
- advanced filters
- favorites