### PR TITLE
Refine core frequency and accessory balance across short novice strength templates

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -1452,11 +1452,6 @@
             "exercise_id": "lunges",
             "sets": 3,
             "reps": "8/leg"
-          },
-          {
-            "exercise_id": "dead_bug",
-            "sets": 3,
-            "reps": "8/side"
           }
         ]
       }
@@ -1541,11 +1536,6 @@
             "exercise_id": "lunges",
             "sets": 3,
             "reps": "8/leg"
-          },
-          {
-            "exercise_id": "dead_bug",
-            "sets": 3,
-            "reps": "8/side"
           }
         ]
       },


### PR DESCRIPTION
## Summary

This PR refines core frequency in the clearest novice home base templates by removing accessory work that was taking up too much space relative to the session length and movement value.

## Background

A scoped review of short beginner and novice strength templates showed that the most obvious remaining accessory-heavy cases were:

- `base_strength_home_2x`
- `base_strength_home_3x`

Before this change:

- `base_strength_home_2x` had 2 core slots and 6 weekly core sets
- `base_strength_home_3x` had 3 core slots and 9 weekly core sets

That was high for short novice-oriented home templates that already had strong coverage of squat, hinge, push, and pull work.

## What changed

Removed `dead_bug` from Day B in:

- `base_strength_home_2x`
- `base_strength_home_3x`

## Why

This issue is not about removing core work entirely.

It is about reducing default accessory frequency where it crowds out training value in short sessions.

The remaining structure is more deliberate:

- `plank` remains as a simple stability marker
- `bird_dog` remains in the 3x variant as a small accessory finish
- Day B is now more focused on the main movements

## Result

### `base_strength_home_2x`
- core slots: 2 → 1
- weekly core sets: 6 → 3

### `base_strength_home_3x`
- core slots: 3 → 2
- weekly core sets: 9 → 6

## Design choice

This is a small, program-specific refinement rather than a blanket anti-core pass.

It preserves:
- beginner/novice clarity
- calm-tech simplicity
- some accessory presence where it still adds value

while making the novice home base templates feel more productive and less filler-heavy.

## Validation

Scoped validation confirmed that:

- both target templates no longer include `dead_bug` on Day B
- the remaining core frequency is lower and more deliberate
- the templates still retain a small amount of core work instead of removing it entirely

## Scope

This PR focuses only on the clearest novice home base cases.

It does not yet redesign all short strength templates or remove core work broadly across the library.