### PR TITLE
Add hinge progression to beginner and home strength programs

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -33,7 +33,7 @@
         "label": "Day B",
         "exercises": [
           {
-            "exercise_id": "glute_bridge",
+            "exercise_id": "hip_hinge_bw",
             "sets": 2,
             "reps": "8-12"
           },
@@ -1477,7 +1477,7 @@
         "label": "Day C",
         "exercises": [
           {
-            "exercise_id": "glute_bridge",
+            "exercise_id": "romanian_deadlift",
             "sets": 3,
             "reps": "10-12"
           },


### PR DESCRIPTION
## Summary

This PR adds a clearer hinge progression path to selected beginner and home-based strength programs.

## What changed

Updated these programs:

- `starter_strength_2x`
  - Day B: replaced `glute_bridge` with `hip_hinge_bw`

- `base_strength_home_3x`
  - Day C: replaced `glute_bridge` with `romanian_deadlift`

## Why

Some beginner and home strength paths relied too heavily on glute bridge as the main hip-dominant pattern.

That works as an introductory movement, but it is not enough as a longer-term hinge solution. This PR makes the hinge path more explicit while staying simple and compatible with equipment constraints.

## Design choice

This PR takes a small first step instead of rewriting every home or beginner template.

- `starter_strength_2x` now introduces a clearer bodyweight hinge pattern
- `base_strength_home_3x` now reinforces a more meaningful dumbbell hinge pattern
- `reentry_strength_2x` is intentionally left unchanged and conservative

## Validation

Scoped validation passed for:

- `starter_strength_2x`
- `base_strength_home_3x`
- `reentry_strength_2x`

Confirmed:
- `starter_strength_2x` now includes `hip_hinge_bw`
- `base_strength_home_3x` now includes `romanian_deadlift` on both Day B and Day C
- `reentry_strength_2x` remains unchanged

## Scope

This PR does not yet redesign every hinge-related home template.

It is a first hinge-progression pass focused on the clearest beginner/home cases.