### PR TITLE
Add user-facing strength journeys and clearer strength program identities

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2420,8 +2420,11 @@ function renderProfileEquipmentCard(){
     activeProgramsLineEl.style.display = activeProgramBits.length ? "none" : "";
   }
 
+  const strengthJourney = strengthTrainingEnabled && activeStrengthProgram
+    ? getStrengthJourneyCopy(activeStrengthProgram)
+    : "";
   const strengthWhy = strengthTrainingEnabled && activeStrengthProgramName
-    ? buildProgramWhyReason("strength")
+    ? [strengthJourney, buildProgramWhyReason("strength")].filter(Boolean).join(" ")
     : "";
   const runWhy = runTrainingEnabled && activeEnduranceProgramName
     ? buildProgramWhyReason("run")
@@ -6494,6 +6497,26 @@ function renderTodayPlan(item){
 
   renderReviewSummary(item);
   renderSessionReview(item);
+}
+
+function getStrengthJourneyCopy(program){
+  const item = program && typeof program === "object" ? program : {};
+  const role = String(item.program_role || "").trim().toLowerCase();
+  const style = String(item.training_style || "").trim().toLowerCase();
+  const tags = Array.isArray(item.tags) ? item.tags.map(x => String(x || "").trim().toLowerCase()) : [];
+  const equipmentProfiles = Array.isArray(item.equipment_profiles) ? item.equipment_profiles.map(x => String(x || "").trim().toLowerCase()) : [];
+
+  if (role === "reentry") return tr("strength_journey.reentry");
+  if (role === "minimal_dose") return tr("strength_journey.minimal_dose");
+  if (role === "starter" && equipmentProfiles.includes("minimal_home")) return tr("strength_journey.beginner_home");
+  if (role === "starter" && equipmentProfiles.includes("dumbbell_home")) return tr("strength_journey.beginner_home");
+  if (role === "starter" && (equipmentProfiles.includes("gym_basic") || equipmentProfiles.includes("full_gym"))) return tr("strength_journey.beginner_gym");
+  if (style === "full_body_base" && equipmentProfiles.includes("dumbbell_home")) return tr("strength_journey.base_home");
+  if (style === "full_body_base" && (equipmentProfiles.includes("gym_basic") || equipmentProfiles.includes("full_gym"))) return tr("strength_journey.base_gym");
+  if (style === "upper_lower_split") return tr("strength_journey.upper_lower");
+  if (style === "hybrid_run_first" || tags.includes("run_first")) return tr("strength_journey.hybrid_support");
+
+  return "";
 }
 
 function getProgramPathLabels(program){

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -812,5 +812,13 @@
   "program.path_mobility": "Mobilitet",
   "program.path_recovery": "Restitution",
   "program.path_hybrid": "Hybrid",
-  "program.path_simple_start": "Enkel opstart"
+  "program.path_simple_start": "Enkel opstart",
+  "strength_journey.reentry": "En rolig styrkevej tilbage med lavere friktion og fokus på at komme stabilt i gang.",
+  "strength_journey.minimal_dose": "En kort og enkel styrkevej, der prioriterer vedholdenhed og lav friktion.",
+  "strength_journey.beginner_home": "En begyndervenlig full-body styrkevej til hjemmet med enkel struktur og tydelige basisbevægelser.",
+  "strength_journey.beginner_gym": "En begyndervenlig styrkevej i gym med en enkel base af squat, pres og træk.",
+  "strength_journey.base_home": "En hjemmebaseret basevej for styrke med mere progression og lidt mere samlet træningsarbejde.",
+  "strength_journey.base_gym": "En basevej for styrke i gym med fokus på stabile basisløft og tydelig progression.",
+  "strength_journey.upper_lower": "En mere struktureret upper/lower styrkevej med højere frekvens og tydeligere ugerytme.",
+  "strength_journey.hybrid_support": "En styrkevej, der skal støtte et hybridforløb uden at tage hele fokus fra løb eller blandet træning."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -796,5 +796,13 @@
   "program.path_mobility": "Mobility",
   "program.path_recovery": "Recovery",
   "program.path_hybrid": "Hybrid",
-  "program.path_simple_start": "Simple start"
+  "program.path_simple_start": "Simple start",
+  "strength_journey.reentry": "A gentle return-to-strength path with lower friction and a focus on getting started consistently.",
+  "strength_journey.minimal_dose": "A short and simple strength path that prioritizes adherence and low friction.",
+  "strength_journey.beginner_home": "A beginner-friendly full-body strength path for home training with simple structure and clear main movements.",
+  "strength_journey.beginner_gym": "A beginner-friendly gym strength path built around a simple base of squat, press, and pull.",
+  "strength_journey.base_home": "A home-based base strength path with more progression and slightly more total training work.",
+  "strength_journey.base_gym": "A base gym strength path focused on stable main lifts and clear progression.",
+  "strength_journey.upper_lower": "A more structured upper/lower strength path with higher frequency and a clearer weekly rhythm.",
+  "strength_journey.hybrid_support": "A strength path meant to support a hybrid setup without taking all the focus away from running or mixed training."
 }


### PR DESCRIPTION
## Summary

This PR adds a first user-facing strength journey layer to the frontend so active strength programs feel more understandable as product paths, not only as internally selected templates.

## What changed

Added a frontend helper that derives short strength journey copy from existing program metadata such as:

- `program_role`
- `training_style`
- `equipment_profiles`
- `tags`

Examples include journey framing such as:

- gentle re-entry
- minimal-dose strength
- beginner home strength
- beginner gym strength
- base home strength
- base gym strength
- upper/lower strength
- hybrid support strength

## UI update

### Profile / active strength program
The active strength program card now includes this journey framing as part of the existing explanatory text.

That means the user now sees not only:
- which strength program is active
- why it was selected

but also:
- what kind of strength path it represents

## Why

SovereignStrength has become stronger at internal program selection, but strength structure was still too invisible at the user-facing product layer.

This change improves clarity by helping users understand:

- what sort of strength path they are on
- what that path is for
- how it fits their context
- why it differs from other possible strength structures

## Design choice

This is a calm-tech first pass:

- no backend changes
- no giant catalog language
- no bodybuilding split encyclopedia
- no heavy new UI section

It builds on existing metadata and the current profile explanation surface.

## Validation

Checked that:

- frontend code parses successfully
- i18n files remain valid JSON
- active strength program explanations now include user-facing journey copy

## Scope

This PR focuses on the active strength program surface in the profile card.

It does not yet extend the same strength journey language across every planning and recommendation surface.