### PR TITLE
Consolidate workout set transitions because active execution paths should advance the same way

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6058,6 +6058,34 @@ function finishActiveWorkoutAndOpenReview(item){
   showWizardStep("review");
 }
 
+function advanceActiveWorkoutAfterCompletedSet(item, idx, currentSetIndex, hasMoreSetsRemaining){
+  if (hasMoreSetsRemaining){
+    STATE.currentWorkoutSetIndex = currentSetIndex + 1;
+    startWorkoutRestTimer(undefined, {
+      targetKind: "next_set",
+      nextEntryIndex: idx,
+    });
+    renderTodayPlan(item);
+    return;
+  }
+
+  STATE.currentWorkoutSetIndex = 0;
+
+  const entries = Array.isArray(item?.entries) ? item.entries : [];
+  const isLast = idx >= entries.length - 1;
+  if (isLast){
+    finishActiveWorkoutAndOpenReview(item);
+    return;
+  }
+
+  STATE.currentWorkoutEntryIndex = idx + 1;
+  startWorkoutRestTimer(undefined, {
+    targetKind: "next_exercise",
+    nextEntryIndex: idx + 1,
+  });
+  renderTodayPlan(item);
+}
+
 function startWorkoutRestTimer(durationSec, options = {}){
   const seconds = Math.max(5, Number(durationSec || STATE.workoutRestTimerDurationSec || 90));
   STATE.workoutRestTimerDurationSec = seconds;
@@ -6418,29 +6446,7 @@ function renderActiveWorkoutCard(item){
           clearTimedHoldTick();
           saveActiveWorkoutEntryProgress(item);
 
-          if (hasMoreSetsRemaining){
-            STATE.currentWorkoutSetIndex = currentSetIndex + 1;
-            startWorkoutRestTimer(undefined, {
-              targetKind: "next_set",
-              nextEntryIndex: idx,
-            });
-            renderTodayPlan(item);
-            return;
-          }
-
-          STATE.currentWorkoutSetIndex = 0;
-
-          if (isLast){
-            finishActiveWorkoutAndOpenReview(item);
-            return;
-          }
-
-          STATE.currentWorkoutEntryIndex = idx + 1;
-          startWorkoutRestTimer(undefined, {
-            targetKind: "next_exercise",
-            nextEntryIndex: idx + 1,
-          });
-          renderTodayPlan(item);
+          advanceActiveWorkoutAfterCompletedSet(item, idx, currentSetIndex, hasMoreSetsRemaining);
         }
       });
 
@@ -6453,29 +6459,7 @@ function renderActiveWorkoutCard(item){
 
         saveActiveWorkoutEntryProgress(item);
 
-        if (hasMoreSetsRemaining && !isCardioEntry){
-          STATE.currentWorkoutSetIndex = currentSetIndex + 1;
-          startWorkoutRestTimer(undefined, {
-            targetKind: "next_set",
-            nextEntryIndex: idx,
-          });
-          renderTodayPlan(item);
-          return;
-        }
-
-        STATE.currentWorkoutSetIndex = 0;
-
-        if (isLast){
-          finishActiveWorkoutAndOpenReview(item);
-          return;
-        }
-
-        STATE.currentWorkoutEntryIndex = idx + 1;
-        startWorkoutRestTimer(undefined, {
-          targetKind: "next_exercise",
-          nextEntryIndex: idx + 1,
-        });
-        renderTodayPlan(item);
+        advanceActiveWorkoutAfterCompletedSet(item, idx, currentSetIndex, hasMoreSetsRemaining && !isCardioEntry);
       });
 }
 


### PR DESCRIPTION
## Summary

This PR continues issue #232 with a small structural cleanup in the workout execution model.

It consolidates the repeated post-set transition logic that previously existed in parallel branches for timed hold exercises and standard workout exercises.

Both flows were making the same core decision after a completed set:

- continue to next set with rest
- move to next exercise with rest
- or finish the workout and open review

That logic now lives in one shared helper instead of being duplicated.

## What changed

Added:

- `advanceActiveWorkoutAfterCompletedSet(item, idx, currentSetIndex, hasMoreSetsRemaining)`

This helper now owns the common transition after a completed set:

- if more sets remain:
  - increment active set index
  - start rest timer toward next set
  - rerender today plan

- if no more sets remain:
  - reset active set index
  - if this is the last entry, finish workout and open review
  - otherwise move to next exercise, start rest timer, and rerender

Replaced duplicated transition branches in:

- timed hold completion flow inside `renderActiveWorkoutCard(...)`
- standard next-step flow inside `renderActiveWorkoutCard(...)`

## Why this helps

This makes the workout execution model more consistent.

Before this PR, timed hold and standard set flows contained their own copies of the same post-set progression logic. That made the flow harder to reason about and increased the risk that the two paths would drift apart over time.

After this PR, both flows advance through the workout using the same shared transition helper.

## Scope

Included:

- frontend workout execution cleanup
- shared post-set transition helper
- reduced duplication in active workout flow

Not included:

- no backend changes
- no UI redesign
- no manual workout state isolation fix
- no mixed summary metric fix
- no full workout execution rewrite

## Validation

Validated by checking that the active workout flow still advances correctly through:

- next set transitions
- next exercise transitions
- final handoff into review

## Issue

Closes part of #232