### PR TITLE
Expose home, no-equipment, mobility, and beginner-friendly training paths more clearly across setup, Library, and planning

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6496,6 +6496,48 @@ function renderTodayPlan(item){
   renderSessionReview(item);
 }
 
+function getProgramPathLabels(program){
+  const item = program && typeof program === "object" ? program : {};
+  const kind = String(item.kind || "").trim().toLowerCase();
+  const role = String(item.program_role || "").trim().toLowerCase();
+  const levels = Array.isArray(item.recommended_levels) ? item.recommended_levels.map(x => String(x || "").trim().toLowerCase()) : [];
+  const equipmentProfiles = Array.isArray(item.equipment_profiles) ? item.equipment_profiles.map(x => String(x || "").trim().toLowerCase()) : [];
+  const tags = Array.isArray(item.tags) ? item.tags.map(x => String(x || "").trim().toLowerCase()) : [];
+  const labels = [];
+
+  const add = (key) => {
+    const value = tr(key);
+    if (!value || value === key || labels.includes(value)) return;
+    labels.push(value);
+  };
+
+  if (kind === "mobility" || kind === "mobilitet") add("program.path_mobility");
+  if (kind === "recovery" || kind === "restitution" || kind === "rest") add("program.path_recovery");
+  if (kind === "hybrid" || kind === "mixed") add("program.path_hybrid");
+
+  if (equipmentProfiles.includes("minimal_home") || equipmentProfiles.includes("dumbbell_home") || equipmentProfiles.includes("hybrid_home") || tags.includes("home")) {
+    add("program.path_home_friendly");
+  }
+
+  if (equipmentProfiles.includes("minimal_home") || tags.includes("low_barrier") || tags.includes("minimalist")) {
+    add("program.path_low_equipment");
+  }
+
+  if (levels.includes("beginner") || role === "starter" || tags.includes("beginner")) {
+    add("program.path_beginner_friendly");
+  }
+
+  if (role === "reentry" || item.good_for_reentry === true || tags.includes("reentry")) {
+    add("program.path_reentry");
+  }
+
+  if (tags.includes("simple") || tags.includes("low_barrier") || role === "starter") {
+    add("program.path_simple_start");
+  }
+
+  return labels.slice(0, 4);
+}
+
 function getProgramIdentityLabel(program){
   const item = program && typeof program === "object" ? program : {};
   const role = String(item.program_role || "").trim().toLowerCase();
@@ -6574,6 +6616,7 @@ function renderPrograms(programs, exercises){
 
   root.innerHTML = filteredPrograms.map(program => {
     const identityLabel = getProgramIdentityLabel(program);
+    const pathLabels = getProgramPathLabels(program);
     return `
     <div class="card" style="margin-top:12px; background:#141414">
       <div class="row">
@@ -6581,6 +6624,7 @@ function renderPrograms(programs, exercises){
         <span class="pill">${esc(getProgramKindDisplayLabel(program.kind || ""))}</span>
       </div>
       ${identityLabel ? `<div class="small" style="margin-top:6px">${esc(identityLabel)}</div>` : ""}
+      ${pathLabels.length ? `<div class="row" style="gap:8px; margin-top:8px; flex-wrap:wrap;">${pathLabels.map(label => `<span class="pill">${esc(label)}</span>`).join("")}</div>` : ""}
       ${(program.days || []).map(day => `
         <div class="program-day">
           <strong>${esc(getProgramDayDisplayLabel(day))}</strong>

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -804,5 +804,13 @@
   "program.identity_base_builder": "Base builder",
   "program.identity_foundation": "Grundforløb",
   "program.identity_upper_lower": "Upper/lower split",
-  "program.identity_base_running": "Base løb"
+  "program.identity_base_running": "Base løb",
+  "program.path_home_friendly": "Hjemmevenlig",
+  "program.path_low_equipment": "Få redskaber",
+  "program.path_beginner_friendly": "Begyndervenlig",
+  "program.path_reentry": "Rolig genstart",
+  "program.path_mobility": "Mobilitet",
+  "program.path_recovery": "Restitution",
+  "program.path_hybrid": "Hybrid",
+  "program.path_simple_start": "Enkel opstart"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -788,5 +788,13 @@
   "program.identity_base_builder": "Base builder",
   "program.identity_foundation": "Foundation",
   "program.identity_upper_lower": "Upper/lower split",
-  "program.identity_base_running": "Base running"
+  "program.identity_base_running": "Base running",
+  "program.path_home_friendly": "Home-friendly",
+  "program.path_low_equipment": "Low equipment",
+  "program.path_beginner_friendly": "Beginner-friendly",
+  "program.path_reentry": "Gentle re-entry",
+  "program.path_mobility": "Mobility",
+  "program.path_recovery": "Recovery",
+  "program.path_hybrid": "Hybrid",
+  "program.path_simple_start": "Simple start"
 }


### PR DESCRIPTION
## Summary

This PR takes a first product-level step toward exposing home, low-equipment, mobility, and beginner-friendly training paths more clearly in SovereignStrength.

It focuses on Library visibility first.

## What changed

Added lightweight path labels to program cards in the Library so users can more quickly see when a program is:

- home-friendly
- low equipment
- beginner-friendly
- gentle re-entry
- mobility-oriented
- recovery-oriented
- hybrid
- a simple start

These labels are derived from existing program metadata such as:

- `kind`
- `program_role`
- `recommended_levels`
- `equipment_profiles`
- `good_for_reentry`
- `tags`

## Why

The system already supports multiple non-gym and lower-friction training paths, but too much of that support was still implicit.

That creates a product gap:

- home users may not immediately see that the app supports their reality
- beginner-friendly paths may still feel hidden
- mobility and recovery may appear secondary rather than intentional
- simple starting options may be technically present without being easy to recognize

This PR improves that visibility where users already browse programs.

## Design choice

This is a calm-tech first pass:

- no heavy filtering system
- no major layout change
- no backend changes
- no noisy badge explosion

It adds small, readable path labels to existing Library cards using metadata that already exists.

## Validation

Checked that:

- frontend code parses successfully
- i18n files remain valid JSON
- Library program cards now surface more visible product paths using existing metadata

## Scope

This PR covers Library visibility only.

It does not yet fully address:
- setup/onboarding exposure
- planning-surface phrasing
- broader UI treatment across all path-sensitive screens

Those can continue as follow-up work under the same broader issue.