### PR TITLE
Consolidate workout review handoff before further execution model expansion

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6006,12 +6006,7 @@ function completeTimedHoldSet(item){
   STATE.currentWorkoutSetIndex = 0;
 
   if (isLast){
-    STATE.workoutInProgress = false;
-    STATE.currentWorkoutEntryIndex = 0;
-    clearWorkoutRestTimer();
-    renderReviewSummary(item);
-    renderSessionReview(item);
-    showWizardStep("review");
+    finishActiveWorkoutAndOpenReview(item);
     return true;
   }
 
@@ -6030,6 +6025,16 @@ function clearWorkoutRestTimer(){
   STATE.workoutRestTargetKind = "";
   STATE.workoutRestNextEntryIndex = -1;
   window.clearTimeout(window.__ssWorkoutRestTick || 0);
+}
+
+function finishActiveWorkoutAndOpenReview(item){
+  STATE.workoutInProgress = false;
+  STATE.currentWorkoutEntryIndex = 0;
+  STATE.currentWorkoutSetIndex = 0;
+  clearWorkoutRestTimer();
+  renderReviewSummary(item);
+  renderSessionReview(item);
+  showWizardStep("review");
 }
 
 function startWorkoutRestTimer(durationSec, options = {}){
@@ -6112,6 +6117,22 @@ function saveActiveWorkoutEntryProgress(item){
   const entry = active.entry;
   const idx = active.index;
   const setCount = Math.max(1, Number(entry.sets || 1));
+
+  setText("sessionResultStatus", JSON.stringify({
+    exercise_id: entry?.exercise_id || "",
+    entry_sets: entry?.sets,
+    computed_set_count: setCount,
+    current_set_index: Number(STATE.currentWorkoutSetIndex || 0),
+    existing_result_sets: Array.isArray(entry?._existing_result?.sets) ? entry._existing_result.sets.length : 0
+  }));
+
+  console.log("[SS workout saveActiveWorkoutEntryProgress]", {
+    exercise_id: entry?.exercise_id || "",
+    entry_sets: entry?.sets,
+    computed_set_count: setCount,
+    current_set_index: Number(STATE.currentWorkoutSetIndex || 0),
+    existing_result: entry?._existing_result || null
+  });
   const currentSetIndex = getCurrentWorkoutSetIndex(entry);
   const existing = entry._existing_result && typeof entry._existing_result === "object"
     ? entry._existing_result
@@ -6404,12 +6425,7 @@ function renderActiveWorkoutCard(item){
           STATE.currentWorkoutSetIndex = 0;
 
           if (isLast){
-            STATE.workoutInProgress = false;
-            STATE.currentWorkoutEntryIndex = 0;
-            clearWorkoutRestTimer();
-            renderReviewSummary(item);
-            renderSessionReview(item);
-            showWizardStep("review");
+            finishActiveWorkoutAndOpenReview(item);
             return;
           }
 
@@ -6444,12 +6460,7 @@ function renderActiveWorkoutCard(item){
         STATE.currentWorkoutSetIndex = 0;
 
         if (isLast){
-          STATE.workoutInProgress = false;
-          STATE.currentWorkoutEntryIndex = 0;
-          clearWorkoutRestTimer();
-          renderReviewSummary(item);
-          renderSessionReview(item);
-          showWizardStep("review");
+          finishActiveWorkoutAndOpenReview(item);
           return;
         }
 

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6118,21 +6118,6 @@ function saveActiveWorkoutEntryProgress(item){
   const idx = active.index;
   const setCount = Math.max(1, Number(entry.sets || 1));
 
-  setText("sessionResultStatus", JSON.stringify({
-    exercise_id: entry?.exercise_id || "",
-    entry_sets: entry?.sets,
-    computed_set_count: setCount,
-    current_set_index: Number(STATE.currentWorkoutSetIndex || 0),
-    existing_result_sets: Array.isArray(entry?._existing_result?.sets) ? entry._existing_result.sets.length : 0
-  }));
-
-  console.log("[SS workout saveActiveWorkoutEntryProgress]", {
-    exercise_id: entry?.exercise_id || "",
-    entry_sets: entry?.sets,
-    computed_set_count: setCount,
-    current_set_index: Number(STATE.currentWorkoutSetIndex || 0),
-    existing_result: entry?._existing_result || null
-  });
   const currentSetIndex = getCurrentWorkoutSetIndex(entry);
   const existing = entry._existing_result && typeof entry._existing_result === "object"
     ? entry._existing_result


### PR DESCRIPTION
## Summary

This PR takes a small but important first consolidation step for issue #232 by removing duplicated workout-to-review handoff logic from the active workout execution flow.

The Workout Player already has a real execution layer for active sessions. Before expanding it further with more timer modes, protocol handling, or bundled session structures, it helps to reduce repeated transition logic in the current flow.

This change introduces a shared helper for the final handoff from active workout execution to review and replaces the duplicated inline branches that previously performed the same transition in multiple places.

## What changed

Added a shared helper:

- `finishActiveWorkoutAndOpenReview(item)`

This helper now owns the common transition sequence for:

- ending the active workout state
- resetting the active entry index
- resetting the active set index
- clearing the workout rest timer
- rendering review summary
- rendering session review
- switching to the review step

The duplicated inline handoff branches were replaced in the current execution flow where the workout reaches its final review transition.

## Why this helps

This is intentionally a small guardrail change, not a large refactor.

The main goal is to make the execution path a bit more structurally sane before further Workout Player expansion. Previously, the same workout completion handoff existed in multiple places, which made future changes riskier and increased the chance of drift between branches.

By consolidating that handoff into one shared helper, the current execution model becomes a little easier to reason about and a little harder to fragment through copy-paste changes.

## Scope

Included:

- small execution-model cleanup in the frontend Workout Player flow
- consolidation of duplicated review handoff logic
- no change to intended feature scope or user-facing workout modes

Not included:

- no Workout Player rewrite
- no new workout modes
- no protocol abstraction layer
- no bundled session implementation
- no large state-model redesign

## Validation

Validated locally by checking that workout execution still reaches review correctly in the relevant paths after the shared helper was introduced.

This PR is meant as a first consolidation step under issue #232, not the full execution model documentation effort.

## Issue

Closes part of #232