### PR TITLE
Clarify program role, recommended duration, and exit criteria

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -81,6 +81,17 @@
       "home",
       "simple",
       "low_barrier"
+    ],
+    "program_role": "starter",
+    "transition_type": "temporary",
+    "expected_use_window_weeks": [
+      4,
+      8
+    ],
+    "exit_criteria": [
+      "completes planned sessions consistently for multiple weeks",
+      "tolerates current exercises and recovery demands without difficulty",
+      "needs more progression headroom than the entry template provides"
     ]
   },
   {
@@ -487,6 +498,17 @@
       "home",
       "3x",
       "mixed_friendly"
+    ],
+    "program_role": "starter",
+    "transition_type": "temporary",
+    "expected_use_window_weeks": [
+      4,
+      8
+    ],
+    "exit_criteria": [
+      "completes three weekly sessions consistently for multiple weeks",
+      "handles current hinge, squat, push, and pull work with stable recovery",
+      "needs a more durable novice home progression path"
     ]
   },
   {
@@ -641,6 +663,17 @@
       "gym",
       "foundation",
       "mixed_friendly"
+    ],
+    "program_role": "starter",
+    "transition_type": "temporary",
+    "expected_use_window_weeks": [
+      4,
+      8
+    ],
+    "exit_criteria": [
+      "completes planned sessions consistently for multiple weeks",
+      "shows stable tolerance for gym-based loading and session structure",
+      "is ready for a more durable base gym program"
     ]
   },
   {
@@ -750,6 +783,17 @@
       "gym",
       "3x",
       "mixed_friendly"
+    ],
+    "program_role": "starter",
+    "transition_type": "temporary",
+    "expected_use_window_weeks": [
+      4,
+      8
+    ],
+    "exit_criteria": [
+      "completes three weekly sessions consistently for multiple weeks",
+      "shows stable recovery and low friction across the training week",
+      "is ready for a more durable base gym program"
     ]
   },
   {
@@ -840,6 +884,17 @@
       "low_fatigue",
       "simple",
       "recovery_friendly"
+    ],
+    "program_role": "reentry",
+    "transition_type": "temporary",
+    "expected_use_window_weeks": [
+      2,
+      6
+    ],
+    "exit_criteria": [
+      "completes both weekly sessions consistently for 2 to 3 weeks",
+      "reports low friction and stable recovery after sessions",
+      "is ready for a more standard beginner or novice loading path"
     ]
   },
   {
@@ -1578,6 +1633,17 @@
       "low_fatigue",
       "mixed_friendly",
       "adherence_friendly"
+    ],
+    "program_role": "minimal_dose",
+    "transition_type": "durable",
+    "expected_use_window_weeks": [
+      8,
+      24
+    ],
+    "exit_criteria": [
+      "wants more weekly training volume or broader movement coverage",
+      "has enough recovery and schedule capacity for a fuller base template",
+      "is no longer using minimal dose as the primary adherence strategy"
     ]
   },
   {


### PR DESCRIPTION
## Summary

This PR adds explicit role, duration, and exit metadata to the most transition-oriented strength programs.

## What changed

Added these metadata fields where relevant:

- `program_role`
- `transition_type`
- `expected_use_window_weeks`
- `exit_criteria`

Updated these programs:

- `starter_strength_2x`
- `strength_full_body_3x_beginner`
- `starter_strength_gym_2x`
- `starter_strength_gym_3x`
- `reentry_strength_2x`
- `minimalist_strength_2x`

## Why

Some entry and transition-style programs were doing useful work, but their intended role was too implicit.

This PR makes it clearer:

- who the program is for
- whether it is temporary or durable
- how long it is typically meant to be used
- what signals suggest it is time to move on

## Design choice

This PR intentionally starts with the clearest transition-oriented strength templates rather than trying to annotate the entire program library at once.

It focuses on:

- starter programs
- re-entry programs
- minimal-dose programs

This creates a stronger internal contract for recommendation logic and future UI explanation.

## Validation

Scoped validation confirmed that all targeted programs now have:

- a valid `program_role`
- a valid `transition_type`
- a 2-value `expected_use_window_weeks`
- at least 3 exit criteria signals

## Scope

This PR does not yet add the same metadata to every base or advanced program.

It is a first metadata pass focused on the programs most likely to function as temporary or role-sensitive training paths.