### PR TITLE
Reduce low-value core filler in short strength sessions

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -21,11 +21,6 @@
             "exercise_id": "dumbbell_row",
             "sets": 2,
             "reps": "8/side"
-          },
-          {
-            "exercise_id": "dead_bug",
-            "sets": 2,
-            "reps": "6/side"
           }
         ]
       },
@@ -424,11 +419,6 @@
             "exercise_id": "dumbbell_row",
             "sets": 2,
             "reps": "8/side"
-          },
-          {
-            "exercise_id": "dead_bug",
-            "sets": 2,
-            "reps": "6/side"
           }
         ]
       },
@@ -608,11 +598,6 @@
             "exercise_id": "lat_pulldown",
             "sets": 2,
             "reps": "6-8"
-          },
-          {
-            "exercise_id": "dead_bug",
-            "sets": 2,
-            "reps": "6/side"
           }
         ]
       },
@@ -697,11 +682,6 @@
             "exercise_id": "lat_pulldown",
             "sets": 2,
             "reps": "6-8"
-          },
-          {
-            "exercise_id": "dead_bug",
-            "sets": 2,
-            "reps": "6/side"
           }
         ]
       },


### PR DESCRIPTION
…bigger ## Summary

This PR reduces low-value core filler in selected short strength sessions so the limited exercise slots stay focused on larger movement patterns.

## What changed

Removed `dead_bug` from Day A in these short strength programs:

- `starter_strength_2x`
- `strength_full_body_3x_beginner`
- `starter_strength_gym_2x`
- `starter_strength_gym_3x`

## Why

Core work like `dead_bug`, `bird_dog`, and `plank` can be useful, but in very short sessions they can take up too much space relative to their training return.

This PR reduces cases where dedicated core work displaces more valuable compound training stimulus.

## Design choice

This is a focused first pass rather than a full rewrite.

- removes the lowest-value repeated Day A core filler
- keeps some core work in the affected templates
- preserves conservative core usage in `reentry_strength_2x`
- avoids adding complexity or changing program identity

## Validation

Scoped validation confirmed:

- target Day A sessions no longer contain `dead_bug`
- core work still remains present in the affected programs where useful
- `reentry_strength_2x` remains unchanged and conservative

## Scope

This PR does not remove all core work from short strength sessions.

It only reduces the most repetitive low-value filler in the clearest beginner and gym-beginner cases.