### PR TITLE
Simplify check-in hierarchy for faster mobile completion

### DIFF
--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -307,6 +307,8 @@
   "checkin.section.how_feel_title": "Hvordan har du det i dag?",
   "checkin.section.how_feel_copy": "Vælg det svar der passer bedst lige nu. Det behøver ikke være perfekt.",
   "checkin.section.capacity_title": "Hvad kan dagen bære?",
+  "checkin.section.capacity_intro_title": "Start med rammerne for i dag",
+  "checkin.section.capacity_intro_copy": "Vælg dato og hvor meget tid dagen realistisk kan bære.",
   "checkin.section.context_title": "Ekstra kontekst",
   "checkin.section.context_copy": "Valgfrit. Brug kun dette hvis det hjælper dagens plan til at blive mere præcis.",
   "checkin.menstruation_today": "Menstruation i dag",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -294,6 +294,8 @@
   "checkin.section.how_feel_title": "How do you feel today?",
   "checkin.section.how_feel_copy": "Choose the answer that fits best right now. It does not have to be perfect.",
   "checkin.section.capacity_title": "What can today support?",
+  "checkin.section.capacity_intro_title": "Start with today\u2019s frame",
+  "checkin.section.capacity_intro_copy": "Choose the date and how much time today can realistically support.",
   "checkin.section.context_title": "Extra context",
   "checkin.section.context_copy": "Optional. Use this only if it helps make today’s plan more precise.",
   "checkin.menstruation_today": "Menstruation today",

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1102,11 +1102,21 @@
       <form id="recoveryForm">
         <div class="checkin-section">
           <div class="checkin-section-head">
-            <h3 class="checkin-section-title" data-i18n="common.date">Dato</h3>
+            <h3 class="checkin-section-title" data-i18n="checkin.section.capacity_intro_title">Start med rammerne for i dag</h3>
+            <p class="small checkin-section-copy" data-i18n="checkin.section.capacity_intro_copy">Vælg dato og hvor meget tid dagen realistisk kan bære.</p>
           </div>
           <label>
             <span data-i18n="common.date">Dato</span>
             <input id="recovery_date" name="recovery_date" type="date" required>
+          </label>
+          <label>
+            <span data-i18n="checkin.time_today">Tid i dag</span>
+            <select id="time_budget_min" name="time_budget_min" required>
+              <option value="20">20 min</option>
+              <option value="30">30 min</option>
+              <option value="45" selected>45 min</option>
+              <option value="60">60 min</option>
+            </select>
           </label>
         </div>
 
@@ -1151,18 +1161,73 @@
         </div>
 
         <div class="checkin-section">
-          <div class="checkin-section-head">
-            <h3 class="checkin-section-title" data-i18n="checkin.section.capacity_title">Hvad kan dagen bære?</h3>
-          </div>
-          <label>
-            <span data-i18n="checkin.time_today">Tid i dag</span>
-            <select id="time_budget_min" name="time_budget_min" required>
-              <option value="20">20 min</option>
-              <option value="30">30 min</option>
-              <option value="45" selected>45 min</option>
-              <option value="60">60 min</option>
-            </select>
-          </label>
+          <details class="entry-box">
+            <summary><strong data-i18n="checkin.local_signals_title">Lokale signaler</strong></summary>
+            <p class="small" data-i18n="checkin.local_signals_intro">Valgfrit. Markér kun områder der kræver ekstra hensyn i dag.</p>
+
+            <label>
+              <span data-i18n="checkin.local_signal.knee">Knæ</span>
+              <select name="local_signal_knee">
+                <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
+                <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
+                <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
+              </select>
+            </label>
+
+            <label>
+              <span data-i18n="checkin.local_signal.low_back">Lænd</span>
+              <select name="local_signal_low_back">
+                <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
+                <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
+                <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
+              </select>
+            </label>
+
+            <label>
+              <span data-i18n="checkin.local_signal.shoulder">Skulder</span>
+              <select name="local_signal_shoulder">
+                <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
+                <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
+                <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
+              </select>
+            </label>
+
+            <label>
+              <span data-i18n="checkin.local_signal.elbow">Albue</span>
+              <select name="local_signal_elbow">
+                <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
+                <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
+                <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
+              </select>
+            </label>
+
+            <label>
+              <span data-i18n="checkin.local_signal.hip">Hofte</span>
+              <select name="local_signal_hip">
+                <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
+                <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
+                <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
+              </select>
+            </label>
+
+            <label>
+              <span data-i18n="checkin.local_signal.ankle_calf">Ankel / læg</span>
+              <select name="local_signal_ankle_calf">
+                <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
+                <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
+                <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
+              </select>
+            </label>
+
+            <label>
+              <span data-i18n="checkin.local_signal.wrist">Håndled</span>
+              <select name="local_signal_wrist">
+                <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
+                <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
+                <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
+              </select>
+            </label>
+          </details>
         </div>
 
         <div class="checkin-section">
