### PR TITLE
Consolidate workout runtime cleanup because execution lifecycle paths should clear the same state

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6048,11 +6048,22 @@ function clearWorkoutRestTimer(){
   window.clearTimeout(window.__ssWorkoutRestTick || 0);
 }
 
+function clearWorkoutRuntimeArtifacts(item){
+  clearWorkoutRestTimer();
+  clearTimedHoldTick();
+
+  const entries = Array.isArray(item?.entries) ? item.entries : [];
+  for (const entry of entries){
+    if (!entry || typeof entry !== "object") continue;
+    clearTimedHoldTimer(entry);
+  }
+}
+
 function finishActiveWorkoutAndOpenReview(item){
   STATE.workoutInProgress = false;
   STATE.currentWorkoutEntryIndex = 0;
   STATE.currentWorkoutSetIndex = 0;
-  clearWorkoutRestTimer();
+  clearWorkoutRuntimeArtifacts(item);
   renderReviewSummary(item);
   renderSessionReview(item);
   showWizardStep("review");
@@ -6500,16 +6511,9 @@ async function applyRecommendedStrengthProgram(programId){
 
 function resetWorkoutRuntimeState(item){
   STATE.workoutRuntimeNonce = Number(STATE.workoutRuntimeNonce || 0) + 1;
-  clearWorkoutRestTimer();
-  clearTimedHoldTick();
   STATE.currentWorkoutEntryIndex = 0;
   STATE.currentWorkoutSetIndex = 0;
-
-  const entries = Array.isArray(item?.entries) ? item.entries : [];
-  for (const entry of entries){
-    if (!entry || typeof entry !== "object") continue;
-    clearTimedHoldTimer(entry);
-  }
+  clearWorkoutRuntimeArtifacts(item);
 }
 
 function wireTodayPlanActions(item){


### PR DESCRIPTION
## Summary

This PR continues issue #232 with a small cleanup of workout runtime lifecycle handling.

It introduces a shared helper for clearing workout runtime artifacts and uses it in both:

- workout reset/start preparation
- workout finish/review handoff

Previously, these paths cleared overlapping but not identical runtime state. This PR makes that cleanup consistent.

## What changed

Added:

- `clearWorkoutRuntimeArtifacts(item)`

This helper now clears shared workout runtime artifacts, including:

- workout rest timer state
- timed hold tick timer
- timed hold timer/prep state on workout entries

Updated:

- `finishActiveWorkoutAndOpenReview(item)`
- `resetWorkoutRuntimeState(item)`

Both now use the shared cleanup helper instead of maintaining separate cleanup logic.

## Why this helps

The workout execution model should have a predictable lifecycle.

Before this PR:

- reset and finish paths both cleared runtime artifacts
- but they did so through partially separate logic
- that increases the chance of state cleanup drifting over time

After this PR:

- runtime artifact cleanup is centralized
- reset and finish paths now clear the same execution leftovers
- the workout lifecycle becomes easier to reason about

## Scope

Included:

- frontend workout runtime cleanup consolidation
- shared helper for execution artifact cleanup

Not included:

- no backend changes
- no UI redesign
- no full workout execution rewrite
- no fix for manual workout stale review state
- no fix for mixed summary metric rendering

## Validation

Validated by checking that the frontend still passes syntax check and that the reset/finish lifecycle now routes through the same cleanup helper.

## Issue

Closes part of #232