### PR TITLE
Audit total weekly set balance across movement patterns

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -1830,7 +1830,7 @@
             "reps": "6-8"
           },
           {
-            "exercise_id": "barbell_row",
+            "exercise_id": "lat_pulldown",
             "sets": 4,
             "reps": "6-8"
           },
@@ -1969,7 +1969,7 @@
             "reps": "8-10"
           },
           {
-            "exercise_id": "barbell_row",
+            "exercise_id": "lat_pulldown",
             "sets": 4,
             "reps": "8-10"
           },


### PR DESCRIPTION
## Summary

This PR uses a first weekly set balance audit to correct an obvious structural underdosing issue in the intermediate gym 4x strength templates.

## Audit finding

A library-wide review of weekly movement-pattern set balance showed that these programs had:

- meaningful horizontal pull volume
- zero vertical pull volume

Affected programs:

- `intermediate_upper_lower_4x`
- `intermediate_hypertrophy_4x`

That made upper-body pull balance weaker than it should be for gym-based intermediate templates.

## What changed

Updated Day A in both programs:

- replaced `barbell_row` with `lat_pulldown`

## Why

The issue was not obvious from reading a single day in isolation, but the weekly set audit made it clear that vertical pulling was missing entirely in these templates.

This change creates a more balanced weekly pull profile by ensuring that both:

- horizontal pull
- vertical pull

are represented across the training week.

## Result

Both affected programs now move from:

- `horizontal_pull = 8`
- `vertical_pull = 0`

to:

- `horizontal_pull = 4`
- `vertical_pull = 4`

## Validation

Scoped validation confirmed that:

- both target programs now include `lat_pulldown` on Day A
- neither still contains `barbell_row` on Day A
- weekly pull balance is now less structurally skewed

## Scope

This PR does not complete the full movement-balance audit across the entire library.

It is a first targeted refinement based on the clearest audit finding in the intermediate gym 4x templates.