### PR TITLE
Add user-facing running journeys for beginner return-to-running, 5K, 10K, and half marathon goals

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2426,8 +2426,11 @@ function renderProfileEquipmentCard(){
   const strengthWhy = strengthTrainingEnabled && activeStrengthProgramName
     ? [strengthJourney, buildProgramWhyReason("strength")].filter(Boolean).join(" ")
     : "";
+  const runningJourney = runTrainingEnabled && activeEnduranceProgram
+    ? getRunningJourneyCopy(activeEnduranceProgram)
+    : "";
   const runWhy = runTrainingEnabled && activeEnduranceProgramName
-    ? buildProgramWhyReason("run")
+    ? [runningJourney, buildProgramWhyReason("run")].filter(Boolean).join(" ")
     : "";
 
   if (profileStrengthProgramSummaryEl){
@@ -6497,6 +6500,24 @@ function renderTodayPlan(item){
 
   renderReviewSummary(item);
   renderSessionReview(item);
+}
+
+function getRunningJourneyCopy(program){
+  const item = program && typeof program === "object" ? program : {};
+  const pid = String(item.id || "").trim().toLowerCase();
+  const kind = String(item.kind || "").trim().toLowerCase();
+  const style = String(item.training_style || "").trim().toLowerCase();
+  const family = String(item.program_family || "").trim().toLowerCase();
+  const tags = Array.isArray(item.tags) ? item.tags.map(x => String(x || "").trim().toLowerCase()) : [];
+  const sessions = Array.isArray(item.supported_weekly_sessions) ? item.supported_weekly_sessions.map(x => Number(x) || 0) : [];
+
+  if (pid === "reentry_run_2x") return tr("running_journey.reentry");
+  if (pid === "starter_run_2x" || pid === "starter_run_3x_beginner") return tr("running_journey.beginner_start");
+  if ((family === "base_run" || style === "base_run_progression") && sessions.includes(3)) return tr("running_journey.base_5k_10k");
+  if ((family === "base_run" || style === "base_run_progression") && sessions.includes(4)) return tr("running_journey.base_10k_half");
+  if (kind === "hybrid" || kind === "mixed" || style === "hybrid_run_first" || tags.includes("hybrid")) return tr("running_journey.hybrid");
+
+  return "";
 }
 
 function getStrengthJourneyCopy(program){

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -820,5 +820,10 @@
   "strength_journey.base_home": "En hjemmebaseret basevej for styrke med mere progression og lidt mere samlet træningsarbejde.",
   "strength_journey.base_gym": "En basevej for styrke i gym med fokus på stabile basisløft og tydelig progression.",
   "strength_journey.upper_lower": "En mere struktureret upper/lower styrkevej med højere frekvens og tydeligere ugerytme.",
-  "strength_journey.hybrid_support": "En styrkevej, der skal støtte et hybridforløb uden at tage hele fokus fra løb eller blandet træning."
+  "strength_journey.hybrid_support": "En styrkevej, der skal støtte et hybridforløb uden at tage hele fokus fra løb eller blandet træning.",
+  "running_journey.reentry": "En rolig vej tilbage til løb med lavere belastning og plads til at bygge rytmen op igen.",
+  "running_journey.beginner_start": "En begyndervenlig løbeopstart med overskuelig frekvens og tydelig vej ind i regelmæssig løbetræning.",
+  "running_journey.base_5k_10k": "En løbebase med nok struktur til at pege mod 5K og 10K uden at blive stiv eller overteknisk.",
+  "running_journey.base_10k_half": "En mere udvidet løbebase med plads til længere ture og progression mod 10K eller halvmaraton-base.",
+  "running_journey.hybrid": "En hybrid løbevej, hvor løb og styrke er tænkt sammen i stedet for at konkurrere om al pladsen."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -804,5 +804,10 @@
   "strength_journey.base_home": "A home-based base strength path with more progression and slightly more total training work.",
   "strength_journey.base_gym": "A base gym strength path focused on stable main lifts and clear progression.",
   "strength_journey.upper_lower": "A more structured upper/lower strength path with higher frequency and a clearer weekly rhythm.",
-  "strength_journey.hybrid_support": "A strength path meant to support a hybrid setup without taking all the focus away from running or mixed training."
+  "strength_journey.hybrid_support": "A strength path meant to support a hybrid setup without taking all the focus away from running or mixed training.",
+  "running_journey.reentry": "A gentle return-to-running path with lower load and room to build consistency again.",
+  "running_journey.beginner_start": "A beginner-friendly running start with manageable frequency and a clear path into regular running.",
+  "running_journey.base_5k_10k": "A running base with enough structure to point toward 5K and 10K without becoming rigid or overcomplicated.",
+  "running_journey.base_10k_half": "A more extended running base with room for longer sessions and progression toward 10K or half marathon base work.",
+  "running_journey.hybrid": "A hybrid running path where running and strength are meant to work together instead of competing for all the space."
 }


### PR DESCRIPTION
## Summary

This PR adds a first user-facing running journey layer to the frontend so active running programs feel more understandable as product paths, not only as internally selected templates.

## What changed

Added a frontend helper that derives short running journey copy from existing program metadata such as:

- `id`
- `kind`
- `training_style`
- `program_family`
- `supported_weekly_sessions`
- `tags`

Examples include journey framing such as:

- gentle return to running
- beginner running start
- base toward 5K / 10K
- extended base toward 10K / half marathon
- hybrid running + strength

## UI update

### Profile / active running program
The active running program card now includes this journey framing as part of the existing explanatory text.

That means the user now sees not only:
- which running program is active
- why it was selected

but also:
- what kind of running path it represents

## Why

SovereignStrength is becoming stronger at internal running selection and adaptive planning, but the runner-facing product layer was still too invisible.

This change improves clarity by helping users understand:

- what kind of running path they are on
- what that path is trying to do
- how it fits their current level and training context
- why different running structures exist in the product

## Design choice

This is a calm-tech first pass:

- no backend changes
- no rigid race calendar engine
- no giant running-app feature set
- no heavy new UI section

It builds on existing metadata and the current profile explanation surface.

## Validation

Checked that:

- frontend code parses successfully
- i18n files remain valid JSON
- active running program explanations now include user-facing journey copy

## Scope

This PR focuses on the active running program surface in the profile card.

It does not yet extend the same running journey language across setup, recommendation cards, or all planning surfaces.