### PR TITLE
Redesign lower-day exercise distribution in upper/lower 4x strength

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -1793,7 +1793,7 @@
         "label": "Day D",
         "exercises": [
           {
-            "exercise_id": "squat",
+            "exercise_id": "step_ups",
             "sets": 4,
             "reps": "8-10"
           },
@@ -1932,7 +1932,7 @@
         "label": "Day D",
         "exercises": [
           {
-            "exercise_id": "squat",
+            "exercise_id": "step_ups",
             "sets": 4,
             "reps": "10-12"
           },


### PR DESCRIPTION
## Summary

This PR refines lower-day exercise distribution in the intermediate upper/lower 4x strength templates so the split has a clearer reason to exist.

## What changed

Updated Day D in these programs:

- `intermediate_upper_lower_4x`
- `intermediate_hypertrophy_4x`

In both cases:

- replaced `squat` with `step_ups`

## Why

The previous lower-day structure was functional, but Day B and Day D were too similar in effect:

- squat
- hinge
- unilateral squat pattern
- low-priority accessory/core

That made the 4x split feel closer to “more days with similar work” than a clearly differentiated weekly structure.

## Design choice

This PR takes a small structural step rather than a full rewrite.

- Day B remains the more classic squat + hinge lower session
- Day D becomes more clearly unilateral/support-oriented
- weekly lower-body distribution becomes less redundant
- session structure stays simple and readable

## Validation

Scoped validation confirmed:

- both intermediate 4x templates now use `step_ups` on Day D
- neither template still uses `squat` on Day D
- `base_strength_gym_4x` remains unchanged in this pass

## Scope

This PR does not fully redesign every 4x lower day in the catalog.

It is a first differentiation pass focused on the clearest intermediate upper/lower cases.