### PR TITLE
Add progression depth to running programs beyond basic duration growth

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -246,7 +246,7 @@
           {
             "exercise_id": "run_intervals",
             "sets": 1,
-            "reps": "8 x 1 min hurtigt / 1 min roligt"
+            "reps": "6 x 2 min kontrolleret hurtigt / 1 min roligt"
           }
         ]
       },
@@ -256,7 +256,7 @@
           {
             "exercise_id": "run_easy",
             "sets": 1,
-            "reps": "30-40 min"
+            "reps": "35-45 min roligt"
           }
         ]
       }
@@ -277,6 +277,16 @@
     "equipment_profiles": [
       "run_only",
       "hybrid_home"
+    ],
+    "training_style": "base_run_progression",
+    "program_family": "base_run",
+    "progression_model": "duration_plus_quality",
+    "tags": [
+      "run",
+      "base",
+      "3x",
+      "aerobic",
+      "interval_progression"
     ]
   },
   {
@@ -1265,7 +1275,7 @@
           {
             "exercise_id": "run_intervals",
             "sets": 1,
-            "reps": "10 x 1 min hurtigt / 1 min roligt"
+            "reps": "5 x 3 min kontrolleret hurtigt / 90 sek roligt"
           }
         ]
       },
@@ -1275,7 +1285,7 @@
           {
             "exercise_id": "run_easy",
             "sets": 1,
-            "reps": "30-35 min"
+            "reps": "20-25 min meget roligt"
           }
         ]
       },
@@ -1285,7 +1295,7 @@
           {
             "exercise_id": "run_easy",
             "sets": 1,
-            "reps": "40-50 min"
+            "reps": "45-55 min roligt"
           }
         ]
       }
@@ -1304,6 +1314,17 @@
     "equipment_profiles": [
       "run_only",
       "hybrid_home"
+    ],
+    "training_style": "base_run_progression",
+    "program_family": "base_run",
+    "progression_model": "duration_plus_quality",
+    "tags": [
+      "run",
+      "base",
+      "4x",
+      "aerobic",
+      "interval_progression",
+      "long_run"
     ]
   },
   {


### PR DESCRIPTION
## Summary

This PR adds more progression depth to the base running programs so they develop beyond simple duration growth.

## What changed

Updated:

- `base_run_3x`
- `base_run_4x`

### Metadata
Added explicit running-structure metadata:

- `training_style: base_run_progression`
- `program_family: base_run`
- `progression_model: duration_plus_quality`
- run-specific tags

### Session refinement

#### `base_run_3x`
- Day B intervals:
  - from `8 x 1 min hurtigt / 1 min roligt`
  - to `6 x 2 min kontrolleret hurtigt / 1 min roligt`
- Day C:
  - from `30-40 min`
  - to `35-45 min roligt`

#### `base_run_4x`
- Day B intervals:
  - from `10 x 1 min hurtigt / 1 min roligt`
  - to `5 x 3 min kontrolleret hurtigt / 90 sek roligt`
- Day C:
  - from `30-35 min`
  - to `20-25 min meget roligt`
- Day D:
  - from `40-50 min`
  - to `45-55 min roligt`

## Why

The existing running programs were usable, but progression risked becoming too flat too quickly.

This PR gives the base run tracks:

- clearer session roles
- more meaningful interval development
- a more obvious long-run structure
- better progression depth without losing beginner usability

## Design choice

This PR intentionally leaves the simpler entry and re-entry programs alone.

It focuses on the base run templates, where progression depth matters more and where the library most needs stronger structure.

## Validation

Scoped validation confirmed that:

- `base_run_3x` and `base_run_4x` now have explicit progression metadata
- their updated session roles are reflected in the reps descriptions
- `starter_run_3x_beginner` and `reentry_run_2x` remain unchanged

## Scope

This PR does not introduce entirely new run session types such as tempo or strides yet.

It is a first pass that improves depth and role clarity within the current run session vocabulary.