### PR TITLE
Add program search to the library

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6490,9 +6490,22 @@ function renderTodayPlan(item){
 
 function renderPrograms(programs, exercises){
   const root = document.getElementById("programsRoot");
+  const searchInput = document.getElementById("libraryProgramSearchInput");
   if (!root) return;
 
   const exerciseMap = new Map((Array.isArray(exercises) ? exercises : []).map(x => [x.id, x]));
+
+  if (searchInput && searchInput.dataset.boundSearch !== "true"){
+    searchInput.dataset.boundSearch = "true";
+    searchInput.addEventListener("input", () => {
+      CURRENT_LIBRARY_PROGRAM_QUERY = String(searchInput.value || "").trim();
+      renderPrograms(programs, exercises);
+    });
+  }
+
+  if (searchInput && searchInput.value !== CURRENT_LIBRARY_PROGRAM_QUERY){
+    searchInput.value = CURRENT_LIBRARY_PROGRAM_QUERY;
+  }
 
   if (!Array.isArray(programs) || programs.length === 0){
     root.innerHTML = `<div class="small">${esc(tr("program.none_yet"))}</div>`;
@@ -6500,7 +6513,38 @@ function renderPrograms(programs, exercises){
     return;
   }
 
-  root.innerHTML = programs.map(program => `
+  const query = String(CURRENT_LIBRARY_PROGRAM_QUERY || "").trim().toLowerCase();
+  const filteredPrograms = programs.filter(program => {
+    if (!program || typeof program !== "object") return false;
+    if (!query) return true;
+
+    const dayBits = Array.isArray(program.days) ? program.days.flatMap(day => {
+      const dayLabel = String(getProgramDayDisplayLabel(day) || "");
+      const exerciseBits = Array.isArray(day?.exercises) ? day.exercises.map(ex => {
+        const found = exerciseMap.get(ex.exercise_id) || {};
+        const display = getExerciseDisplayCopy(found);
+        return display.name || formatExerciseName(ex.exercise_id || "") || ex.exercise_id || "";
+      }) : [];
+      return [dayLabel, ...exerciseBits];
+    }) : [];
+
+    const haystack = [
+      String(program.id || ""),
+      String(getProgramDisplayName(program) || ""),
+      String(getProgramKindDisplayLabel(program.kind || "") || ""),
+      ...dayBits
+    ].join(" ").toLowerCase();
+
+    return haystack.includes(query);
+  });
+
+  if (!filteredPrograms.length){
+    root.innerHTML = `<div class="small">${esc(tr("library.program_search_empty"))}</div>`;
+    setText("programMeta", tr("common.items_count", { count: 0 }));
+    return;
+  }
+
+  root.innerHTML = filteredPrograms.map(program => `
     <div class="card" style="margin-top:12px; background:#141414">
       <div class="row">
         <h3>${esc(getProgramDisplayName(program) || "Program")}</h3>
@@ -6529,7 +6573,7 @@ function renderPrograms(programs, exercises){
     </div>
   `).join("");
 
-  setText("programMeta", tr("common.items_count", { count: programs.length }));
+  setText("programMeta", tr("common.items_count", { count: filteredPrograms.length }));
 }
 
 async function refreshAll(){
@@ -7462,6 +7506,7 @@ function getWizardStepLabel(step){
 let CURRENT_STEP = "";
 let CURRENT_LIBRARY_TAB = "exercises";
 let CURRENT_LIBRARY_EXERCISE_QUERY = "";
+let CURRENT_LIBRARY_PROGRAM_QUERY = "";
 
 function renderLibraryTabs(){
   const exercisesBtn = document.getElementById("libraryTabExercises");

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -792,5 +792,8 @@
   "library.tab_programs": "Programmer",
   "library.exercise_search_label": "Søg i øvelser",
   "library.exercise_search_placeholder": "Fx squat eller hofte",
-  "library.exercise_search_empty": "Ingen øvelser matcher din søgning."
+  "library.exercise_search_empty": "Ingen øvelser matcher din søgning.",
+  "library.program_search_label": "Søg i programmer",
+  "library.program_search_placeholder": "Fx styrke, 3x eller squat",
+  "library.program_search_empty": "Ingen programmer matcher din søgning."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -776,5 +776,8 @@
   "library.tab_programs": "Programs",
   "library.exercise_search_label": "Search exercises",
   "library.exercise_search_placeholder": "For example squat or hip",
-  "library.exercise_search_empty": "No exercises match your search."
+  "library.exercise_search_empty": "No exercises match your search.",
+  "library.program_search_label": "Search programs",
+  "library.program_search_placeholder": "For example strength, 3x or squat",
+  "library.program_search_empty": "No programs match your search."
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1386,6 +1386,10 @@
           <h2 data-i18n="programs.title">Programmer</h2>
           <div class="small" id="programMeta"></div>
         </div>
+        <label style="margin-top:12px">
+          <span data-i18n="library.program_search_label">Søg i programmer</span>
+          <input id="libraryProgramSearchInput" type="search" placeholder="Fx styrke, 3x eller squat" data-i18n-placeholder="library.program_search_placeholder">
+        </label>
         <div id="programsRoot"></div>
       </section>
     </div>


### PR DESCRIPTION
## Summary

This PR adds a simple search field to the Library program panel.

## What changed

- Added a search input to the Library programs panel
- Added lightweight frontend state:
  - `CURRENT_LIBRARY_PROGRAM_QUERY`
- Filters programs before rendering
- Matches against:
  - program id
  - display name
  - kind label
  - day labels
  - exercise names inside the program
- Updates the program count based on filtered results
- Shows a dedicated empty-state message when no programs match
- Added Danish and English i18n strings for the new search UI

## Why

After adding separate Library tabs and exercise search, the program side still required full scrolling even when the user already knew roughly what they were looking for.

A simple search field makes the program library faster to browse and keeps the Library experience balanced across both tabs.

## Validation

- Frontend sanity check:
  - `node --check app/frontend/app.js`
- JSON validation:
  - `app/frontend/i18n/da.json`
  - `app/frontend/i18n/en.json`

## Scope

This PR adds search only for the program side of the Library.

It does not yet add:
- advanced program filters
- favorites
- richer program cards or previews