### PR TITLE
Add reusable manual workout templates and faster workout logging for self-directed training

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -666,6 +666,108 @@ function resetEntryInputs(form){
   applyEntryInputMode("");
 }
 
+const MANUAL_TEMPLATE_STORAGE_KEY = "ss_manual_workout_templates";
+
+function readManualWorkoutTemplates(){
+  try{
+    const raw = localStorage.getItem(MANUAL_TEMPLATE_STORAGE_KEY);
+    if (!raw) return [];
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data)) return [];
+    return data.filter(item =>
+      item &&
+      typeof item === "object" &&
+      String(item.name || "").trim() &&
+      Array.isArray(item.entries)
+    );
+  }catch(err){
+    console.error(err);
+    return [];
+  }
+}
+
+function writeManualWorkoutTemplates(items){
+  const clean = Array.isArray(items) ? items : [];
+  localStorage.setItem(MANUAL_TEMPLATE_STORAGE_KEY, JSON.stringify(clean));
+}
+
+function renderManualTemplateOptions(){
+  const selectEl = document.getElementById("manualTemplateSelect");
+  if (!selectEl) return;
+
+  const templates = readManualWorkoutTemplates();
+  const options = [
+    `<option value="">${esc(tr("manual_template.none_saved"))}</option>`,
+    ...templates.map(item => `<option value="${esc(String(item.id || ""))}">${esc(String(item.name || "").trim())}</option>`)
+  ];
+  selectEl.innerHTML = options.join("");
+}
+
+function handleSaveManualTemplate(){
+  const statusEl = document.getElementById("manualTemplateStatus");
+  if (!Array.isArray(STATE.pendingEntries) || STATE.pendingEntries.length === 0){
+    setText("manualTemplateStatus", tr("manual_template.save_requires_entries"));
+    statusEl?.classList.add("warn");
+    return;
+  }
+
+  const rawName = window.prompt(tr("manual_template.prompt_name"), "");
+  const name = String(rawName || "").trim();
+  if (!name){
+    setText("manualTemplateStatus", tr("manual_template.save_cancelled"));
+    statusEl?.classList.remove("warn");
+    return;
+  }
+
+  const templates = readManualWorkoutTemplates();
+  const item = {
+    id: `tpl_${Date.now()}`,
+    name,
+    entries: JSON.parse(JSON.stringify(STATE.pendingEntries))
+  };
+
+  templates.push(item);
+  writeManualWorkoutTemplates(templates);
+  renderManualTemplateOptions();
+  const selectEl = document.getElementById("manualTemplateSelect");
+  if (selectEl) selectEl.value = item.id;
+
+  statusEl?.classList.remove("warn");
+  setText("manualTemplateStatus", tr("manual_template.saved", { name }));
+}
+
+function handleLoadManualTemplate(){
+  const selectEl = document.getElementById("manualTemplateSelect");
+  const statusEl = document.getElementById("manualTemplateStatus");
+  const templateId = String(selectEl?.value || "").trim();
+
+  if (!templateId){
+    setText("manualTemplateStatus", tr("manual_template.select_first"));
+    statusEl?.classList.add("warn");
+    return;
+  }
+
+  const templates = readManualWorkoutTemplates();
+  const found = templates.find(item => String(item.id || "").trim() === templateId);
+  if (!found){
+    setText("manualTemplateStatus", tr("manual_template.not_found"));
+    statusEl?.classList.add("warn");
+    return;
+  }
+
+  STATE.pendingEntries = JSON.parse(JSON.stringify(Array.isArray(found.entries) ? found.entries : []));
+  renderPendingEntries();
+
+  const form = document.getElementById("workoutForm");
+  if (form){
+    resetEntryInputs(form);
+    setText("progressionHint", tr("workout.no_load_suggestion"));
+  }
+
+  statusEl?.classList.remove("warn");
+  setText("manualTemplateStatus", tr("manual_template.loaded", { name: found.name }));
+}
+
 function renderPendingEntries(){
   const root = document.getElementById("pendingEntriesList");
   if (!root) return;
@@ -6799,6 +6901,7 @@ STATE.workouts = Array.isArray(workoutsApi && workoutsApi.items) ? workoutsApi.i
     renderTodayPlan(todayPlanApi.item || null);
   renderPrograms(STATE.programs, STATE.exercises);
   renderLibraryTabs();
+  renderManualTemplateOptions();
   renderPendingEntries();
 
   const dailyUiState = deriveDailyUiState(todayPlanApi.item || null, latestRecoveryApi.item || null, sessionResultsApi.items || []);
@@ -7970,6 +8073,8 @@ async function boot(){
     document.getElementById("addEntryBtn")?.addEventListener("click", handleAddEntry);
     document.getElementById("clearEntriesBtn")?.addEventListener("click", handleClearEntries);
     document.getElementById("loadProgramDayBtn")?.addEventListener("click", handleLoadProgramDay);
+    document.getElementById("saveManualTemplateBtn")?.addEventListener("click", handleSaveManualTemplate);
+    document.getElementById("loadManualTemplateBtn")?.addEventListener("click", handleLoadManualTemplate);
     document.getElementById("program_id")?.addEventListener("change", refreshProgramDaySelect);
     document.getElementById("entry_exercise_id")?.addEventListener("change", handleExerciseChange);
     mountEquipmentEditorInline();

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -825,5 +825,18 @@
   "running_journey.beginner_start": "En begyndervenlig løbeopstart med overskuelig frekvens og tydelig vej ind i regelmæssig løbetræning.",
   "running_journey.base_5k_10k": "En løbebase med nok struktur til at pege mod 5K og 10K uden at blive stiv eller overteknisk.",
   "running_journey.base_10k_half": "En mere udvidet løbebase med plads til længere ture og progression mod 10K eller halvmaraton-base.",
-  "running_journey.hybrid": "En hybrid løbevej, hvor løb og styrke er tænkt sammen i stedet for at konkurrere om al pladsen."
+  "running_journey.hybrid": "En hybrid løbevej, hvor løb og styrke er tænkt sammen i stedet for at konkurrere om al pladsen.",
+  "manual_template.title": "Manuelle templates",
+  "manual_template.select_label": "Vælg template",
+  "manual_template.none_saved": "Ingen gemte templates",
+  "manual_template.save_btn": "Gem som template",
+  "manual_template.load_btn": "Indlæs template",
+  "manual_template.status_ready": "Klar.",
+  "manual_template.prompt_name": "Navn på template",
+  "manual_template.save_requires_entries": "Tilføj mindst én øvelse før du gemmer en template.",
+  "manual_template.save_cancelled": "Template blev ikke gemt.",
+  "manual_template.saved": "Template gemt: {name}",
+  "manual_template.select_first": "Vælg en template først.",
+  "manual_template.not_found": "Template blev ikke fundet.",
+  "manual_template.loaded": "Template indlæst: {name}"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -809,5 +809,18 @@
   "running_journey.beginner_start": "A beginner-friendly running start with manageable frequency and a clear path into regular running.",
   "running_journey.base_5k_10k": "A running base with enough structure to point toward 5K and 10K without becoming rigid or overcomplicated.",
   "running_journey.base_10k_half": "A more extended running base with room for longer sessions and progression toward 10K or half marathon base work.",
-  "running_journey.hybrid": "A hybrid running path where running and strength are meant to work together instead of competing for all the space."
+  "running_journey.hybrid": "A hybrid running path where running and strength are meant to work together instead of competing for all the space.",
+  "manual_template.title": "Manual templates",
+  "manual_template.select_label": "Choose template",
+  "manual_template.none_saved": "No saved templates",
+  "manual_template.save_btn": "Save as template",
+  "manual_template.load_btn": "Load template",
+  "manual_template.status_ready": "Ready.",
+  "manual_template.prompt_name": "Template name",
+  "manual_template.save_requires_entries": "Add at least one exercise before saving a template.",
+  "manual_template.save_cancelled": "Template was not saved.",
+  "manual_template.saved": "Template saved: {name}",
+  "manual_template.select_first": "Choose a template first.",
+  "manual_template.not_found": "Template was not found.",
+  "manual_template.loaded": "Template loaded: {name}"
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -801,6 +801,21 @@
             <button type="button" id="clearEntriesBtn" data-i18n="button.clear_exercises">Ryd øvelser</button>
           </div>
 
+          <div class="card" style="margin-top:12px; padding:12px">
+            <div class="small" data-i18n="manual_template.title">Manuelle templates</div>
+            <label style="margin-top:8px">
+              <span data-i18n="manual_template.select_label">Vælg template</span>
+              <select id="manualTemplateSelect">
+                <option value="" data-i18n="manual_template.none_saved">Ingen gemte templates</option>
+              </select>
+            </label>
+            <div class="btn-row" style="margin-top:10px">
+              <button type="button" id="saveManualTemplateBtn" data-i18n="manual_template.save_btn">Gem som template</button>
+              <button type="button" id="loadManualTemplateBtn" data-i18n="manual_template.load_btn">Indlæs template</button>
+            </div>
+            <p id="manualTemplateStatus" class="small" data-i18n="manual_template.status_ready">Klar.</p>
+          </div>
+
           <p id="entryStatus" class="small" data-i18n="entry.none_added_yet">Ingen øvelser tilføjet endnu.</p>
           <ul id="pendingEntriesList"></ul>
         </div>


### PR DESCRIPTION
## Summary

This PR adds a first reusable manual workout template layer so self-directed users can save and reload familiar session structures instead of rebuilding the same manual workout from scratch each time.

## What changed

### Manual workout templates
Added a local-first template flow to the manual workout section.

Users can now:

- save the current pending workout entries as a reusable template
- choose from previously saved manual templates
- load a saved template back into the pending entries list

### UI updates
Added a small template section inside the manual workout area with:

- template select
- save as template button
- load template button
- template status feedback

### Data model
This first pass reuses the existing manual workout entry structure already used by `STATE.pendingEntries`.

Templates store copies of entries shaped like:

- `exercise_id`
- `sets`
- `reps`
- `achieved_reps`
- `load`
- `notes`

No separate workout-planning engine or backend template model was introduced.

## Why

Manual training should feel like a real supported path, not only a fallback around the adaptive planner.

Before this PR, a self-directed user had to rebuild familiar sessions repeatedly even when the workout structure was basically the same every time.

This change improves:

- reuse
- speed
- continuity
- credibility for self-directed training

## Design choice

This is an intentionally small first pass:

- localStorage only
- no backend template persistence yet
- no template sharing
- no full custom planning engine
- no advanced editing workflow yet

The goal is to validate reusable manual sessions using the existing pending-entry flow instead of introducing a parallel workout system.

## Validation

Checked that:

- the manual workout UI now includes template controls
- templates can be saved from existing pending entries
- templates can be loaded back into pending entries
- i18n files remain valid JSON

## Scope

Included:
- save manual template
- load manual template
- local-first template storage
- reuse of existing manual workout entry model

Not yet included:
- rename/delete template management
- backend persistence for templates
- template history integration
- advanced editing/versioning of templates