### PR TITLE
Add image metadata for 5 library exercises because matching live assets already exist

### DIFF
--- a/app/data/seed/exercises.json
+++ b/app/data/seed/exercises.json
@@ -939,6 +939,11 @@
       "shoulder",
       "elbow",
       "wrist"
+    ],
+    "image_folder": "Push-Ups_-_Close_Triceps_Position",
+    "external_images": [
+      "Push-Ups_-_Close_Triceps_Position/0.jpg",
+      "Push-Ups_-_Close_Triceps_Position/1.jpg"
     ]
   },
   {
@@ -1075,6 +1080,11 @@
     "notes_en": "Isometric back and posterior-chain exercise.",
     "local_load_targets": [
       "low_back"
+    ],
+    "image_folder": "Superman",
+    "external_images": [
+      "Superman/0.jpg",
+      "Superman/1.jpg"
     ]
   },
   {
@@ -1252,6 +1262,11 @@
       "Lean slightly forward without collapsing the back",
       "Stand up with control through the working leg",
       "Sit back down slowly instead of dropping"
+    ],
+    "image_folder": "Single-Leg_High_Box_Squat",
+    "external_images": [
+      "Single-Leg_High_Box_Squat/0.jpg",
+      "Single-Leg_High_Box_Squat/1.jpg"
     ]
   },
   {
@@ -1677,6 +1692,11 @@
       "shoulder",
       "wrist",
       "hip"
+    ],
+    "image_folder": "Mountain_Climbers",
+    "external_images": [
+      "Mountain_Climbers/0.jpg",
+      "Mountain_Climbers/1.jpg"
     ]
   },
   {
@@ -1718,6 +1738,11 @@
     "local_load_targets": [
       "hip",
       "shoulder"
+    ],
+    "image_folder": "Worlds_Greatest_Stretch",
+    "external_images": [
+      "Worlds_Greatest_Stretch/0.jpg",
+      "Worlds_Greatest_Stretch/1.jpg"
     ]
   },
   {


### PR DESCRIPTION
## Summary
Add image metadata for five exercises that already have matching live image assets.

## Changes
- add image_folder and external_images for diamond_push_ups
- add image_folder and external_images for superman_hold
- add image_folder and external_images for single_leg_sit_to_stand
- add image_folder and external_images for mountain_climbers
- add image_folder and external_images for worlds_greatest_stretch

## Why
These exercises were missing Library image coverage even though matching live assets already existed.

## Validation
- verified JSON syntax
- checked frontend syntax
- confirmed matching live image folders and files exist
- confirmed live data needed explicit catalog sync