### PR TITLE
Add persistent custom workouts to support saved reusable sessions

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -155,6 +155,7 @@ DATA_DIR = Path("/var/www/sovereign-strength/data")
 
 FILES = {
     "workouts": DATA_DIR / "workouts.json",
+    "custom_workouts": DATA_DIR / "custom_workouts.json",
     "runs": DATA_DIR / "runs.json",
     "recovery": DATA_DIR / "recovery.json",
     "checkins": DATA_DIR / "checkins.json",
@@ -318,6 +319,9 @@ def consume_manual_override_workout(user_id, date):
 
 def list_workouts_for_user(user_id):
     return list_user_items("workouts", user_id)
+
+def list_custom_workouts_for_user(user_id):
+    return list_user_items("custom_workouts", user_id)
 
 def make_error_payload(error, message, **extra):
     payload = {
@@ -533,6 +537,64 @@ def create_workout(user_id, payload):
     }
 
     item, count = append_user_item("workouts", item)
+    return item, None, count
+
+def create_custom_workout(user_id, payload):
+    if not isinstance(payload, dict):
+        return None, make_error_payload("invalid_payload", "ugyldig payload"), 400
+
+    name = str(payload.get("name", "")).strip()
+    session_type = str(payload.get("session_type", "styrke") or "styrke").strip().lower()
+    notes = str(payload.get("notes", "")).strip()
+    raw_entries = payload.get("entries", [])
+
+    if not name:
+        return None, make_error_payload("missing_name", "name mangler", field="name"), 400
+
+    if session_type not in {"styrke", "strength", "løb", "run", "mobilitet", "mobility", "andet", "other"}:
+        return None, make_error_payload("invalid_session_type", "ugyldig session_type", field="session_type"), 400
+
+    if not isinstance(raw_entries, list):
+        return None, make_error_payload("invalid_entries", "entries skal være en liste", field="entries"), 400
+
+    clean_entries = []
+    for entry in raw_entries:
+        if not isinstance(entry, dict):
+            continue
+
+        exercise_id = str(entry.get("exercise_id", "")).strip()
+        sets = str(entry.get("sets", "")).strip()
+        reps = str(entry.get("reps", "")).strip()
+        achieved_reps = str(entry.get("achieved_reps", "")).strip()
+        load = str(entry.get("load", "")).strip()
+        entry_notes = str(entry.get("notes", "")).strip()
+
+        if not exercise_id:
+            continue
+
+        clean_entries.append({
+            "exercise_id": exercise_id,
+            "sets": sets,
+            "reps": reps,
+            "achieved_reps": achieved_reps,
+            "load": load,
+            "notes": entry_notes,
+        })
+
+    if not clean_entries:
+        return None, make_error_payload("empty_custom_workout", "ingen øvelser at gemme"), 400
+
+    item = {
+        "id": str(uuid.uuid4()),
+        "user_id": user_id,
+        "name": name,
+        "session_type": session_type,
+        "notes": notes,
+        "entries": clean_entries,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    item, count = append_user_item("custom_workouts", item)
     return item, None, count
 
 def list_checkins_for_user(user_id):
@@ -7859,6 +7921,29 @@ def post_workouts():
         return auth_err
 
     item, err_payload, third = create_workout(auth_user.get("user_id"), request.get_json(silent=True) or {})
+    if err_payload is not None:
+        payload, status = ensure_error_contract(err_payload, third)
+        return jsonify(payload), status
+
+    return jsonify({"ok": True, "item": item, "count": third}), 201
+
+@app.get("/api/custom-workouts")
+def get_custom_workouts():
+    auth_user, auth_err = require_auth_user()
+    if auth_err:
+        log_auth_failure("custom-workouts:get", auth_err)
+        return auth_err
+    items = list_custom_workouts_for_user(auth_user.get("user_id"))
+    return jsonify({"ok": True, "items": items})
+
+@app.post("/api/custom-workouts")
+def post_custom_workouts():
+    auth_user, auth_err = require_auth_user()
+    if auth_err:
+        log_auth_failure("custom-workouts:post", auth_err)
+        return auth_err
+
+    item, err_payload, third = create_custom_workout(auth_user.get("user_id"), request.get_json(silent=True) or {})
     if err_payload is not None:
         payload, status = ensure_error_contract(err_payload, third)
         return jsonify(payload), status

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -14,6 +14,7 @@ let STATE = {
   programs: [],
   userSettings: {},
   pendingEntries: [],
+  customWorkouts: [],
   workouts: [],
   sessionResults: [],
   recoveryHistory: [],
@@ -689,6 +690,101 @@ function readManualWorkoutTemplates(){
 function writeManualWorkoutTemplates(items){
   const clean = Array.isArray(items) ? items : [];
   localStorage.setItem(MANUAL_TEMPLATE_STORAGE_KEY, JSON.stringify(clean));
+}
+
+function renderCustomWorkoutOptions(){
+  const selectEl = document.getElementById("customWorkoutSelect");
+  if (!selectEl) return;
+
+  const items = Array.isArray(STATE.customWorkouts) ? STATE.customWorkouts : [];
+  const options = [
+    `<option value="">${esc(tr("custom_workout.none_saved"))}</option>`,
+    ...items.map(item => `<option value="${esc(String(item.id || ""))}">${esc(String(item.name || "").trim())}</option>`)
+  ];
+  selectEl.innerHTML = options.join("");
+}
+
+async function handleSaveCustomWorkout(){
+  const statusEl = document.getElementById("customWorkoutStatus");
+
+  if (!Array.isArray(STATE.pendingEntries) || STATE.pendingEntries.length === 0){
+    setText("customWorkoutStatus", tr("custom_workout.save_requires_entries"));
+    statusEl?.classList.add("warn");
+    return;
+  }
+
+  const rawName = window.prompt(tr("custom_workout.prompt_name"), "");
+  const name = String(rawName || "").trim();
+  if (!name){
+    setText("customWorkoutStatus", tr("custom_workout.save_cancelled"));
+    statusEl?.classList.remove("warn");
+    return;
+  }
+
+  try{
+    const form = document.getElementById("workoutForm");
+    const sessionType = String(form?.type?.value || "styrke").trim().toLowerCase();
+    const notes = String(form?.notes?.value || "").trim();
+
+    const res = await apiPost("/api/custom-workouts", {
+      name,
+      session_type: sessionType,
+      notes,
+      entries: STATE.pendingEntries,
+    });
+
+    const item = res && res.item && typeof res.item === "object" ? res.item : null;
+    if (!item){
+      throw new Error("missing custom workout item");
+    }
+
+    STATE.customWorkouts = [item, ...(Array.isArray(STATE.customWorkouts) ? STATE.customWorkouts : [])];
+    renderCustomWorkoutOptions();
+
+    const selectEl = document.getElementById("customWorkoutSelect");
+    if (selectEl) selectEl.value = String(item.id || "");
+
+    statusEl?.classList.remove("warn");
+    setText("customWorkoutStatus", tr("custom_workout.saved", { name }));
+  }catch(err){
+    statusEl?.classList.add("warn");
+    setText("customWorkoutStatus", tr("status.error_prefix") + (err?.message || String(err)));
+  }
+}
+
+function handleLoadCustomWorkout(){
+  const selectEl = document.getElementById("customWorkoutSelect");
+  const statusEl = document.getElementById("customWorkoutStatus");
+  const workoutId = String(selectEl?.value || "").trim();
+
+  if (!workoutId){
+    setText("customWorkoutStatus", tr("custom_workout.select_first"));
+    statusEl?.classList.add("warn");
+    return;
+  }
+
+  const items = Array.isArray(STATE.customWorkouts) ? STATE.customWorkouts : [];
+  const found = items.find(item => String(item.id || "").trim() === workoutId);
+
+  if (!found){
+    setText("customWorkoutStatus", tr("custom_workout.not_found"));
+    statusEl?.classList.add("warn");
+    return;
+  }
+
+  STATE.pendingEntries = JSON.parse(JSON.stringify(Array.isArray(found.entries) ? found.entries : []));
+  renderPendingEntries();
+
+  const form = document.getElementById("workoutForm");
+  if (form){
+    resetEntryInputs(form);
+    if (form.type) form.type.value = String(found.session_type || "styrke");
+    if (form.notes) form.notes.value = String(found.notes || "");
+    setText("progressionHint", tr("workout.no_load_suggestion"));
+  }
+
+  statusEl?.classList.remove("warn");
+  setText("customWorkoutStatus", tr("custom_workout.loaded", { name: found.name }));
 }
 
 function renderManualTemplateOptions(){
@@ -6800,7 +6896,7 @@ function renderPrograms(programs, exercises){
 
 async function refreshAll(){
   const debug = {};
-  const [workoutsFile, runs, recoveryFile, programs, exercises, userSettingsApi, workoutsApi, recoveryApi, latestRecoveryApi, todayPlanApi, sessionResultsApi] = await Promise.all([
+  const [workoutsFile, runs, recoveryFile, programs, exercises, userSettingsApi, workoutsApi, customWorkoutsApi, recoveryApi, latestRecoveryApi, todayPlanApi, sessionResultsApi] = await Promise.all([
     getJson(FILES.workouts),
     getJson(FILES.runs),
     getJson(FILES.recovery),
@@ -6808,6 +6904,7 @@ async function refreshAll(){
     getJsonOrSeed(FILES.exercises, FILES.seed_exercises),
     apiGet("/api/user-settings"),
     apiGet("/api/workouts"),
+    apiGet("/api/custom-workouts"),
     apiGet("/api/checkins"),
     apiGet("/api/checkin/latest"),
     apiGet("/api/today-plan"),
@@ -6821,6 +6918,7 @@ async function refreshAll(){
     : {};
   STATE.checkins = Array.isArray(recoveryApi && recoveryApi.items) ? recoveryApi.items : [];
 STATE.workouts = Array.isArray(workoutsApi && workoutsApi.items) ? workoutsApi.items : [];
+  STATE.customWorkouts = Array.isArray(customWorkoutsApi && customWorkoutsApi.items) ? customWorkoutsApi.items : [];
   STATE.sessionResults = Array.isArray(sessionResultsApi && sessionResultsApi.items) ? sessionResultsApi.items : [];
   STATE.latestCheckin = latestRecoveryApi.item || null;
   STATE.currentTodayPlan = todayPlanApi.item || null;
@@ -6902,6 +7000,7 @@ STATE.workouts = Array.isArray(workoutsApi && workoutsApi.items) ? workoutsApi.i
   renderPrograms(STATE.programs, STATE.exercises);
   renderLibraryTabs();
   renderManualTemplateOptions();
+  renderCustomWorkoutOptions();
   renderPendingEntries();
 
   const dailyUiState = deriveDailyUiState(todayPlanApi.item || null, latestRecoveryApi.item || null, sessionResultsApi.items || []);
@@ -6909,6 +7008,7 @@ STATE.workouts = Array.isArray(workoutsApi && workoutsApi.items) ? workoutsApi.i
   debug.pendingEntries = STATE.pendingEntries;
   debug.workouts_file = workoutsFile;
   debug.workouts_api = workoutsApi;
+  debug.custom_workouts_api = customWorkoutsApi;
   debug.recovery_file = recoveryFile;
   debug.recovery_api = recoveryApi;
   debug.latest_recovery_api = latestRecoveryApi;
@@ -8075,6 +8175,8 @@ async function boot(){
     document.getElementById("loadProgramDayBtn")?.addEventListener("click", handleLoadProgramDay);
     document.getElementById("saveManualTemplateBtn")?.addEventListener("click", handleSaveManualTemplate);
     document.getElementById("loadManualTemplateBtn")?.addEventListener("click", handleLoadManualTemplate);
+    document.getElementById("saveCustomWorkoutBtn")?.addEventListener("click", handleSaveCustomWorkout);
+    document.getElementById("loadCustomWorkoutBtn")?.addEventListener("click", handleLoadCustomWorkout);
     document.getElementById("program_id")?.addEventListener("change", refreshProgramDaySelect);
     document.getElementById("entry_exercise_id")?.addEventListener("change", handleExerciseChange);
     mountEquipmentEditorInline();

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -838,5 +838,18 @@
   "manual_template.saved": "Template gemt: {name}",
   "manual_template.select_first": "Vælg en template først.",
   "manual_template.not_found": "Template blev ikke fundet.",
-  "manual_template.loaded": "Template indlæst: {name}"
+  "manual_template.loaded": "Template indlæst: {name}",
+  "custom_workout.title": "Gemte custom workouts",
+  "custom_workout.select_label": "Vælg workout",
+  "custom_workout.none_saved": "Ingen gemte workouts",
+  "custom_workout.save_btn": "Gem som workout",
+  "custom_workout.load_btn": "Indlæs workout",
+  "custom_workout.status_ready": "Klar.",
+  "custom_workout.prompt_name": "Navn på workout",
+  "custom_workout.save_requires_entries": "Tilføj mindst én øvelse før du gemmer et workout.",
+  "custom_workout.save_cancelled": "Workout blev ikke gemt.",
+  "custom_workout.saved": "Workout gemt: {name}",
+  "custom_workout.select_first": "Vælg et workout først.",
+  "custom_workout.not_found": "Workout blev ikke fundet.",
+  "custom_workout.loaded": "Workout indlæst: {name}"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -822,5 +822,18 @@
   "manual_template.saved": "Template saved: {name}",
   "manual_template.select_first": "Choose a template first.",
   "manual_template.not_found": "Template was not found.",
-  "manual_template.loaded": "Template loaded: {name}"
+  "manual_template.loaded": "Template loaded: {name}",
+  "custom_workout.title": "Saved custom workouts",
+  "custom_workout.select_label": "Choose workout",
+  "custom_workout.none_saved": "No saved workouts",
+  "custom_workout.save_btn": "Save as workout",
+  "custom_workout.load_btn": "Load workout",
+  "custom_workout.status_ready": "Ready.",
+  "custom_workout.prompt_name": "Workout name",
+  "custom_workout.save_requires_entries": "Add at least one exercise before saving a workout.",
+  "custom_workout.save_cancelled": "Workout was not saved.",
+  "custom_workout.saved": "Workout saved: {name}",
+  "custom_workout.select_first": "Choose a workout first.",
+  "custom_workout.not_found": "Workout was not found.",
+  "custom_workout.loaded": "Workout loaded: {name}"
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -816,6 +816,21 @@
             <p id="manualTemplateStatus" class="small" data-i18n="manual_template.status_ready">Klar.</p>
           </div>
 
+          <div class="card" style="margin-top:12px; padding:12px">
+            <div class="small" data-i18n="custom_workout.title">Gemte custom workouts</div>
+            <label style="margin-top:8px">
+              <span data-i18n="custom_workout.select_label">Vælg workout</span>
+              <select id="customWorkoutSelect">
+                <option value="" data-i18n="custom_workout.none_saved">Ingen gemte workouts</option>
+              </select>
+            </label>
+            <div class="btn-row" style="margin-top:10px">
+              <button type="button" id="saveCustomWorkoutBtn" data-i18n="custom_workout.save_btn">Gem som workout</button>
+              <button type="button" id="loadCustomWorkoutBtn" data-i18n="custom_workout.load_btn">Indlæs workout</button>
+            </div>
+            <p id="customWorkoutStatus" class="small" data-i18n="custom_workout.status_ready">Klar.</p>
+          </div>
+
           <p id="entryStatus" class="small" data-i18n="entry.none_added_yet">Ingen øvelser tilføjet endnu.</p>
           <ul id="pendingEntriesList"></ul>
         </div>


### PR DESCRIPTION
## Summary

This PR introduces a first persistent custom workout layer so self-directed users can save and reload named workout structures across sessions, instead of rebuilding them manually every time.

It builds on the earlier manual template work, but moves the core “saved workout” concept into the app’s real user data model and API.

## What changed

### Backend
Added a new persistent user-scoped storage path for custom workouts:

- `custom_workouts` added to backend file storage
- `list_custom_workouts_for_user(...)`
- `create_custom_workout(...)`
- `GET /api/custom-workouts`
- `POST /api/custom-workouts`

Each custom workout currently stores:

- `id`
- `user_id`
- `name`
- `session_type`
- `notes`
- `entries`
- `created_at`

The entry structure reuses the existing manual workout entry format instead of introducing a separate builder-specific schema.

### Frontend
Added a new custom workout UI layer inside the manual workout section.

Users can now:

- save the current pending entries as a persistent custom workout
- fetch saved custom workouts from the API
- choose a saved custom workout from a select
- load that workout back into the current pending entries flow

### State / loading
Added:

- `STATE