### PR TITLE
Fix manual override plan rendering on rest days

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -521,6 +521,8 @@ def create_workout(user_id, payload):
     if session_type == "styrke" and not clean_entries:
         return None, make_error_payload("empty_workout", "ingen træningsdata at gemme"), 400
 
+    is_manual_override = bool(payload.get("is_manual_override", False))
+
     item = {
         "id": str(uuid.uuid4()),
         "user_id": user_id,
@@ -531,8 +533,8 @@ def create_workout(user_id, payload):
         "program_id": program_id,
         "program_day_label": program_day_label,
         "entries": clean_entries,
-        "is_manual_override": True,
-        "is_consumed": False,
+        "is_manual_override": is_manual_override,
+        "is_consumed": False if is_manual_override else None,
         "created_at": datetime.now(timezone.utc).isoformat()
     }
 

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6616,7 +6616,9 @@ function deriveTodayPlanDisplayState(item){
   const todayWeekPlanItem = getTodayWeekPlanItem(item);
   const todayWeekKind = String(todayWeekPlanItem?.kind || "").trim().toLowerCase();
   const actualKind = String(item?.session_type || "").trim().toLowerCase();
-  const isPlannedRestDay = todayWeekKind === "rest";
+  const isManualOverridePlan = String(item?.plan_variant || "").trim() === "manual_override"
+    || String(item?.source || "").trim() === "manual_override";
+  const isPlannedRestDay = todayWeekKind === "rest" && !isManualOverridePlan;
 
   let trainingAllowedSummary = "";
   if (todayWeekKind === "rest"){
@@ -8181,6 +8183,13 @@ function showWizardStep(stepId){
 
   if (todayPlanList){
     todayPlanList.classList.toggle("wizard-step-hidden", stepId === "review");
+  }
+
+  if (stepId === "plan"){
+    renderTodayPlan(STATE.currentTodayPlan || null);
+  } else if (stepId === "review"){
+    renderReviewSummary(STATE.currentTodayPlan || null);
+    renderSessionReview(STATE.currentTodayPlan || null);
   }
 
   if (todayPlanTiming){

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -24,6 +24,7 @@ let STATE = {
   workoutRestTimerActive: false,
   workoutRestTimerEndsAt: 0,
   workoutRestTimerDurationSec: 90,
+  manualWorkoutActsAsTodayOverride: false,
   workoutRestTargetKind: "",
   workoutRestNextEntryIndex: -1,
   editingCheckinId: null,
@@ -6436,6 +6437,7 @@ function wireTodayPlanActions(item){
 
   document.getElementById("acknowledgeRestDayBtn")?.addEventListener("click", handleRestDayAcknowledge);
   document.getElementById("openManualTrainingBtn")?.addEventListener("click", () => {
+    STATE.manualWorkoutActsAsTodayOverride = true;
     showWizardStep("manual");
   });
 
@@ -6580,17 +6582,25 @@ function buildTodayPlanHeroCardHtml({
   timeBudgetMin,
   planContextBits,
 }){
+  const metaBits = [
+    !isPlannedRestDay ? (variantLabel || "") : "",
+    timeBudgetMin ? tr("overview.time_today_short", { minutes: timeBudgetMin }) : ""
+  ].filter(Boolean);
+
+  const recoveryBit = planContextBits[0] || "";
+  const secondaryBits = planContextBits.slice(1);
+
   return `
     <li>
-      <div style="font-weight:700; font-size:1.1rem">${esc(heroTitle)}</div>
-      <div class="small" style="margin-top:6px">
-        ${esc([
-          !isPlannedRestDay ? (variantLabel || "") : "",
-          timeBudgetMin ? tr("overview.time_today_short", { minutes: timeBudgetMin }) : ""
-        ].filter(Boolean).join(" · "))}
-      </div>
-      ${heroLead ? `<div class="small" style="margin-top:8px; line-height:1.45">${esc(heroLead)}</div>` : ""}
-      ${planContextBits.length ? `<div class="small" style="margin-top:8px; line-height:1.45">${planContextBits.map(bit => esc(bit)).join("<br>")}</div>` : ""}
+      <div class="today-plan-hero-title">${esc(heroTitle)}</div>
+      ${metaBits.length ? `
+        <div class="today-plan-hero-meta">
+          ${metaBits.map(bit => `<div class="today-plan-hero-pill small">${esc(bit)}</div>`).join("")}
+        </div>
+      ` : ""}
+      ${heroLead ? `<div class="small today-plan-hero-lead">${esc(heroLead)}</div>` : ""}
+      ${recoveryBit ? `<div class="small today-plan-hero-context">${esc(recoveryBit)}</div>` : ""}
+      ${secondaryBits.map(bit => `<div class="small today-plan-hero-context">${esc(bit)}</div>`).join("")}
       ${heroActions}
     </li>
   `;
@@ -6650,6 +6660,13 @@ function deriveTodayPlanDisplayState(item){
       ? tr("plan.light_movement_today")
       : "";
 
+  const recoverySummaryText = recovery
+    ? tr("today_plan.recovery_label", { value: `${formatRecoveryState(recovery.recovery_state || "")}${recovery.recovery_score != null ? ` (${recovery.recovery_score})` : ""}` })
+    : "";
+  const recoveryExplanationText = Array.isArray(recovery?.explanation) && recovery.explanation.length
+    ? recovery.explanation.map(formatRecoveryExplanationBit).join(" · ")
+    : "";
+
   const decisionTrace = item?.decision_trace && typeof item.decision_trace === "object" ? item.decision_trace : null;
   const planVariantKey = String(item?.plan_variant || "").trim();
   const hasHighImpactOverride = Boolean(
@@ -6661,12 +6678,16 @@ function deriveTodayPlanDisplayState(item){
 
   const rawReason = String(item?.reason || "").trim();
   const overrideReasonText = rawReason ? formatPlanReason(rawReason) : "";
-  const planContextBits = hasHighImpactOverride
-    ? [
-        overrideReasonText ? `${tr("common.why_label")}: ${overrideReasonText}` : "",
-        familiesSummary,
-      ].filter(Boolean)
-    : [];
+  const planContextBits = [
+    recoverySummaryText,
+    recoveryExplanationText,
+    ...(hasHighImpactOverride
+      ? [
+          overrideReasonText ? `${tr("common.why_label")}: ${overrideReasonText}` : "",
+          familiesSummary,
+        ]
+      : [])
+  ].filter(Boolean);
 
   return {
     variantLabel,
@@ -6757,7 +6778,7 @@ function renderTodayPlan(item){
       planContextBits,
     });
 
-    const recoveryCard = buildTodayPlanRecoveryCardHtml(recovery);
+    const recoveryCard = "";
     const recommendationCard = buildTodayPlanProgramRecommendationCardHtml(item);
 
     const entryCards = buildTodayPlanEntryCardsHtml(item, isPlannedRestDay);
@@ -7325,6 +7346,7 @@ async function handleWorkoutSubmit(ev){
     notes: form.notes.value.trim(),
     program_id: form.program_id.value.trim(),
     program_day_label: selectedDay?.label || "",
+    is_manual_override: STATE.manualWorkoutActsAsTodayOverride === true,
     entries: [...STATE.pendingEntries]
   };
 
@@ -7335,6 +7357,7 @@ async function handleWorkoutSubmit(ev){
     setText("formStatus", tr("workout.saved"));
     statusEl?.classList.add("ok");
     STATE.pendingEntries = [];
+    STATE.manualWorkoutActsAsTodayOverride = false;
     form.reset();
     form.date.value = new Date().toISOString().slice(0,10);
     form.duration_min.value = 45;

--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -444,6 +444,44 @@ button{
   margin-top:12px;
 }
 
+.today-plan-hero-title{
+  font-weight:700;
+  font-size:1.1rem;
+}
+
+.today-plan-hero-meta{
+  margin-top:8px;
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+}
+
+.today-plan-hero-pill{
+  display:inline-flex;
+  align-items:center;
+  min-height:28px;
+  padding:4px 10px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,0.08);
+  background:rgba(255,255,255,0.03);
+  font-size:0.92rem;
+  line-height:1.2;
+}
+
+.today-plan-hero-lead{
+  margin-top:10px;
+  line-height:1.45;
+}
+
+.today-plan-hero-context{
+  margin-top:10px;
+  line-height:1.45;
+}
+
+.today-plan-hero-context + .today-plan-hero-context{
+  margin-top:6px;
+}
+
 #sessionReviewHeading{
   padding-top:2px;
 }


### PR DESCRIPTION
## Summary
This PR fixes the remaining today-plan rendering issue where an active manual override could still appear as a planned rest day in the UI.

## What changed
- treat `manual_override` today-plans as active session plans in the display layer
- prevent the plan screen from using rest-day presentation when the active plan source is a manual override
- force today-plan and review re-render when entering the corresponding wizard steps

## Why
The previous fix corrected manual override semantics and data flow, but one rendering issue remained:
- the backend returned the manual override correctly
- the saved workout was matched correctly
- but the frontend still used the week-plan rest-day presentation when the underlying week plan said rest

That created a contradictory screen where the user had an active strength plan, but the hero still behaved like a planned rest day.

## Result
- active manual override plans now render as actual training plans
- rest-day presentation is still preserved for true rest days
- plan/review steps now refresh from current state when opened, reducing stale UI after manual saves

## Validation
- `node --check app/frontend/app.js`
- manual test:
  - open a planned rest day
  - choose manual training
  - save workout
  - verify that today-plan renders the manual strength override instead of planned rest-day presentation