### PR TITLE
Refine workout execution flow because active logging should stay consistent and goal-shaped

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6006,12 +6006,7 @@ function completeTimedHoldSet(item){
   STATE.currentWorkoutSetIndex = 0;
 
   if (isLast){
-    STATE.workoutInProgress = false;
-    STATE.currentWorkoutEntryIndex = 0;
-    clearWorkoutRestTimer();
-    renderReviewSummary(item);
-    renderSessionReview(item);
-    showWizardStep("review");
+    finishActiveWorkoutAndOpenReview(item);
     return true;
   }
 
@@ -6030,6 +6025,16 @@ function clearWorkoutRestTimer(){
   STATE.workoutRestTargetKind = "";
   STATE.workoutRestNextEntryIndex = -1;
   window.clearTimeout(window.__ssWorkoutRestTick || 0);
+}
+
+function finishActiveWorkoutAndOpenReview(item){
+  STATE.workoutInProgress = false;
+  STATE.currentWorkoutEntryIndex = 0;
+  STATE.currentWorkoutSetIndex = 0;
+  clearWorkoutRestTimer();
+  renderReviewSummary(item);
+  renderSessionReview(item);
+  showWizardStep("review");
 }
 
 function startWorkoutRestTimer(durationSec, options = {}){
@@ -6112,6 +6117,22 @@ function saveActiveWorkoutEntryProgress(item){
   const entry = active.entry;
   const idx = active.index;
   const setCount = Math.max(1, Number(entry.sets || 1));
+
+  setText("sessionResultStatus", JSON.stringify({
+    exercise_id: entry?.exercise_id || "",
+    entry_sets: entry?.sets,
+    computed_set_count: setCount,
+    current_set_index: Number(STATE.currentWorkoutSetIndex || 0),
+    existing_result_sets: Array.isArray(entry?._existing_result?.sets) ? entry._existing_result.sets.length : 0
+  }));
+
+  console.log("[SS workout saveActiveWorkoutEntryProgress]", {
+    exercise_id: entry?.exercise_id || "",
+    entry_sets: entry?.sets,
+    computed_set_count: setCount,
+    current_set_index: Number(STATE.currentWorkoutSetIndex || 0),
+    existing_result: entry?._existing_result || null
+  });
   const currentSetIndex = getCurrentWorkoutSetIndex(entry);
   const existing = entry._existing_result && typeof entry._existing_result === "object"
     ? entry._existing_result
@@ -6404,12 +6425,7 @@ function renderActiveWorkoutCard(item){
           STATE.currentWorkoutSetIndex = 0;
 
           if (isLast){
-            STATE.workoutInProgress = false;
-            STATE.currentWorkoutEntryIndex = 0;
-            clearWorkoutRestTimer();
-            renderReviewSummary(item);
-            renderSessionReview(item);
-            showWizardStep("review");
+            finishActiveWorkoutAndOpenReview(item);
             return;
           }
 
@@ -6444,12 +6460,7 @@ function renderActiveWorkoutCard(item){
         STATE.currentWorkoutSetIndex = 0;
 
         if (isLast){
-          STATE.workoutInProgress = false;
-          STATE.currentWorkoutEntryIndex = 0;
-          clearWorkoutRestTimer();
-          renderReviewSummary(item);
-          renderSessionReview(item);
-          showWizardStep("review");
+          finishActiveWorkoutAndOpenReview(item);
           return;
         }
 

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4106,6 +4106,7 @@ function buildReviewSetFields(entry, idx, setIdx){
 function buildWorkoutSetFields(entry, idx, setIdx){
   const meta = getReviewExerciseMeta(entry?.exercise_id);
   const inputKind = String(meta?.input_kind || "");
+  const workoutRepChoices = getWorkoutRepChoicesForEntry(entry);
   const currentLoad = String(entry?.target_load || "").trim();
   const existingResult = entry?._existing_result && typeof entry._existing_result === "object" ? entry._existing_result : {};
   const existingSets = Array.isArray(existingResult.sets) ? existingResult.sets : [];
@@ -4162,8 +4163,8 @@ function buildWorkoutSetFields(entry, idx, setIdx){
         <div class="small" style="margin-bottom:8px; opacity:0.82">${tr("exercise.set_label", { number: setIdx + 1 })}</div>
         <label style="margin-bottom:0">
           Reps
-          ${Array.isArray(meta?.workout_rep_choices) && meta.workout_rep_choices.length
-            ? buildWorkoutRepChoiceButtons(`review_set_reps_${idx}_${setIdx}`, meta.workout_rep_choices, existingReps)
+          ${workoutRepChoices.length
+            ? buildWorkoutRepChoiceButtons(`review_set_reps_${idx}_${setIdx}`, workoutRepChoices, existingReps)
             : buildReviewValueSelect(`review_set_reps_${idx}_${setIdx}`, getReviewRepOptions(meta), existingReps, tr("after_training.select_reps"))}
         </label>
         <div class="small" style="margin-top:6px; opacity:0.72">${tr("exercise.load_bodyweight")}</div>
@@ -4176,8 +4177,8 @@ function buildWorkoutSetFields(entry, idx, setIdx){
       <div class="small" style="margin-bottom:8px; opacity:0.82">${tr("exercise.set_label", { number: setIdx + 1 })}</div>
       <label style="margin-bottom:10px">
         Reps
-        ${Array.isArray(meta?.workout_rep_choices) && meta.workout_rep_choices.length
-          ? buildWorkoutRepChoiceButtons(`review_set_reps_${idx}_${setIdx}`, meta.workout_rep_choices, existingReps)
+        ${workoutRepChoices.length
+          ? buildWorkoutRepChoiceButtons(`review_set_reps_${idx}_${setIdx}`, workoutRepChoices, existingReps)
           : buildReviewValueSelect(`review_set_reps_${idx}_${setIdx}`, getReviewRepOptions(meta), existingReps, tr("after_training.select_reps"))}
       </label>
       <label style="margin-bottom:0">
@@ -5044,6 +5045,26 @@ function getEntrySetBounds(entry){
     max: options[options.length - 1] || currentSets,
     options: options.length ? options : [currentSets]
   };
+}
+
+function getWorkoutRepChoicesForEntry(entry){
+  const target = String(entry?.target_reps || "").trim();
+  const nums = [...target.matchAll(/\d+/g)]
+    .map(m => Number(m[0]))
+    .filter(Number.isFinite)
+    .map(n => Math.max(0, Math.trunc(n)));
+
+  if (nums.length){
+    const max = Math.max(...nums);
+    return Array.from({ length: max + 1 }, (_, i) => String(i));
+  }
+
+  const repBounds = getEntryRepBounds(entry);
+  if (repBounds.kind === "reps" && Array.isArray(repBounds.options) && repBounds.options.length){
+    return repBounds.options.map(String);
+  }
+
+  return [];
 }
 
 function getEntryRepBounds(entry){

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6118,21 +6118,6 @@ function saveActiveWorkoutEntryProgress(item){
   const idx = active.index;
   const setCount = Math.max(1, Number(entry.sets || 1));
 
-  setText("sessionResultStatus", JSON.stringify({
-    exercise_id: entry?.exercise_id || "",
-    entry_sets: entry?.sets,
-    computed_set_count: setCount,
-    current_set_index: Number(STATE.currentWorkoutSetIndex || 0),
-    existing_result_sets: Array.isArray(entry?._existing_result?.sets) ? entry._existing_result.sets.length : 0
-  }));
-
-  console.log("[SS workout saveActiveWorkoutEntryProgress]", {
-    exercise_id: entry?.exercise_id || "",
-    entry_sets: entry?.sets,
-    computed_set_count: setCount,
-    current_set_index: Number(STATE.currentWorkoutSetIndex || 0),
-    existing_result: entry?._existing_result || null
-  });
   const currentSetIndex = getCurrentWorkoutSetIndex(entry);
   const existing = entry._existing_result && typeof entry._existing_result === "object"
     ? entry._existing_result


### PR DESCRIPTION
## Summary

This PR refines the active workout execution flow in two small but important ways under issue #232.

First, it consolidates the repeated handoff from active workout execution to the review step into a shared helper. This reduces duplication in the workout player and makes the execution path easier to keep consistent.

Second, it changes workout rep buttons so they follow the day's actual target rep range instead of broad exercise-level metadata options. In workout mode, rep logging should reflect the concrete goal of the current plan entry, not a wider catalog of possible progression ranges.

## What changed

### 1. Consolidated workout → review handoff

Added a shared helper:

- `finishActiveWorkoutAndOpenReview(item)`

This helper now owns the final transition from active workout execution to review, including:

- ending workout-in-progress state
- resetting active entry index
- resetting active set index
- clearing rest timer state
- rendering review summary
- rendering session review
- opening the review step

The duplicated inline branches were replaced in the current execution flow.

### 2. Workout rep buttons now follow the actual plan target

Added:

- `getWorkoutRepChoicesForEntry(entry)`

This helper derives compact rep choices from the current entry's `target_reps`.

Examples:

- `6-8` → `0..8`
- `10-12` → `0..12`
- `4-6` → `0..6`
- `8/side` → `0..8`

`buildWorkoutSetFields()` now uses these entry-specific choices for rep buttons instead of relying only on `meta.workout_rep_choices`.

This makes active workout logging more consistent across rep-based exercises like squat, bench press, and RDL.

## Why this helps

The workout player should optimize for fast, clear execution during a live session.

Before this PR:

- the final workout-to-review transition was duplicated
- some rep-based exercises showed button choices based on broad metadata rather than the actual goal for the day

After this PR:

- the execution handoff is structurally cleaner
- rep buttons better match the actual workout prescription
- the active logging flow is more predictable on mobile

## Scope

Included:

- small frontend execution-flow cleanup
- shared helper for final workout handoff
- entry-based workout rep button choices

Not included:

- no state-model redesign
- no backend changes
- no protocol bundling or multi-block workout system
- no large workout player rewrite

## Validation

Validated by checking the active workout flow and confirming that rep-based exercises now use goal-shaped button ranges based on the current entry target.

## Issue

Closes part of #232