### PR TITLE
Surface program identity more clearly in UI and recommendation explanation

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2258,13 +2258,17 @@ function renderProfileEquipmentCard(){
     displayNameEl.textContent = username;
   }
 
-  const getProgramNameById = (programId) => {
+  const getProgramById = (programId) => {
     const id = String(programId || "").trim();
     if (!id) return null;
-    const found = Array.isArray(STATE.programs)
-      ? STATE.programs.find(program => String(program?.id || "").trim() === id)
+    return Array.isArray(STATE.programs)
+      ? (STATE.programs.find(program => String(program?.id || "").trim() === id) || null)
       : null;
-    return found ? getProgramDisplayName(found) : id;
+  };
+
+  const getProgramNameById = (programId) => {
+    const found = getProgramById(programId);
+    return found ? getProgramDisplayName(found) : (String(programId || "").trim() || null);
   };
 
   const recommendedStrengthProgramName = getProgramNameById(recommendedStrengthProgramId);
@@ -2356,17 +2360,21 @@ function renderProfileEquipmentCard(){
   const runTrainingEnabled = Boolean(trainingTypes.running);
 
   const activeProgramBits = [];
-  const activeStrengthProgramName = getProgramNameById(activeProgramsByDomain.strength);
+  const activeStrengthProgram = getProgramById(activeProgramsByDomain.strength);
+  const activeStrengthProgramName = activeStrengthProgram ? getProgramDisplayName(activeStrengthProgram) : getProgramNameById(activeProgramsByDomain.strength);
+  const activeStrengthIdentity = activeStrengthProgram ? getProgramIdentityLabel(activeStrengthProgram) : "";
   const activeStrengthSource = formatProgramSelectionSource(activeProgramStatusByDomain?.strength?.selection_source);
   if (strengthTrainingEnabled && activeStrengthProgramName){
     const strengthLabel = tr("profile.active_program_strength_value", { value: activeStrengthProgramName });
-    activeProgramBits.push([strengthLabel, activeStrengthSource].filter(Boolean).join(" · "));
+    activeProgramBits.push([strengthLabel, activeStrengthIdentity, activeStrengthSource].filter(Boolean).join(" · "));
   }
-  const activeEnduranceProgramName = getProgramNameById(activeProgramsByDomain.run);
+  const activeEnduranceProgram = getProgramById(activeProgramsByDomain.run);
+  const activeEnduranceProgramName = activeEnduranceProgram ? getProgramDisplayName(activeEnduranceProgram) : getProgramNameById(activeProgramsByDomain.run);
+  const activeEnduranceIdentity = activeEnduranceProgram ? getProgramIdentityLabel(activeEnduranceProgram) : "";
   const activeEnduranceSource = formatProgramSelectionSource(activeProgramStatusByDomain?.run?.selection_source);
   if (runTrainingEnabled && activeEnduranceProgramName){
     const enduranceLabel = tr("profile.active_program_endurance_value", { value: activeEnduranceProgramName });
-    activeProgramBits.push([enduranceLabel, activeEnduranceSource].filter(Boolean).join(" · "));
+    activeProgramBits.push([enduranceLabel, activeEnduranceIdentity, activeEnduranceSource].filter(Boolean).join(" · "));
   }
 
   const selectedTraining = [
@@ -6488,6 +6496,26 @@ function renderTodayPlan(item){
   renderSessionReview(item);
 }
 
+function getProgramIdentityLabel(program){
+  const item = program && typeof program === "object" ? program : {};
+  const role = String(item.program_role || "").trim().toLowerCase();
+  const style = String(item.training_style || "").trim().toLowerCase();
+  const kind = String(item.kind || "").trim().toLowerCase();
+
+  if (role === "reentry") return tr("program.identity_reentry");
+  if (role === "starter" && (kind === "strength" || kind === "styrke")) return tr("program.identity_beginner_entry");
+  if (role === "minimal_dose") return tr("program.identity_low_dose");
+
+  if (style === "hybrid_run_first") return tr("program.identity_run_first_hybrid");
+  if (style === "full_body_base") return tr("program.identity_base_builder");
+  if (style === "full_body_foundation") return tr("program.identity_foundation");
+  if (style === "upper_lower_split") return tr("program.identity_upper_lower");
+  if (style === "base_run_progression") return tr("program.identity_base_running");
+  if (style === "reentry_full_body") return tr("program.identity_reentry");
+
+  return "";
+}
+
 function renderPrograms(programs, exercises){
   const root = document.getElementById("programsRoot");
   const searchInput = document.getElementById("libraryProgramSearchInput");
@@ -6544,12 +6572,15 @@ function renderPrograms(programs, exercises){
     return;
   }
 
-  root.innerHTML = filteredPrograms.map(program => `
+  root.innerHTML = filteredPrograms.map(program => {
+    const identityLabel = getProgramIdentityLabel(program);
+    return `
     <div class="card" style="margin-top:12px; background:#141414">
       <div class="row">
         <h3>${esc(getProgramDisplayName(program) || "Program")}</h3>
         <span class="pill">${esc(getProgramKindDisplayLabel(program.kind || ""))}</span>
       </div>
+      ${identityLabel ? `<div class="small" style="margin-top:6px">${esc(identityLabel)}</div>` : ""}
       ${(program.days || []).map(day => `
         <div class="program-day">
           <strong>${esc(getProgramDayDisplayLabel(day))}</strong>
@@ -6571,7 +6602,8 @@ function renderPrograms(programs, exercises){
         </div>
       `).join("")}
     </div>
-  `).join("");
+  `;
+  }).join("");
 
   setText("programMeta", tr("common.items_count", { count: filteredPrograms.length }));
 }

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -796,5 +796,13 @@
   "library.program_search_label": "Søg i programmer",
   "library.program_search_placeholder": "Fx styrke, 3x eller squat",
   "library.program_search_empty": "Ingen programmer matcher din søgning.",
-  "wizard.library": "Bibliotek"
+  "wizard.library": "Bibliotek",
+  "program.identity_reentry": "Re-entry",
+  "program.identity_beginner_entry": "Begynderopstart",
+  "program.identity_low_dose": "Lav dosis",
+  "program.identity_run_first_hybrid": "Løbe-først hybrid",
+  "program.identity_base_builder": "Base builder",
+  "program.identity_foundation": "Grundforløb",
+  "program.identity_upper_lower": "Upper/lower split",
+  "program.identity_base_running": "Base løb"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -780,5 +780,13 @@
   "library.program_search_label": "Search programs",
   "library.program_search_placeholder": "For example strength, 3x or squat",
   "library.program_search_empty": "No programs match your search.",
-  "wizard.library": "Library"
+  "wizard.library": "Library",
+  "program.identity_reentry": "Re-entry",
+  "program.identity_beginner_entry": "Beginner entry",
+  "program.identity_low_dose": "Low dose",
+  "program.identity_run_first_hybrid": "Run-first hybrid",
+  "program.identity_base_builder": "Base builder",
+  "program.identity_foundation": "Foundation",
+  "program.identity_upper_lower": "Upper/lower split",
+  "program.identity_base_running": "Base running"
 }


### PR DESCRIPTION
## Summary

This PR surfaces program identity more clearly in the frontend so users can better understand what kind of program they are looking at or currently using.

## What changed

Added a frontend helper for short program identity labels based on existing program metadata such as:

- `program_role`
- `training_style`
- `kind`

Examples include labels such as:

- Beginner entry
- Re-entry
- Low dose
- Run-first hybrid
- Base builder
- Foundation
- Upper/lower split
- Base running

## UI updates

### Library
Program cards in the Library now show a short identity label under the program name when one is available.

### Profile / active programs
The active program summary in the profile card now includes the same identity label, alongside the existing selection-source explanation.

## Why

The program library has become more structured, but too much of that structure was still invisible to the user.

This change helps users understand:

- what kind of program they are seeing
- why similar-looking programs are not actually the same
- why recommendation changes over time may still make sense

## Design choice

This PR takes a calm-tech first step:

- short text labels
- no heavy badge system
- no extra backend logic
- no major layout changes

It makes program identity more visible without cluttering the interface.

## Validation

Checked that:

- frontend code parses successfully
- i18n files remain valid JSON
- identity labels are now available in both the library and active program summaries

## Scope

This PR does not yet expand recommendation cards or detailed switch explanations with full identity metadata.

It is a first UI pass focused on surfacing program identity in the most useful and least noisy places.