### PR TITLE
Polish today-plan override copy and empty workout error feedback

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6758,7 +6758,11 @@ function renderTodayPlan(item){
       planContextBits,
     } = deriveTodayPlanDisplayState(item);
 
-    const compactSummaryLead = trainingAllowedSummary || recoveryDaySummary || "";
+    const isManualOverridePlan = String(item?.plan_variant || "").trim() === "manual_override"
+      || String(item?.source || "").trim() === "manual_override";
+    const compactSummaryLead = isManualOverridePlan
+      ? ""
+      : (trainingAllowedSummary || recoveryDaySummary || "");
     setText(
       "todayPlanSummary",
       compactSummaryLead
@@ -7398,7 +7402,11 @@ async function handleWorkoutSubmit(ev){
     await refreshAll();
     advanceWizardAfterCheckin();
   }catch(err){
-    setText("formStatus", tr("status.error_prefix") + (err?.message || String(err)));
+    const rawMessage = String(err?.message || err || "").trim();
+    const normalizedMessage = rawMessage === "empty_workout"
+      ? tr("workout.empty_workout_error")
+      : rawMessage;
+    setText("formStatus", tr("status.error_prefix") + normalizedMessage);
     statusEl?.classList.remove("ok");
     statusEl?.classList.add("warn");
   }

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -283,6 +283,7 @@
   "workout.select_program_day_first": "Vælg en dag fra programmet.",
   "status.saving_generic": "Gemmer...",
   "workout.saved": "Workout gemt.",
+  "workout.empty_workout_error": "Tilføj mindst én øvelse før du gemmer workout.",
   "review.saving_session_result": "Gemmer session-resultat...",
   "review.session_result_saved": "Session-resultat gemt.",
   "review.next_progression_label": "Progression næste gang",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -270,6 +270,7 @@
   "workout.select_program_day_first": "Select a day from the program first.",
   "status.saving_generic": "Saving...",
   "workout.saved": "Workout saved.",
+  "workout.empty_workout_error": "Add at least one exercise before saving the workout.",
   "review.saving_session_result": "Saving session result...",
   "review.session_result_saved": "Session result saved.",
   "review.next_progression_label": "Next progression",


### PR DESCRIPTION
## Summary
This PR fixes the last two UI rough edges in the today-plan/manual workout flow.

## What changed
- hide the misleading top summary line when the active today-plan is a manual override
- map the `empty_workout` save error to a clear user-facing validation message
- add translated empty-workout error copy in Danish and English

## Why
Two small but visible issues remained after the main override fixes:
- the today-plan screen could still show a rest-day summary line even when a manual override was already active
- saving a manual workout without exercises showed a raw backend error instead of a helpful message

These were no longer logic failures, just UI honesty and feedback problems.

## Result
- active manual override plans no longer show contradictory rest-day summary copy
- empty manual workout saves now show a clear validation message
- the manual flow feels more complete and less raw at the edges

## Validation
- `node --check app/frontend/app.js`
- manual test:
  - activate manual override and verify the top summary no longer claims rest day
  - try saving an empty workout and verify the user sees a clear validation error