### PR TITLE
Tighten recommendation logic so temporary programs do not become default long-term homes

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2698,6 +2698,13 @@ def infer_equipment_profile(user_settings):
     if not isinstance(available, dict):
         available = {}
 
+    if not available:
+        preferences = user_settings.get("preferences", {})
+        if isinstance(preferences, dict):
+            pref_equipment = preferences.get("equipment", {})
+            if isinstance(pref_equipment, dict):
+                available = pref_equipment
+
     has_barbell = bool(available.get("barbell"))
     has_bench = bool(available.get("bench"))
     has_dumbbell = bool(available.get("dumbbell"))
@@ -2739,6 +2746,8 @@ def _sort_strength_candidates(candidates, target_level, preferred_ids, strength_
         program_family = str(program.get("program_family", "")).strip().lower()
         fatigue_profile = str(program.get("fatigue_profile", "")).strip().lower()
         complexity = str(program.get("complexity", "")).strip().lower()
+        transition_type = str(program.get("transition_type", "")).strip().lower()
+        program_role = str(program.get("program_role", "")).strip().lower()
         sessions = program.get("supported_weekly_sessions", []) or []
 
         if starting_profile == "conservative_beginner":
@@ -2746,6 +2755,14 @@ def _sort_strength_candidates(candidates, target_level, preferred_ids, strength_
 
         if running_enabled:
             penalty += 0 if good_for_concurrent_running else 20
+
+        if transition_type == "temporary":
+            if starting_profile == "conservative_beginner":
+                penalty += 0
+            elif program_role == "reentry":
+                penalty += 18
+            else:
+                penalty += 10
 
         if target == "beginner":
             if training_style == "full_body_foundation":


### PR DESCRIPTION
## Summary

This PR tightens strength program recommendation behavior so temporary entry programs are less likely to become default long-term homes once better-fitting options are available.

## What changed

### 1. Temporary program penalty in strength candidate sorting
Updated `_sort_strength_candidates(...)` so strength programs marked as temporary are penalized in recommendation ranking.

Behavior:
- conservative beginner / re-entry situations are still protected
- temporary re-entry programs get a stronger penalty outside those situations
- other temporary starter-style programs get a smaller penalty

This helps the system move users toward more durable base templates when appropriate.

### 2. Equipment profile inference fix
Updated `infer_equipment_profile(...)` to also read equipment from:

- `preferences["equipment"]`

This matters because recommendation behavior was previously falling back to `minimal_home` in realistic settings payloads, which distorted candidate filtering and selection.

## Why

Program role metadata only matters if recommendation logic actually uses it.

Before this PR:
- temporary programs could remain overly sticky
- equipment inference could misclassify users and route them into weaker recommendations

This PR makes recommendation behavior better aligned with:
- actual equipment access
- temporary vs durable program intent
- more credible long-term progression

## Validation

Confirmed in targeted backend checks:

- conservative beginner, 2x, minimal home:
  - still selects `reentry_strength_2x`

- general beginner, 2x, minimal home:
  - selects `starter_strength_2x`

- novice, 2x, dumbbell home:
  - now correctly infers `dumbbell_home`
  - selects `base_strength_home_2x`

- beginner, 3x, gym basic:
  - now correctly infers `gym_basic`
  - selects `starter_strength_gym_3x`

## Scope

This PR focuses on strength recommendation logic.

It does not yet:
- use time-in-program directly
- use readiness consistency directly
- operationalize full exit criteria evaluation

It is a first pass that makes temporary program intent matter in real recommendation behavior.