### PR TITLE
Add vertical pulling to gym-based strength programs

### DIFF
--- a/app/data/seed/exercises.json
+++ b/app/data/seed/exercises.json
@@ -2822,5 +2822,72 @@
       "Keep the hip stable at the top",
       "Lower back down under control without dropping"
     ]
+  },
+  {
+    "id": "lat_pulldown",
+    "name": "Lat pulldown",
+    "name_en": "Lat pulldown",
+    "category": "pull",
+    "category_en": "pull",
+    "default_unit": "kg",
+    "progression_step": 10,
+    "start_weight": 30,
+    "notes": "Vertikalt træk i maskine eller kabel. Træk albuerne ned mod siden med kontrol.",
+    "notes_en": "Vertical pull on a machine or cable. Pull the elbows down toward the sides with control.",
+    "progression_mode": "double_progression",
+    "recommended_step": 2.5,
+    "load_increment": 10,
+    "equipment_type": "machine",
+    "movement_pattern": "vertical_pull",
+    "difficulty_tier": 1,
+    "progression_style": "load",
+    "input_kind": "load_reps",
+    "load_optional": false,
+    "supports_bodyweight": false,
+    "supports_load": true,
+    "set_options": [
+      1,
+      2,
+      3,
+      4,
+      5
+    ],
+    "rep_options": [
+      "4-6",
+      "6-8",
+      "8-10",
+      "10-12",
+      "12-15"
+    ],
+    "load_options": [
+      "10 kg",
+      "20 kg",
+      "30 kg",
+      "40 kg",
+      "50 kg",
+      "60 kg",
+      "70 kg",
+      "80 kg"
+    ],
+    "image_folder": "Wide-Grip_Lat_Pulldown",
+    "external_images": [
+      "Wide-Grip_Lat_Pulldown/0.jpg",
+      "Wide-Grip_Lat_Pulldown/1.jpg"
+    ],
+    "local_load_targets": [
+      "shoulder",
+      "elbow",
+      "wrist"
+    ],
+    "form_cues": [
+      "Start med skuldrene aktive og brystet let løftet",
+      "Træk albuerne ned mod siden i stedet for at hive med hænderne",
+      "Stop før du mister kontrol eller læner dig for langt tilbage"
+    ],
+    "form_cues_en": [
+      "Start with active shoulders and a lightly lifted chest",
+      "Pull the elbows down toward the sides instead of yanking with the hands",
+      "Stop before you lose control or lean too far back"
+    ]
   }
 ]

--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -605,7 +605,7 @@
             "reps": "6-8"
           },
           {
-            "exercise_id": "barbell_row",
+            "exercise_id": "lat_pulldown",
             "sets": 2,
             "reps": "6-8"
           },
@@ -694,7 +694,7 @@
             "reps": "6-8"
           },
           {
-            "exercise_id": "barbell_row",
+            "exercise_id": "lat_pulldown",
             "sets": 2,
             "reps": "6-8"
           },
@@ -896,7 +896,7 @@
             "reps": "6-8"
           },
           {
-            "exercise_id": "barbell_row",
+            "exercise_id": "lat_pulldown",
             "sets": 3,
             "reps": "6-8"
           },
@@ -1034,7 +1034,7 @@
             "reps": "6-8"
           },
           {
-            "exercise_id": "barbell_row",
+            "exercise_id": "lat_pulldown",
             "sets": 3,
             "reps": "6-8"
           },


### PR DESCRIPTION
## Summary

This PR adds structured vertical pulling exposure to relevant gym-based strength programs.

## What changed

### Exercise seed
- Added a new strength exercise:
  - `lat_pulldown`

### Program updates
Replaced one horizontal pull slot with `lat_pulldown` in these gym-based programs:

- `starter_strength_gym_2x` on Day A
- `starter_strength_gym_3x` on Day A
- `base_strength_gym_3x` on Day A
- `base_strength_gym_4x` on Day B

## Why

Several gym-based strength templates had pressing and horizontal pulling, but no systematic vertical pulling at all.

This change improves movement balance and makes the gym templates look more complete and credible, while preserving simplicity and session length.

## Design choice

This PR intentionally uses a small first step:

- adds one gym-friendly vertical pull exercise
- introduces vertical pulling in the most relevant beginner/novice gym programs
- preserves at least some horizontal pulling in the affected templates
- avoids increasing session length by swapping instead of adding exercises

## Validation

- Confirmed `lat_pulldown` exists in exercise seed
- Confirmed updated target programs reference `lat_pulldown`
- Scoped validation passed for:
  - `starter_strength_gym_2x`
  - `starter_strength_gym_3x`
  - `base_strength_gym_3x`
  - `base_strength_gym_4x`

## Scope

This PR does not yet update:
- `base_strength_a`
- `intermediate_upper_lower_4x`
- `intermediate_hypertrophy_4x`

Those can be handled in a follow-up if we want a broader upper-body movement rebalance.