### PR TITLE
Improve hybrid program honesty and completeness

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -1310,7 +1310,7 @@
     "id": "hybrid_run_strength_2x_beginner",
     "name": "Hybrid run + strength foundation (2 sessions/week)",
     "name_en": "Hybrid run + strength foundation (2 sessions/week)",
-    "kind": "run",
+    "kind": "mixed",
     "days": [
       {
         "label": "Day A",
@@ -1318,7 +1318,7 @@
           {
             "exercise_id": "run_easy",
             "sets": 1,
-            "reps": "20-25 min"
+            "reps": "20-30 min"
           }
         ]
       },
@@ -1326,9 +1326,19 @@
         "label": "Day B",
         "exercises": [
           {
-            "exercise_id": "run_intervals",
-            "sets": 1,
-            "reps": "5 x 1 min hurtigt / 1 min roligt"
+            "exercise_id": "squat",
+            "sets": 2,
+            "reps": "6-8"
+          },
+          {
+            "exercise_id": "incline_push_ups",
+            "sets": 2,
+            "reps": "6-10"
+          },
+          {
+            "exercise_id": "dumbbell_row",
+            "sets": 2,
+            "reps": "8/side"
           }
         ]
       }
@@ -1346,6 +1356,16 @@
     ],
     "equipment_profiles": [
       "hybrid_home"
+    ],
+    "training_style": "hybrid_run_first",
+    "program_family": "hybrid_run_strength",
+    "progression_model": "hybrid_beginner_balanced",
+    "tags": [
+      "hybrid",
+      "beginner",
+      "run_first",
+      "home",
+      "mixed_friendly"
     ]
   },
   {


### PR DESCRIPTION
## Summary

This PR improves hybrid program honesty by fixing the clearest mismatch between program naming and actual training content.

## What changed

Updated `hybrid_run_strength_2x_beginner`:

- changed `kind` from `run` to `mixed`
- changed Day B from a second run session to a real beginner strength session
- added explicit hybrid metadata:
  - `training_style: hybrid_run_first`
  - `program_family: hybrid_run_strength`
  - `progression_model: hybrid_beginner_balanced`
  - hybrid-oriented tags

## New structure

- Day A: `run_easy`
- Day B:
  - `squat`
  - `incline_push_ups`
  - `dumbbell_row`

## Why

Previously, this program was labeled as a hybrid run + strength foundation, but in practice it only contained running.

That made the program name misleading and weakened recommendation credibility.

This change turns it into a real run-first beginner hybrid with meaningful exposure to both domains.

## Design choice

This PR intentionally fixes the most obvious honesty problem first instead of redesigning every mixed-goal template at once.

It keeps the 2x version simple:

- one easy running day
- one compact full-body strength day

That makes it easier to explain and easier to trust.

## Validation

Scoped validation confirmed that:

- the program now has `kind = mixed`
- it contains both run exposure and strength exposure
- the updated exercise references are valid
- metadata and day structure now point in the same direction

## Scope

This PR does not yet redesign all programs that happen to support the `mixed` goal.

It focuses on the clearest mislabeled hybrid case.