### PR TITLE
Consolidate timed hold runtime state because workout timer flow should read one lifecycle source

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -5948,6 +5948,24 @@ function startTimedHoldTimer(entry){
   return targetSec;
 }
 
+function getTimedHoldRuntimeState(entry){
+  const prepEndsAt = Number(entry?._active_hold_prep_ends_at || 0);
+  const timerEndsAt = Number(entry?._active_hold_timer_ends_at || 0);
+  const prepRemainingSec = getTimedHoldPrepRemainingSeconds(entry);
+  const remainingSec = getTimedHoldRemainingSeconds(entry);
+
+  return {
+    hasPrep: prepEndsAt > 0,
+    hasActiveTimer: timerEndsAt > 0,
+    prepRemainingSec,
+    remainingSec,
+    isPrepRunning: prepRemainingSec > 0,
+    isActiveRunning: timerEndsAt > 0 && remainingSec > 0,
+    isReadyToStartActive: prepEndsAt > 0 && remainingSec <= 0,
+    isReadyToComplete: timerEndsAt > 0 && remainingSec <= 0,
+  };
+}
+
 function ensureTimedHoldTick(item){
   window.clearTimeout(window.__ssWorkoutActiveHoldTick || 0);
   const runtimeNonce = Number(STATE.workoutRuntimeNonce || 0);
@@ -5955,8 +5973,8 @@ function ensureTimedHoldTick(item){
   const entry = active?.entry;
   if (!entry || !isTimedHoldWorkoutEntry(entry)) return;
 
-  const prepRemaining = getTimedHoldPrepRemainingSeconds(entry);
-  if (prepRemaining > 0){
+  const holdState = getTimedHoldRuntimeState(entry);
+  if (holdState.isPrepRunning){
     window.__ssWorkoutActiveHoldTick = window.setTimeout(() => {
       if (Number(STATE.workoutRuntimeNonce || 0) !== runtimeNonce) return;
       renderTodayPlan(item);
@@ -5964,7 +5982,7 @@ function ensureTimedHoldTick(item){
     return;
   }
 
-  if (Number(entry?._active_hold_prep_ends_at || 0) > 0 && getTimedHoldRemainingSeconds(entry) <= 0){
+  if (holdState.isReadyToStartActive){
     clearTimedHoldPrep(entry);
     startTimedHoldTimer(entry);
     window.__ssWorkoutActiveHoldTick = window.setTimeout(() => {
@@ -5974,8 +5992,7 @@ function ensureTimedHoldTick(item){
     return;
   }
 
-  const hasActiveHoldTimer = Number(entry?._active_hold_timer_ends_at || 0) > 0;
-  if (hasActiveHoldTimer && getTimedHoldRemainingSeconds(entry) <= 0){
+  if (holdState.isReadyToComplete){
     completeTimedHoldSet(item);
     return;
   }


### PR DESCRIPTION
## Summary

This PR continues issue #232 with a small cleanup of timed hold lifecycle handling in the workout execution flow.

It introduces a shared timed hold runtime state helper and updates the timed hold tick loop to read from that shared lifecycle view instead of repeating raw timer-state checks inline.

## What changed

Added:

- `getTimedHoldRuntimeState(entry)`

This helper derives a shared timed hold lifecycle view from the current entry, including:

- whether prep state exists
- whether active timer state exists
- remaining prep seconds
- remaining active seconds
- whether prep is currently running
- whether the hold is ready to start active timing
- whether the hold is ready to complete

Updated:

- `ensureTimedHoldTick(item)`

The tick loop now reads from `getTimedHoldRuntimeState(entry)` instead of repeating separate checks against raw timed hold fields.

## Why this helps

Timed hold execution still has its own lifecycle inside the broader workout engine.

Before this PR, `ensureTimedHoldTick(item)` inspected several raw timed hold fields inline and combined them into behavior decisions directly. That worked, but it made the lifecycle harder to read and easier to fragment over time.

After this PR, timed hold state reading is centralized in one helper, which makes the timer flow more understandable and gives future changes a single lifecycle view to build on.

## Scope

Included:

- frontend timed hold lifecycle cleanup
- shared timed hold runtime state helper
- simplified state reading in timed hold tick flow

Not included:

- no backend changes
- no UI redesign
- no manual workout state isolation fix
- no mixed summary metric fix
- no full timed hold rewrite

## Validation

Validated by checking frontend syntax and confirming that the timed hold tick flow now uses the shared lifecycle helper for prep/start/complete decisions.

## Issue

Closes part of #232