### PR TITLE
Move profile management into dedicated profile step

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2383,7 +2383,12 @@ function renderProfileEquipmentCard(){
   const profileRunProgramCardEl = document.getElementById("profileRunProgramCard");
   const profileRunProgramSummaryEl = document.getElementById("profileRunProgramSummary");
   const profileRunProgramWhyEl = document.getElementById("profileRunProgramWhy");
+  const profileSectionDisplayNameEl = document.getElementById("profileSectionDisplayName");
+  const profileSectionBodyLineEl = document.getElementById("profileSectionBodyLine");
+  const profileSectionTrainingTypesLineEl = document.getElementById("profileSectionTrainingTypesLine");
+  const profileSectionTrainingDaysLineEl = document.getElementById("profileSectionTrainingDaysLine");
   const equipmentLineEl = document.getElementById("profileEquipmentLine");
+  const profileSectionEquipmentLineEl = document.getElementById("profileSectionEquipmentLine");
   const strengthProgramControlWrapEl = document.getElementById("profileStrengthProgramControlWrap");
   const strengthProgramSelectEl = document.getElementById("profileStrengthProgramSelect");
   const runProgramControlWrapEl = document.getElementById("profileRunProgramControlWrap");
@@ -2395,6 +2400,17 @@ function renderProfileEquipmentCard(){
   const recommendedStrengthReasonEl = document.getElementById("profileRecommendedStrengthReason");
   const profileProgramActionStatusEl = document.getElementById("profileProgramActionStatus");
   const applyRecommendedStrengthProgramBtn = document.getElementById("applyRecommendedStrengthProgramBtn");
+  const strengthProgramControlWrapProfileEl = document.getElementById("profileStrengthProgramControlWrapProfile");
+  const strengthProgramSelectProfileEl = document.getElementById("profileStrengthProgramSelectProfile");
+  const runProgramControlWrapProfileEl = document.getElementById("profileRunProgramControlWrapProfile");
+  const runProgramSelectProfileEl = document.getElementById("profileRunProgramSelectProfile");
+  const saveProfileProgramsBtnProfile = document.getElementById("saveProfileProgramsBtnProfile");
+  const recommendedProgramWrapProfileEl = document.getElementById("profileRecommendedProgramWrapProfile");
+  const recommendedCurrentStrengthLineProfileEl = document.getElementById("profileRecommendedCurrentStrengthLineProfile");
+  const recommendedStrengthLineProfileEl = document.getElementById("profileRecommendedStrengthLineProfile");
+  const recommendedStrengthReasonProfileEl = document.getElementById("profileRecommendedStrengthReasonProfile");
+  const profileProgramActionStatusProfileEl = document.getElementById("profileProgramActionStatusProfile");
+  const applyRecommendedStrengthProgramBtnProfile = document.getElementById("applyRecommendedStrengthProgramBtnProfile");
   const incrementLineEl = document.getElementById("profileIncrementLine");
   const accountLineEl = document.getElementById("profileAccountLine");
   const accountHelpLineEl = document.getElementById("profileAccountHelpLine");
@@ -2454,6 +2470,9 @@ function renderProfileEquipmentCard(){
 
   if (displayNameEl){
     displayNameEl.textContent = username;
+  }
+  if (profileSectionDisplayNameEl){
+    profileSectionDisplayNameEl.textContent = username;
   }
 
   const getProgramById = (programId) => {
@@ -2592,23 +2611,40 @@ function renderProfileEquipmentCard(){
     trainingDays.sun ? tr("day.sun") : ""
   ].filter(Boolean);
 
+  const profileBodyText = profileBits.length
+    ? profileBits.join(" · ")
+    : tr("profile.no_body_metrics_yet");
+
   if (bodyLineEl){
-    bodyLineEl.textContent = profileBits.length
-      ? profileBits.join(" · ")
-      : tr("profile.no_body_metrics_yet");
+    bodyLineEl.textContent = profileBodyText;
   }
+  if (profileSectionBodyLineEl){
+    profileSectionBodyLineEl.textContent = profileBodyText;
+  }
+
+  const trainingTypesText = selectedTraining.length
+    ? tr("profile.training_types_value", { value: selectedTraining.join(", ") })
+    : tr("profile.training_types_none");
 
   if (trainingTypesLineEl){
-    trainingTypesLineEl.textContent = selectedTraining.length
-      ? tr("profile.training_types_value", { value: selectedTraining.join(", ") })
-      : tr("profile.training_types_none");
+    trainingTypesLineEl.textContent = trainingTypesText;
+  }
+  if (profileSectionTrainingTypesLineEl){
+    profileSectionTrainingTypesLineEl.textContent = trainingTypesText;
   }
 
-  if (trainingDaysLineEl){
+  const trainingDaysText = (() => {
     const dayText = selectedDays.length
       ? tr("profile.training_days_value", { value: selectedDays.join(", ") })
       : tr("checkin.possible_days_none");
-    trainingDaysLineEl.textContent = `${dayText} · ${tr("profile.week_goal_value", { count: weeklyTargetSessions })}`;
+    return `${dayText} · ${tr("profile.week_goal_value", { count: weeklyTargetSessions })}`;
+  })();
+
+  if (trainingDaysLineEl){
+    trainingDaysLineEl.textContent = trainingDaysText;
+  }
+  if (profileSectionTrainingDaysLineEl){
+    profileSectionTrainingDaysLineEl.textContent = trainingDaysText;
   }
 
   if (activeProgramsLineEl){
@@ -2662,61 +2698,91 @@ function renderProfileEquipmentCard(){
     profileActiveProgramCardsWrapEl.style.display = hasCards ? "" : "none";
   }
 
-  if (profileProgramActionStatusEl){
-    profileProgramActionStatusEl.classList.remove("ok", "warn");
+  const applyProgramStatusState = (statusEl) => {
+    if (!statusEl) return;
+    statusEl.classList.remove("ok", "warn");
     if (PROFILE_PROGRAM_SWITCH_STATUS && PROFILE_PROGRAM_SWITCH_STATUS.kind === "ok"){
-      profileProgramActionStatusEl.textContent = PROFILE_PROGRAM_SWITCH_STATUS.message || "";
-      profileProgramActionStatusEl.style.display = PROFILE_PROGRAM_SWITCH_STATUS.message ? "" : "none";
-      profileProgramActionStatusEl.classList.add("ok");
+      statusEl.textContent = PROFILE_PROGRAM_SWITCH_STATUS.message || "";
+      statusEl.style.display = PROFILE_PROGRAM_SWITCH_STATUS.message ? "" : "none";
+      statusEl.classList.add("ok");
       requestAnimationFrame(() => {
-        profileProgramActionStatusEl.style.opacity = PROFILE_PROGRAM_SWITCH_STATUS.message ? "1" : "0";
+        statusEl.style.opacity = PROFILE_PROGRAM_SWITCH_STATUS.message ? "1" : "0";
       });
     } else {
-      profileProgramActionStatusEl.textContent = "";
-      profileProgramActionStatusEl.style.opacity = "0";
-      profileProgramActionStatusEl.style.display = "none";
+      statusEl.textContent = "";
+      statusEl.style.opacity = "0";
+      statusEl.style.display = "none";
     }
-  }
+  };
 
-  if (recommendedProgramWrapEl && recommendedStrengthLineEl && recommendedStrengthReasonEl){
-    const hasRecommendation = strengthTrainingEnabled
-      && Boolean(recommendedStrengthProgramId && recommendedStrengthProgramName)
-      && recommendedStrengthProgramId !== String(activeProgramsByDomain.strength || "").trim();
+  applyProgramStatusState(profileProgramActionStatusEl);
+  applyProgramStatusState(profileProgramActionStatusProfileEl);
 
-    recommendedProgramWrapEl.classList.toggle("wizard-step-hidden", !hasRecommendation);
-    recommendedProgramWrapEl.style.display = hasRecommendation ? "" : "none";
+  const hasRecommendation = strengthTrainingEnabled
+    && Boolean(recommendedStrengthProgramId && recommendedStrengthProgramName)
+    && recommendedStrengthProgramId !== String(activeProgramsByDomain.strength || "").trim();
 
-    if (applyRecommendedStrengthProgramBtn){
-      applyRecommendedStrengthProgramBtn.dataset.recommendedProgramId = hasRecommendation ? recommendedStrengthProgramId : "";
+  const applyRecommendationState = (wrapEl, currentEl, lineEl, reasonEl, buttonEl) => {
+    if (!wrapEl || !lineEl || !reasonEl) return;
+
+    wrapEl.classList.toggle("wizard-step-hidden", !hasRecommendation);
+    wrapEl.style.display = hasRecommendation ? "" : "none";
+
+    if (buttonEl){
+      buttonEl.dataset.recommendedProgramId = hasRecommendation ? recommendedStrengthProgramId : "";
     }
 
     if (hasRecommendation){
-      if (recommendedCurrentStrengthLineEl){
-        recommendedCurrentStrengthLineEl.textContent = activeStrengthProgramName
+      if (currentEl){
+        currentEl.textContent = activeStrengthProgramName
           ? tr("profile.recommended_current_strength_program_value", { value: activeStrengthProgramName })
           : tr("profile.recommended_current_strength_program_missing");
       }
-      recommendedStrengthLineEl.textContent = tr("profile.recommended_strength_program_value", {
+      lineEl.textContent = tr("profile.recommended_strength_program_value", {
         value: recommendedStrengthProgramName
       });
-      recommendedStrengthReasonEl.textContent = recommendedStrengthReason || tr("profile.recommended_strength_program_default_reason");
+      reasonEl.textContent = recommendedStrengthReason || tr("profile.recommended_strength_program_default_reason");
     } else {
-      if (recommendedCurrentStrengthLineEl){
-        recommendedCurrentStrengthLineEl.textContent = "";
+      if (currentEl){
+        currentEl.textContent = "";
       }
-      recommendedStrengthLineEl.textContent = "";
-      recommendedStrengthReasonEl.textContent = "";
+      lineEl.textContent = "";
+      reasonEl.textContent = "";
     }
-  }
+  };
+
+  applyRecommendationState(
+    recommendedProgramWrapEl,
+    recommendedCurrentStrengthLineEl,
+    recommendedStrengthLineEl,
+    recommendedStrengthReasonEl,
+    applyRecommendedStrengthProgramBtn
+  );
+  applyRecommendationState(
+    recommendedProgramWrapProfileEl,
+    recommendedCurrentStrengthLineProfileEl,
+    recommendedStrengthLineProfileEl,
+    recommendedStrengthReasonProfileEl,
+    applyRecommendedStrengthProgramBtnProfile
+  );
 
   if (strengthProgramControlWrapEl){
     strengthProgramControlWrapEl.style.display = strengthTrainingEnabled ? "" : "none";
   }
+  if (strengthProgramControlWrapProfileEl){
+    strengthProgramControlWrapProfileEl.style.display = strengthTrainingEnabled ? "" : "none";
+  }
   if (runProgramControlWrapEl){
     runProgramControlWrapEl.style.display = runTrainingEnabled ? "" : "none";
   }
+  if (runProgramControlWrapProfileEl){
+    runProgramControlWrapProfileEl.style.display = runTrainingEnabled ? "" : "none";
+  }
   if (saveProfileProgramsBtn){
     saveProfileProgramsBtn.style.display = (strengthTrainingEnabled || runTrainingEnabled) ? "" : "none";
+  }
+  if (saveProfileProgramsBtnProfile){
+    saveProfileProgramsBtnProfile.style.display = (strengthTrainingEnabled || runTrainingEnabled) ? "" : "none";
   }
   const overrideHelpEl = document.getElementById("profileProgramOverrideHelp");
   if (overrideHelpEl){
@@ -2725,14 +2791,18 @@ function renderProfileEquipmentCard(){
 
   if (strengthTrainingEnabled){
     fillProgramOverrideSelect(strengthProgramSelectEl, "strength", activeProgramOverrides.strength);
-  } else if (strengthProgramSelectEl){
-    strengthProgramSelectEl.value = "";
+    fillProgramOverrideSelect(strengthProgramSelectProfileEl, "strength", activeProgramOverrides.strength);
+  } else {
+    if (strengthProgramSelectEl) strengthProgramSelectEl.value = "";
+    if (strengthProgramSelectProfileEl) strengthProgramSelectProfileEl.value = "";
   }
 
   if (runTrainingEnabled){
     fillProgramOverrideSelect(runProgramSelectEl, "run", activeProgramOverrides.run);
-  } else if (runProgramSelectEl){
-    runProgramSelectEl.value = "";
+    fillProgramOverrideSelect(runProgramSelectProfileEl, "run", activeProgramOverrides.run);
+  } else {
+    if (runProgramSelectEl) runProgramSelectEl.value = "";
+    if (runProgramSelectProfileEl) runProgramSelectProfileEl.value = "";
   }
 
   if (applyRecommendedStrengthProgramBtn && !applyRecommendedStrengthProgramBtn.dataset.bound){
@@ -2846,10 +2916,15 @@ function renderProfileEquipmentCard(){
     });
   }
 
+    const equipmentText = enabledEquipment.length
+    ? tr("profile.available_equipment_value", { value: formatEquipmentList(enabledEquipment) })
+    : tr("profile.no_equipment_yet");
+
   if (equipmentLineEl){
-    equipmentLineEl.textContent = enabledEquipment.length
-      ? tr("profile.available_equipment_value", { value: formatEquipmentList(enabledEquipment) })
-      : tr("profile.no_equipment_yet");
+    equipmentLineEl.textContent = equipmentText;
+  }
+  if (profileSectionEquipmentLineEl){
+    profileSectionEquipmentLineEl.textContent = equipmentText;
   }
 
   if (incrementLineEl){
@@ -3335,7 +3410,7 @@ function bindEquipmentEditor(){
     openBtn.dataset.bound = "1";
     openBtn.onclick = (ev) => {
       ev.preventDefault();
-      setEquipmentEditorOpen(true);
+      showWizardStep("profile");
     };
   }
 
@@ -3348,6 +3423,24 @@ function bindEquipmentEditor(){
       } else if (form){
         form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
       }
+    };
+  }
+
+  const openProfileBtn = document.getElementById("openEquipmentSettingsBtnProfile");
+  if (openProfileBtn && !openProfileBtn.dataset.bound){
+    openProfileBtn.dataset.bound = "1";
+    openProfileBtn.onclick = (ev) => {
+      ev.preventDefault();
+      setEquipmentEditorOpen(true);
+    };
+  }
+
+  const openAccountProfileBtn = document.getElementById("openAccountSettingsBtnProfile");
+  if (openAccountProfileBtn && !openAccountProfileBtn.dataset.bound){
+    openAccountProfileBtn.dataset.bound = "1";
+    openAccountProfileBtn.onclick = (ev) => {
+      ev.preventDefault();
+      accountBtn2?.click();
     };
   }
 
@@ -7888,6 +7981,9 @@ function getWizardSections(){
       document.getElementById("historyTopSection"),
       document.getElementById("historyBottomSection"),
     ],
+    profile: [
+      document.getElementById("profileSection"),
+    ],
     library: [
       document.getElementById("librarySection"),
     ],
@@ -7915,13 +8011,6 @@ function renderUtilityNav(){
   root.querySelectorAll("[data-utility-step]").forEach(btn => {
     btn.addEventListener("click", () => {
       const target = String(btn.getAttribute("data-utility-step") || "").trim();
-      if (target === "profile"){
-        showWizardStep("overview");
-        requestAnimationFrame(() => {
-          setEquipmentEditorOpen(true);
-        });
-        return;
-      }
       showWizardStep(target);
     });
   });

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2972,18 +2972,7 @@ function renderProfileEquipmentCard(){
   }
 
 function mountEquipmentEditorInline(){
-  const wrap = document.getElementById("equipmentEditorWrap");
-  const modal = document.getElementById("equipmentSettingsModal");
-  if (!wrap || !modal) return;
-
-  const card = modal.querySelector(".modal-card");
-  if (!card) return;
-
-  if (wrap.dataset.mounted !== "1"){
-    wrap.innerHTML = "";
-    wrap.appendChild(card);
-    wrap.dataset.mounted = "1";
-  }
+  return;
 }
 
 
@@ -3243,26 +3232,27 @@ function bindFirstRunSetupNavigation(){
 }
 
 function setEquipmentEditorOpen(isOpen){
-  const wrap = document.getElementById("equipmentEditorWrap");
-  const modal = document.getElementById("equipmentSettingsModal");
-  if (wrap){
-    wrap.classList.toggle("wizard-step-hidden", !isOpen);
-    wrap.style.display = isOpen ? "block" : "none";
+  const section = document.getElementById("profileEquipmentEditorSection");
+  if (section){
+    section.classList.toggle("wizard-step-hidden", !isOpen);
+    section.style.display = isOpen ? "" : "none";
   }
-  if (modal){
-    modal.classList.add("wizard-step-hidden");
-    modal.style.display = "none";
-  }
+
   if (isOpen){
     populateEquipmentEditor();
     bindFirstRunSetupNavigation();
     renderFirstRunSetupEditorState();
     const status = document.getElementById("equipmentSettingsStatus");
     if (status) status.textContent = tr("profile.edit_and_save_when_ready");
-    const firstField =
-      document.querySelector('.first-run-setup-section[data-first-run-step]:not([style*="display: none"]) input, .first-run-setup-section[data-first-run-step]:not([style*="display: none"]) select')
-      || document.getElementById("profile_height_cm");
-    if (firstField && typeof firstField.focus === "function") firstField.focus();
+    requestAnimationFrame(() => {
+      const firstField =
+        document.querySelector('.first-run-setup-section[data-first-run-step]:not([style*="display: none"]) input, .first-run-setup-section[data-first-run-step]:not([style*="display: none"]) select')
+        || document.getElementById("profile_height_cm");
+      if (firstField && typeof firstField.focus === "function") firstField.focus();
+      if (section && typeof section.scrollIntoView === "function"){
+        section.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    });
   } else {
     renderFirstRunSetupEditorState();
   }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -410,80 +410,100 @@
           <div class="stat-line" id="profileBodyLine" data-i18n="profile.loading">Profil indlæses...</div>
           <div class="stat-line" id="profileTrainingTypesLine" data-i18n="profile.training_types_loading">Træningstyper indlæses...</div>
           <div class="stat-line" id="profileTrainingDaysLine" data-i18n="profile.training_days_loading">Træningsdage indlæses...</div>
-          <div class="stat-line" id="profileActiveProgramsLine" data-i18n="profile.active_programs_loading" style="display:none">Aktive programmer indlæses...</div>
-          <div id="profileActiveProgramCardsWrap" class="profile-program-cards" style="display:none">
-            <div id="profileStrengthProgramCard" class="small profile-program-card" style="display:none">
-              <div style="font-weight:700" data-i18n="profile.domain_strength_title">Styrke</div>
-              <div id="profileStrengthProgramSummary" style="margin-top:4px"></div>
-              <div id="profileStrengthProgramWhy" style="margin-top:4px; opacity:0.85"></div>
-            </div>
-            <div id="profileRunProgramCard" class="small profile-program-card" style="display:none">
-              <div style="font-weight:700" data-i18n="profile.domain_run_title">Løb</div>
-              <div id="profileRunProgramSummary" style="margin-top:4px"></div>
-              <div id="profileRunProgramWhy" style="margin-top:4px; opacity:0.85"></div>
-            </div>
-          </div>
-          <div class="stat-line" id="profileEquipmentLine" data-i18n="profile.equipment_loading">Udstyr indlæses...</div>
-        </div>
-        <details id="profileEquipmentDetails" class="profile-details">
-          <summary class="small" data-i18n="overview.more_profile_details">Flere profiloplysninger</summary>
-          <div class="overview-status" style="margin-top:10px">
-            <div class="stat-line" id="profileIncrementLine" data-i18n="profile.increment_loading">Vægtspring indlæses...</div>
-            <div class="stat-line" id="profileAccountLine" data-i18n="profile.account_loading">Konto indlæses...</div>
-            <div class="stat-line" id="profileAccountHelpLine" data-i18n="profile.account_help">Profil og adgangskode håndteres centralt via auth.</div>
-          </div>
-        </details>
-        <div class="overview-status profile-summary-actions wizard-step-hidden" style="display:none">
-          <div class="stat-line"><strong data-i18n="profile.program_selection_title">Programvalg</strong></div>
-          <div class="small" id="profileProgramActionStatus" style="display:none; opacity:0; transition:opacity 220ms ease"></div>
-          <div class="small" id="profileProgramOverrideHelp" data-i18n="profile.active_program_override_help">Vælg et program her for at overstyre den automatiske anbefaling.</div>
-
-          <div id="profileStrengthProgramControlWrap" class="wizard-step-hidden" style="display:none">
-            <label class="small" for="profileStrengthProgramSelect" data-i18n="profile.active_program_strength_label">Styrkeprogram</label>
-            <select id="profileStrengthProgramSelect">
-              <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
-            </select>
-          </div>
-
-          <div id="profileRunProgramControlWrap" class="wizard-step-hidden" style="display:none">
-            <label class="small" for="profileRunProgramSelect" data-i18n="profile.active_program_run_label">Løbeprogram</label>
-            <select id="profileRunProgramSelect">
-              <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
-            </select>
-          </div>
-
-          <div id="profileRecommendedProgramWrap" class="overview-status wizard-step-hidden" style="display:none">
-            <div class="stat-line"><strong data-i18n="profile.recommended_program_title">Anbefalet program</strong></div>
-            <div class="small" id="profileRecommendedProgramCurrentLabel" data-i18n="profile.recommended_program_current_label">Du bruger nu</div>
-            <div class="stat-line" id="profileRecommendedCurrentStrengthLine">-</div>
-            <div class="small" id="profileRecommendedProgramSuggestedLabel" data-i18n="profile.recommended_program_suggested_label">Appen anbefaler nu</div>
-            <div class="stat-line" id="profileRecommendedStrengthLine">-</div>
-            <div class="small" id="profileRecommendedStrengthReason">-</div>
-            <div class="btn-row">
-              <button type="button" id="applyRecommendedStrengthProgramBtn" class="primary" data-i18n="button.switch_to_recommended_program">Skift til anbefalet program</button>
-            </div>
-          </div>
-
-          <button type="button" id="saveProfileProgramsBtn" class="wizard-step-hidden" style="display:none" data-i18n="button.save_active_programs">Gem aktive programmer</button>
         </div>
         <div class="btn-row profile-summary-buttons">
           <button type="button" id="openEquipmentSettingsBtn" data-i18n="button.edit_profile_equipment">Redigér profil og udstyr</button>
           <button type="button" id="openAccountSettingsSecondaryBtn" data-i18n="button.account_password">Konto og adgangskode</button>
         </div>
       </section>
-      
-      <div id="equipmentEditorWrap" class="card wizard-step-hidden" style="margin-top:14px; display:none"></div>
 
-      <div id="equipmentSettingsModal" class="modal-backdrop wizard-step-hidden" style="display:none">
-        <div class="modal-card">
-          <div class="row" style="align-items:center; margin-bottom:10px">
-            <h3 style="margin:0" data-i18n="overview.profile_equipment">Profil og udstyr</h3>
-            <button type="button" id="cancelEquipmentSettingsBtn" class="small" data-i18n="button.close">Luk</button>
+      <section class="card">
+        <h2 data-i18n="workouts.title">Workouts</h2>
+        <div class="metric" id="workoutsCount">-</div>
+        <div class="small" data-i18n="stats.logged_strength_sessions">Logged strength sessions</div>
+      </section>
+
+      <section class="card">
+        <h2 data-i18n="exercises.title">Øvelser</h2>
+        <div class="metric" id="exercisesCount">-</div>
+        <div class="small" data-i18n="exercises.count_label">Antal øvelser i biblioteket</div>
+      </section>
+
+      <section class="card">
+        <h2 data-i18n="programs.title">Programmer</h2>
+        <div class="metric" id="programsCount">-</div>
+        <div class="small" data-i18n="programs.count_label">Antal aktive programmer</div>
+      </section>
+
+      <section class="card">
+        <h2 data-i18n="recovery.title">Recovery</h2>
+        <div class="metric" id="recoveryCount">-</div>
+        <div class="small" data-i18n="recovery.count_label">Antal recovery-logs</div>
+      </section>
+
+      <section class="card">
+        <h2 data-i18n="readiness.title">Readiness</h2>
+        <div class="metric" id="readinessScore">-</div>
+        <div class="small" id="readinessLabel" data-i18n="common.no_data_yet">Ingen data endnu</div>
+        <div class="small" id="readinessSuggestion" style="margin-top:8px"></div>
+        <div class="small" id="readinessAction" style="margin-top:8px"></div>
+      </section>
+    </div>
+
+    <section class="card wizard-step-hidden" id="profileSection" style="margin-top:18px">
+      <div class="row">
+        <h2 data-i18n="overview.profile_equipment">Profil og udstyr</h2>
+        <div class="small" id="profileSectionDisplayName">-</div>
+      </div>
+      <p class="small" data-i18n="settings.help">Vælg hvilket udstyr du har adgang til, angiv højde og kropsvægt, og gem når du er klar.</p>
+
+      <div class="overview-status" style="margin-top:12px">
+        <div class="stat-line" id="profileSectionBodyLine" data-i18n="profile.loading">Profil indlæses...</div>
+        <div class="stat-line" id="profileSectionTrainingTypesLine" data-i18n="profile.training_types_loading">Træningstyper indlæses...</div>
+        <div class="stat-line" id="profileSectionTrainingDaysLine" data-i18n="profile.training_days_loading">Træningsdage indlæses...</div>
+        <div class="stat-line" id="profileSectionEquipmentLine" data-i18n="profile.equipment_loading">Udstyr indlæses...</div>
+      </div>
+
+      <div class="overview-status" style="margin-top:12px">
+        <div class="stat-line"><strong data-i18n="profile.program_selection_title">Programvalg</strong></div>
+        <div class="small" id="profileProgramActionStatusProfile" style="display:none; opacity:0; transition:opacity 220ms ease"></div>
+        <div class="small" data-i18n="profile.active_program_override_help">Vælg et program her for at overstyre den automatiske anbefaling.</div>
+
+        <div id="profileStrengthProgramControlWrapProfile">
+          <label class="small" for="profileStrengthProgramSelectProfile" data-i18n="profile.active_program_strength_label">Styrkeprogram</label>
+          <select id="profileStrengthProgramSelectProfile">
+            <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
+          </select>
+        </div>
+
+        <div id="profileRunProgramControlWrapProfile">
+          <label class="small" for="profileRunProgramSelectProfile" data-i18n="profile.active_program_run_label">Løbeprogram</label>
+          <select id="profileRunProgramSelectProfile">
+            <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
+          </select>
+        </div>
+
+        <div id="profileRecommendedProgramWrapProfile" class="overview-status wizard-step-hidden" style="display:none">
+          <div class="stat-line"><strong data-i18n="profile.recommended_program_title">Anbefalet program</strong></div>
+          <div class="small" data-i18n="profile.recommended_program_current_label">Du bruger nu</div>
+          <div class="stat-line" id="profileRecommendedCurrentStrengthLineProfile">-</div>
+          <div class="small" data-i18n="profile.recommended_program_suggested_label">Appen anbefaler nu</div>
+          <div class="stat-line" id="profileRecommendedStrengthLineProfile">-</div>
+          <div class="small" id="profileRecommendedStrengthReasonProfile">-</div>
+          <div class="btn-row">
+            <button type="button" id="applyRecommendedStrengthProgramBtnProfile" class="primary" data-i18n="button.switch_to_recommended_program">Skift til anbefalet program</button>
           </div>
+        </div>
 
-          <p class="small" data-i18n="settings.help">Vælg hvilket udstyr du har adgang til, angiv højde og kropsvægt, og gem når du er klar.</p>
+        <button type="button" id="saveProfileProgramsBtnProfile" data-i18n="button.save_active_programs">Gem aktive programmer</button>
+      </div>
 
-          <form id="equipmentSettingsForm">
+      
+      <div class="overview-status" style="margin-top:18px">
+        <div class="stat-line"><strong data-i18n="button.edit_profile_equipment">Redigér profil og udstyr</strong></div>
+      </div>
+
+<div id="profileEquipmentEditorSection" class="wizard-step-hidden" style="display:none; margin-top:12px">\n        <form id="equipmentSettingsForm" style="margin-top:12px">
             <div id="firstRunSetupIntro" class="small wizard-step-hidden" style="margin-bottom:12px; display:none"></div>
 
             <div class="first-run-setup-section" data-first-run-step="basic_profile">
@@ -676,93 +696,14 @@
                 <button type="button" id="resetCatalogFromSeedBtn" class="secondary" data-i18n="button.reset_catalog_from_seed">Reset øvelser og programmer</button>
             </div>
             </div>
-          </form>
-
           <p id="equipmentSettingsStatus" class="small" style="margin-top:12px">Ikke ændret endnu.</p>
+        <div class="btn-row" style="margin-top:12px">
+          <button type="button" id="cancelEquipmentSettingsBtn" class="secondary" data-i18n="button.close">Luk</button>
         </div>
-      </div>
-      <section class="card">
-        <h2 data-i18n="workouts.title">Workouts</h2>
-        <div class="metric" id="workoutsCount">-</div>
-        <div class="small" data-i18n="stats.logged_strength_sessions">Logged strength sessions</div>
-      </section>
-
-      <section class="card">
-        <h2 data-i18n="exercises.title">Øvelser</h2>
-        <div class="metric" id="exercisesCount">-</div>
-        <div class="small" data-i18n="exercises.count_label">Antal øvelser i biblioteket</div>
-      </section>
-
-      <section class="card">
-        <h2 data-i18n="programs.title">Programmer</h2>
-        <div class="metric" id="programsCount">-</div>
-        <div class="small" data-i18n="programs.count_label">Antal aktive programmer</div>
-      </section>
-
-      <section class="card">
-        <h2 data-i18n="recovery.title">Recovery</h2>
-        <div class="metric" id="recoveryCount">-</div>
-        <div class="small" data-i18n="recovery.count_label">Antal recovery-logs</div>
-      </section>
-
-      <section class="card">
-        <h2 data-i18n="readiness.title">Readiness</h2>
-        <div class="metric" id="readinessScore">-</div>
-        <div class="small" id="readinessLabel" data-i18n="common.no_data_yet">Ingen data endnu</div>
-        <div class="small" id="readinessSuggestion" style="margin-top:8px"></div>
-        <div class="small" id="readinessAction" style="margin-top:8px"></div>
-      </section>
-    </div>
-
-    <section class="card wizard-step-hidden" id="profileSection" style="margin-top:18px">
-      <div class="row">
-        <h2 data-i18n="overview.profile_equipment">Profil og udstyr</h2>
-        <div class="small" id="profileSectionDisplayName">-</div>
-      </div>
-      <p class="small" data-i18n="settings.help">Vælg hvilket udstyr du har adgang til, angiv højde og kropsvægt, og gem når du er klar.</p>
-
-      <div class="overview-status" style="margin-top:12px">
-        <div class="stat-line" id="profileSectionBodyLine" data-i18n="profile.loading">Profil indlæses...</div>
-        <div class="stat-line" id="profileSectionTrainingTypesLine" data-i18n="profile.training_types_loading">Træningstyper indlæses...</div>
-        <div class="stat-line" id="profileSectionTrainingDaysLine" data-i18n="profile.training_days_loading">Træningsdage indlæses...</div>
-        <div class="stat-line" id="profileSectionEquipmentLine" data-i18n="profile.equipment_loading">Udstyr indlæses...</div>
+        </form>
       </div>
 
-      <div class="overview-status" style="margin-top:12px">
-        <div class="stat-line"><strong data-i18n="profile.program_selection_title">Programvalg</strong></div>
-        <div class="small" id="profileProgramActionStatusProfile" style="display:none; opacity:0; transition:opacity 220ms ease"></div>
-        <div class="small" data-i18n="profile.active_program_override_help">Vælg et program her for at overstyre den automatiske anbefaling.</div>
-
-        <div id="profileStrengthProgramControlWrapProfile">
-          <label class="small" for="profileStrengthProgramSelectProfile" data-i18n="profile.active_program_strength_label">Styrkeprogram</label>
-          <select id="profileStrengthProgramSelectProfile">
-            <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
-          </select>
-        </div>
-
-        <div id="profileRunProgramControlWrapProfile">
-          <label class="small" for="profileRunProgramSelectProfile" data-i18n="profile.active_program_run_label">Løbeprogram</label>
-          <select id="profileRunProgramSelectProfile">
-            <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
-          </select>
-        </div>
-
-        <div id="profileRecommendedProgramWrapProfile" class="overview-status wizard-step-hidden" style="display:none">
-          <div class="stat-line"><strong data-i18n="profile.recommended_program_title">Anbefalet program</strong></div>
-          <div class="small" data-i18n="profile.recommended_program_current_label">Du bruger nu</div>
-          <div class="stat-line" id="profileRecommendedCurrentStrengthLineProfile">-</div>
-          <div class="small" data-i18n="profile.recommended_program_suggested_label">Appen anbefaler nu</div>
-          <div class="stat-line" id="profileRecommendedStrengthLineProfile">-</div>
-          <div class="small" id="profileRecommendedStrengthReasonProfile">-</div>
-          <div class="btn-row">
-            <button type="button" id="applyRecommendedStrengthProgramBtnProfile" class="primary" data-i18n="button.switch_to_recommended_program">Skift til anbefalet program</button>
-          </div>
-        </div>
-
-        <button type="button" id="saveProfileProgramsBtnProfile" data-i18n="button.save_active_programs">Gem aktive programmer</button>
-      </div>
-
-      <div class="btn-row" style="margin-top:12px">
+<div class="btn-row" style="margin-top:12px">
         <button type="button" id="openEquipmentSettingsBtnProfile" data-i18n="button.edit_profile_equipment">Redigér profil og udstyr</button>
         <button type="button" id="openAccountSettingsBtnProfile" data-i18n="button.account_password">Konto og adgangskode</button>
       </div>

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -714,6 +714,60 @@
       </section>
     </div>
 
+    <section class="card wizard-step-hidden" id="profileSection" style="margin-top:18px">
+      <div class="row">
+        <h2 data-i18n="overview.profile_equipment">Profil og udstyr</h2>
+        <div class="small" id="profileSectionDisplayName">-</div>
+      </div>
+      <p class="small" data-i18n="settings.help">Vælg hvilket udstyr du har adgang til, angiv højde og kropsvægt, og gem når du er klar.</p>
+
+      <div class="overview-status" style="margin-top:12px">
+        <div class="stat-line" id="profileSectionBodyLine" data-i18n="profile.loading">Profil indlæses...</div>
+        <div class="stat-line" id="profileSectionTrainingTypesLine" data-i18n="profile.training_types_loading">Træningstyper indlæses...</div>
+        <div class="stat-line" id="profileSectionTrainingDaysLine" data-i18n="profile.training_days_loading">Træningsdage indlæses...</div>
+        <div class="stat-line" id="profileSectionEquipmentLine" data-i18n="profile.equipment_loading">Udstyr indlæses...</div>
+      </div>
+
+      <div class="overview-status" style="margin-top:12px">
+        <div class="stat-line"><strong data-i18n="profile.program_selection_title">Programvalg</strong></div>
+        <div class="small" id="profileProgramActionStatusProfile" style="display:none; opacity:0; transition:opacity 220ms ease"></div>
+        <div class="small" data-i18n="profile.active_program_override_help">Vælg et program her for at overstyre den automatiske anbefaling.</div>
+
+        <div id="profileStrengthProgramControlWrapProfile">
+          <label class="small" for="profileStrengthProgramSelectProfile" data-i18n="profile.active_program_strength_label">Styrkeprogram</label>
+          <select id="profileStrengthProgramSelectProfile">
+            <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
+          </select>
+        </div>
+
+        <div id="profileRunProgramControlWrapProfile">
+          <label class="small" for="profileRunProgramSelectProfile" data-i18n="profile.active_program_run_label">Løbeprogram</label>
+          <select id="profileRunProgramSelectProfile">
+            <option value="" data-i18n="profile.active_program_auto">Automatisk anbefalet</option>
+          </select>
+        </div>
+
+        <div id="profileRecommendedProgramWrapProfile" class="overview-status wizard-step-hidden" style="display:none">
+          <div class="stat-line"><strong data-i18n="profile.recommended_program_title">Anbefalet program</strong></div>
+          <div class="small" data-i18n="profile.recommended_program_current_label">Du bruger nu</div>
+          <div class="stat-line" id="profileRecommendedCurrentStrengthLineProfile">-</div>
+          <div class="small" data-i18n="profile.recommended_program_suggested_label">Appen anbefaler nu</div>
+          <div class="stat-line" id="profileRecommendedStrengthLineProfile">-</div>
+          <div class="small" id="profileRecommendedStrengthReasonProfile">-</div>
+          <div class="btn-row">
+            <button type="button" id="applyRecommendedStrengthProgramBtnProfile" class="primary" data-i18n="button.switch_to_recommended_program">Skift til anbefalet program</button>
+          </div>
+        </div>
+
+        <button type="button" id="saveProfileProgramsBtnProfile" data-i18n="button.save_active_programs">Gem aktive programmer</button>
+      </div>
+
+      <div class="btn-row" style="margin-top:12px">
+        <button type="button" id="openEquipmentSettingsBtnProfile" data-i18n="button.edit_profile_equipment">Redigér profil og udstyr</button>
+        <button type="button" id="openAccountSettingsBtnProfile" data-i18n="button.account_password">Konto og adgangskode</button>
+      </div>
+    </section>
+
     <section class="card" id="manualWorkoutSection" style="margin-top:18px">
       <h2 data-i18n="new_workout.title">Nyt workout</h2>
       <form id="workoutForm">


### PR DESCRIPTION
## Summary
- move profile and equipment management into a dedicated profile step
- reduce the overview profile card to a compact teaser
- open the profile editor inline on the profile step instead of using the old modal/wrap behavior
- keep profile changes saveable from the dedicated profile screen

## Why
The old overview screen had become too heavy because profile summary, program controls, and full editing all lived in the same place. This change separates browsing from editing so overview stays lighter and profile management has a clearer home.

## Testing
- node --check app/frontend/app.js
- deployed frontend
- verified overview card is lighter
- verified profile step opens
- verified inline editor opens from "Redigér profil og udstyr"
- verified a profile change can be saved successfully