### PR TITLE
Refine upper-body movement balance in intermediate gym strength templates

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -1885,7 +1885,7 @@
             "reps": "10/side"
           },
           {
-            "exercise_id": "push_ups",
+            "exercise_id": "barbell_row",
             "sets": 3,
             "reps": "8-12"
           },
@@ -2024,7 +2024,7 @@
             "reps": "10/side"
           },
           {
-            "exercise_id": "push_ups",
+            "exercise_id": "barbell_row",
             "sets": 3,
             "reps": "10-15"
           },


### PR DESCRIPTION
## Summary

This PR refines upper-body movement balance in the intermediate gym 4x templates by reducing weekly push overrepresentation and increasing deliberate pull coverage.

## Background

A scoped weekly upper-body audit showed that these templates were still overly push-heavy even after the earlier vertical-pull refinement.

Before this change, both programs had weekly upper-body totals of:

- horizontal_push: 11
- vertical_push: 3
- horizontal_pull: 4
- vertical_pull: 4

That left the weekly upper-body structure more push-dominant than intended for intermediate gym templates.

## What changed

Updated Day C in:

- `intermediate_upper_lower_4x`
- `intermediate_hypertrophy_4x`

Change:
- replaced `push_ups` with `barbell_row`

## Why

The issue was no longer just missing vertical pulling.

After the previous refinement, the clearer remaining problem was total weekly push/pull balance.

This change improves the weekly structure by making Day C less push-heavy and more deliberately pull-supported, without increasing session length or adding unnecessary complexity.

## Result

Both affected programs now move from:

- horizontal_push: 11
- vertical_push: 3
- horizontal_pull: 4
- vertical_pull: 4

to:

- horizontal_push: 8
- vertical_push: 3
- horizontal_pull: 7
- vertical_pull: 4

## Design choice

This PR treats the intermediate templates as complete weekly structures rather than isolated daily swaps.

It keeps the templates readable and gym-realistic while improving overall upper-body balance.

## Validation

Scoped validation confirmed that:

- both target programs now include `barbell_row` on Day C
- neither still includes `push_ups` on Day C
- weekly upper-body balance is less push-heavy than before

## Scope

This PR focuses only on the two intermediate gym 4x templates.

It does not yet redesign every gym strength template or introduce different pull strategies for all equipment contexts.