@@ -1190,73 +1255,6 @@
           <label>
             <span data-i18n="checkin.notes">Noter</span>
             <textarea id="recovery_notes" name="recovery_notes" data-i18n-placeholder="checkin.notes_placeholder" placeholder="Fx sov fint, lidt træt i ben, 45 min tid i dag"></textarea>
-          </label>
-
-          <div class="entry-box">
-            <strong data-i18n="checkin.local_signals_title">Lokale signaler</strong>
-            <p class="small" data-i18n="checkin.local_signals_intro">Valgfrit. Markér kun områder der kræver ekstra hensyn i dag.</p>
-
-          <label>
-            <span data-i18n="checkin.local_signal.knee">Knæ</span>
-            <select name="local_signal_knee">
-              <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
-              <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
-              <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
-            </select>
-          </label>
-
-          <label>
-            <span data-i18n="checkin.local_signal.low_back">Lænd</span>
-            <select name="local_signal_low_back">
-              <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
-              <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
-              <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
-            </select>
-          </label>
-
-          <label>
-            <span data-i18n="checkin.local_signal.shoulder">Skulder</span>
-            <select name="local_signal_shoulder">
-              <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
-              <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
-              <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
-            </select>
-          </label>
-
-          <label>
-            <span data-i18n="checkin.local_signal.elbow">Albue</span>
-            <select name="local_signal_elbow">
-              <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
-              <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
-              <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
-            </select>
-          </label>
-
-          <label>
-            <span data-i18n="checkin.local_signal.hip">Hofte</span>
-            <select name="local_signal_hip">
-              <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
-              <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
-              <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
-            </select>
-          </label>
-
-          <label>
-            <span data-i18n="checkin.local_signal.ankle_calf">Ankel / læg</span>
-            <select name="local_signal_ankle_calf">
-              <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
-              <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
-              <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
-            </select>
-          </label>
-
-          <label>
-            <span data-i18n="checkin.local_signal.wrist">Håndled</span>
-            <select name="local_signal_wrist">
-              <option value="" data-i18n="checkin.local_signal.none">Ingen særlige signaler</option>
-              <option value="caution" data-i18n="checkin.local_signal.caution">Vær opmærksom</option>
-              <option value="irritated" data-i18n="checkin.local_signal.irritated">Irriteret</option>
-            </select>
           </label>
         </div>
 

--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -353,6 +353,46 @@ button{
   min-height: 48px;
 }
 
+#recoveryForm details.entry-box{
+  margin-top: 0;
+}
+
+#recoveryForm details.entry-box summary{
+  cursor: pointer;
+  list-style: none;
+}
+
+#recoveryForm details.entry-box summary::-webkit-details-marker{
+  display: none;
+}
+
+#recoveryForm details.entry-box summary strong{
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#recoveryForm details.entry-box summary strong::before{
+  content: "+";
+  display: inline-block;
+  width: 1em;
+  text-align: center;
+  opacity: 0.72;
+}
+
+#recoveryForm details[open].entry-box summary strong::before{
+  content: "−";
+}
+
+#recoveryForm details.entry-box p.small{
+  margin-top: 10px;
+}
+
+#recoveryFormStatus{
+  margin-top: 14px;
+  line-height: 1.45;
+}
+
 @media (min-width: 700px){
   .checkin-section{
     padding: 16px 16px 18px;


### PR DESCRIPTION
## Summary
- move date and time budget into one compact top section
- keep the main readiness questions grouped as the primary check-in block
- collapse local signals into a closed details section by default
- move extra context lower in the flow so optional input comes after the main decisions
- add small i18n updates and targeted check-in styling for the new hierarchy

## Why
The check-in flow felt too long and heavy on mobile because secondary inputs took up too much space before the user could finish the core check-in.

This change makes the hierarchy clearer:
- first define the frame for today
- then rate how you feel
- only open local signals if needed
- add optional context near the end

The goal is to make check-in completion feel faster and clearer without changing the data model or breaking the planning flow.

## Testing
- node --check app/frontend/app.js
- deployed frontend locally/live
- verified date and time now appear together at the top
- verified local signals are collapsed by default
- verified local signals can still be opened and used
- verified menstruation-related fields still appear and work when enabled
- verified check-in submission still calculates today's plan correctly
- verified the new top copy works through i18n in Danish and English