### PR TITLE
Clear all same-day manual overrides when returning to autoplan

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6442,12 +6442,25 @@ function wireTodayPlanActions(item){
   });
 
   document.getElementById("returnToAutoplanBtn")?.addEventListener("click", async () => {
-    const workoutId = String(item?.manual_override_workout_id || "").trim();
-    if (!workoutId) return;
+    const todayDate = String(STATE.latestCheckin?.date || item?.date || "").trim();
+    if (!todayDate) return;
     if (!window.confirm(tr("today_plan.return_to_autoplan_confirm"))){
       return;
     }
-    await apiJsonRequest("DELETE", `/api/workouts/${encodeURIComponent(workoutId)}`);
+
+    const overrideWorkoutIds = (Array.isArray(STATE.workouts) ? STATE.workouts : [])
+      .filter(workout =>
+        workout
+        && String(workout.date || "").trim() === todayDate
+        && workout.is_manual_override === true
+      )
+      .map(workout => String(workout.id || "").trim())
+      .filter(Boolean);
+
+    for (const workoutId of overrideWorkoutIds){
+      await apiJsonRequest("DELETE", `/api/workouts/${encodeURIComponent(workoutId)}`);
+    }
+
     STATE.manualWorkoutActsAsTodayOverride = false;
     await refreshAll();
     showWizardStep("plan");


### PR DESCRIPTION
## Summary
This PR fixes the remaining return-to-autoplan issue by clearing all manual override workouts for the active day instead of deleting only the latest one.

## What changed
- updated the `Return to autoplan` action to find all same-day workouts with `is_manual_override === true`
- delete each matching override workout before refreshing today-plan state
- keep the existing refresh and plan-step return flow unchanged

## Why
The previous implementation only removed the latest manual override workout. If older manual overrides still existed for the same day, the backend would simply resolve the next remaining override and the user would appear stuck in manual override mode.

Returning to autoplan should remove the full active override state for that day, not just the newest layer of it.

## Result
- `Return to autoplan` now actually returns the user to autoplan
- older same-day override workouts no longer re-activate the manual override state
- the behavior now matches the user’s expectation of a full reset back to the automatic plan

## Validation
- `node --check app/frontend/app.js`
- manual test:
  - create multiple same-day manual overrides
  - activate `Return to autoplan`
  - verify today-plan returns to autoplan instead of falling back to an older override