### PR TITLE
Add return-to-autoplan action for manual today-plan overrides

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6441,6 +6441,18 @@ function wireTodayPlanActions(item){
     showWizardStep("manual");
   });
 
+  document.getElementById("returnToAutoplanBtn")?.addEventListener("click", async () => {
+    const workoutId = String(item?.manual_override_workout_id || "").trim();
+    if (!workoutId) return;
+    if (!window.confirm(tr("today_plan.return_to_autoplan_confirm"))){
+      return;
+    }
+    await apiJsonRequest("DELETE", `/api/workouts/${encodeURIComponent(workoutId)}`);
+    STATE.manualWorkoutActsAsTodayOverride = false;
+    await refreshAll();
+    showWizardStep("plan");
+  });
+
   document.querySelectorAll("[data-apply-recommended-strength-program]").forEach(btn => {
     btn.addEventListener("click", async () => {
       const programId = String(btn.getAttribute("data-apply-recommended-strength-program") || "").trim();
@@ -6557,6 +6569,7 @@ function buildTodayPlanRecoveryCardHtml(recovery){
 function buildTodayPlanHeroActionsHtml({
   showPlannedRestChoiceCard,
   showRestitutionChoice,
+  manualOverrideWorkoutId,
 }){
   return showPlannedRestChoiceCard
     ? `
@@ -6567,8 +6580,9 @@ function buildTodayPlanHeroActionsHtml({
       </div>
     `
     : `
-      <div style="margin-top:12px">
+      <div style="margin-top:12px; display:flex; gap:10px; flex-wrap:wrap">
         <button type="button" id="startWorkoutBtn">${esc(tr("button.start_workout"))}</button>
+        ${manualOverrideWorkoutId ? `<button type="button" class="secondary" id="returnToAutoplanBtn">${esc(tr("today_plan.return_to_autoplan"))}</button>` : ""}
       </div>
     `;
 }
@@ -6768,6 +6782,7 @@ function renderTodayPlan(item){
       : buildTodayPlanHeroActionsHtml({
           showPlannedRestChoiceCard,
           showRestitutionChoice,
+          manualOverrideWorkoutId: String(item?.manual_override_workout_id || "").trim(),
         });
 
     const heroCard = buildTodayPlanHeroCardHtml({

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -718,6 +718,8 @@
   "button.switch_to_recommended_program": "Skift til anbefalet program",
   "today_plan.recommended_program_title": "Anbefalet program",
   "today_plan.recommended_strength_program_value": "Anbefalet styrkeprogram: {value}",
+  "today_plan.return_to_autoplan": "Tilbage til autoplan",
+  "today_plan.return_to_autoplan_confirm": "Fjern manuel overstyring og gå tilbage til autoplan for i dag?",
   "profile.active_program_selected_by_user": "Valgt af dig",
   "profile.active_program_selected_automatically": "Valgt automatisk",
   "profile.active_program_auto_assigned": "Valgt automatisk fra start",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -702,6 +702,8 @@
   "button.switch_to_recommended_program": "Switch to recommended program",
   "today_plan.recommended_program_title": "Recommended program",
   "today_plan.recommended_strength_program_value": "Recommended strength program: {value}",
+  "today_plan.return_to_autoplan": "Return to autoplan",
+  "today_plan.return_to_autoplan_confirm": "Remove the manual override and return to autoplan for today?",
   "profile.active_program_selected_by_user": "Selected by you",
   "profile.active_program_selected_automatically": "Chosen automatically",
   "profile.active_program_auto_assigned": "Auto-assigned initially",


### PR DESCRIPTION
## Summary
This PR makes manual today-plan overrides reversible by adding a clear “Return to autoplan” action when a manual override is active.

## What changed
- show a `Return to autoplan` button in the today-plan hero when the active plan comes from a manual override
- use the existing `manual_override_workout_id` to remove the override workout through the existing workout delete route
- refresh today-plan state after removal and return the user to the plan step
- move the new button label and confirmation copy into i18n for Danish and English

## Why
Manual override could be activated from today-plan, but there was no direct way back to the app’s normal automatic planning. That made the override feel sticky and harder to trust.

A manual override should be:
- explicit
- visible
- reversible

This PR adds the missing reversible step without introducing new backend state or duplicate flows.

## Result
- users can return from manual override to the normal autoplan for today
- the action is available only when relevant
- the flow stays simple and uses existing backend deletion logic
- the UI remains translated in both Danish and English

## Validation
- `node --check app/frontend/app.js`
- manual test:
  - activate manual override from today-plan
  - verify the `Return to autoplan` button appears
  - confirm removal
  - verify today-plan returns to normal autoplan state