### PR TITLE
Refine today-plan scanability and fix manual override semantics

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -521,6 +521,8 @@ def create_workout(user_id, payload):
     if session_type == "styrke" and not clean_entries:
         return None, make_error_payload("empty_workout", "ingen træningsdata at gemme"), 400
 
+    is_manual_override = bool(payload.get("is_manual_override", False))
+
     item = {
         "id": str(uuid.uuid4()),
         "user_id": user_id,
@@ -531,8 +533,8 @@ def create_workout(user_id, payload):
         "program_id": program_id,
         "program_day_label": program_day_label,
         "entries": clean_entries,
-        "is_manual_override": True,
-        "is_consumed": False,
+        "is_manual_override": is_manual_override,
+        "is_consumed": False if is_manual_override else None,
         "created_at": datetime.now(timezone.utc).isoformat()
     }
 

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -24,6 +24,7 @@ let STATE = {
   workoutRestTimerActive: false,
   workoutRestTimerEndsAt: 0,
   workoutRestTimerDurationSec: 90,
+  manualWorkoutActsAsTodayOverride: false,
   workoutRestTargetKind: "",
   workoutRestNextEntryIndex: -1,
   editingCheckinId: null,
@@ -6436,6 +6437,7 @@ function wireTodayPlanActions(item){
 
   document.getElementById("acknowledgeRestDayBtn")?.addEventListener("click", handleRestDayAcknowledge);
   document.getElementById("openManualTrainingBtn")?.addEventListener("click", () => {
+    STATE.manualWorkoutActsAsTodayOverride = true;
     showWizardStep("manual");
   });
 
@@ -6580,17 +6582,25 @@ function buildTodayPlanHeroCardHtml({
   timeBudgetMin,
   planContextBits,
 }){
+  const metaBits = [
+    !isPlannedRestDay ? (variantLabel || "") : "",
+    timeBudgetMin ? tr("overview.time_today_short", { minutes: timeBudgetMin }) : ""
+  ].filter(Boolean);
+
+  const recoveryBit = planContextBits[0] || "";
+  const secondaryBits = planContextBits.slice(1);
+
   return `
     <li>
-      <div style="font-weight:700; font-size:1.1rem">${esc(heroTitle)}</div>
-      <div class="small" style="margin-top:6px">
-        ${esc([
-          !isPlannedRestDay ? (variantLabel || "") : "",
-          timeBudgetMin ? tr("overview.time_today_short", { minutes: timeBudgetMin }) : ""
-        ].filter(Boolean).join(" · "))}
-      </div>
-      ${heroLead ? `<div class="small" style="margin-top:8px; line-height:1.45">${esc(heroLead)}</div>` : ""}
-      ${planContextBits.length ? `<div class="small" style="margin-top:8px; line-height:1.45">${planContextBits.map(bit => esc(bit)).join("<br>")}</div>` : ""}
+      <div class="today-plan-hero-title">${esc(heroTitle)}</div>
+      ${metaBits.length ? `
+        <div class="today-plan-hero-meta">
+          ${metaBits.map(bit => `<div class="today-plan-hero-pill small">${esc(bit)}</div>`).join("")}
+        </div>
+      ` : ""}
+      ${heroLead ? `<div class="small today-plan-hero-lead">${esc(heroLead)}</div>` : ""}
+      ${recoveryBit ? `<div class="small today-plan-hero-context">${esc(recoveryBit)}</div>` : ""}
+      ${secondaryBits.map(bit => `<div class="small today-plan-hero-context">${esc(bit)}</div>`).join("")}
       ${heroActions}
     </li>
   `;
@@ -6650,6 +6660,13 @@ function deriveTodayPlanDisplayState(item){
       ? tr("plan.light_movement_today")
       : "";
 
+  const recoverySummaryText = recovery
+    ? tr("today_plan.recovery_label", { value: `${formatRecoveryState(recovery.recovery_state || "")}${recovery.recovery_score != null ? ` (${recovery.recovery_score})` : ""}` })
+    : "";
+  const recoveryExplanationText = Array.isArray(recovery?.explanation) && recovery.explanation.length
+    ? recovery.explanation.map(formatRecoveryExplanationBit).join(" · ")
+    : "";
+
   const decisionTrace = item?.decision_trace && typeof item.decision_trace === "object" ? item.decision_trace : null;
   const planVariantKey = String(item?.plan_variant || "").trim();
   const hasHighImpactOverride = Boolean(
@@ -6661,12 +6678,16 @@ function deriveTodayPlanDisplayState(item){
 
   const rawReason = String(item?.reason || "").trim();
   const overrideReasonText = rawReason ? formatPlanReason(rawReason) : "";
-  const planContextBits = hasHighImpactOverride
-    ? [
-        overrideReasonText ? `${tr("common.why_label")}: ${overrideReasonText}` : "",
-        familiesSummary,
-      ].filter(Boolean)
-    : [];
+  const planContextBits = [
+    recoverySummaryText,
+    recoveryExplanationText,
+    ...(hasHighImpactOverride
+      ? [
+          overrideReasonText ? `${tr("common.why_label")}: ${overrideReasonText}` : "",
+          familiesSummary,
+        ]
+      : [])
+  ].filter(Boolean);
 
   return {
     variantLabel,
@@ -6757,7 +6778,7 @@ function renderTodayPlan(item){
       planContextBits,
     });
 
-    const recoveryCard = buildTodayPlanRecoveryCardHtml(recovery);
+    const recoveryCard = "";
     const recommendationCard = buildTodayPlanProgramRecommendationCardHtml(item);
 
     const entryCards = buildTodayPlanEntryCardsHtml(item, isPlannedRestDay);
@@ -7325,6 +7346,7 @@ async function handleWorkoutSubmit(ev){
     notes: form.notes.value.trim(),
     program_id: form.program_id.value.trim(),
     program_day_label: selectedDay?.label || "",
+    is_manual_override: STATE.manualWorkoutActsAsTodayOverride === true,
     entries: [...STATE.pendingEntries]
   };
 
@@ -7335,6 +7357,7 @@ async function handleWorkoutSubmit(ev){
     setText("formStatus", tr("workout.saved"));
     statusEl?.classList.add("ok");
     STATE.pendingEntries = [];
+    STATE.manualWorkoutActsAsTodayOverride = false;
     form.reset();
     form.date.value = new Date().toISOString().slice(0,10);
     form.duration_min.value = 45;

--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -444,6 +444,44 @@ button{
   margin-top:12px;
 }
 
+.today-plan-hero-title{
+  font-weight:700;
+  font-size:1.1rem;
+}
+
+.today-plan-hero-meta{
+  margin-top:8px;
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+}
+
+.today-plan-hero-pill{
+  display:inline-flex;
+  align-items:center;
+  min-height:28px;
+  padding:4px 10px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.08);
+  background:rgba(255,255,255,0.03);
+  font-size:0.92rem;
+  line-height:1.2;
+}
+
+.today-plan-hero-lead{
+  margin-top:10px;
+  line-height:1.45;
+}
+
+.today-plan-hero-context{
+  margin-top:10px;
+  line-height:1.45;
+}
+
+.today-plan-hero-context + .today-plan-hero-context{
+  margin-top:6px;
+}
+
 #sessionReviewHeading{
   padding-top:2px;
 }


### PR DESCRIPTION
## Summary
This PR improves today-plan clarity on mobile and fixes a manual override bug that made the plan flow unstable.

## What changed

### Today-plan clarity
- moved recovery information into the hero area instead of showing it as a separate top card
- refined the hero layout so title, timing, recovery, and explanation scan more clearly
- added lightweight hero styling for better mobile readability

### Manual override semantics
- scoped manual override so it only applies when the user explicitly enters manual training from the today-plan flow
- stopped treating all manually saved workouts as today-plan overrides
- updated workout submit payload to send `is_manual_override: true` only for explicit today-plan override saves
- updated backend workout creation so override state is only stored when explicitly requested

## Why
The previous today-plan layout made users read through too many equally weighted blocks before reaching the actual session.

At the same time, manual workout saves were always stored as manual overrides, which blurred the distinction between:
- logging a normal workout
- explicitly overriding today's recommended plan

This caused especially confusing behavior on rest days, where manual override could feel unstable and there was no clear mental model for why the plan changed or reverted.

## Result
- today-plan is faster to scan
- recovery context is shown where it matters
- manual override now has clearer semantics
- normal workout logging no longer accidentally becomes a today-plan override

## Validation
- `node --check app/frontend/app.js`
- `python3 -m py_compile app/backend/app.py`
- manual UI test of:
  - normal training day
  - planned rest day
  - manual override entry from today-plan