### PR TITLE
Reuse shared timed hold transition because workout completion paths should advance identically

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6015,8 +6015,6 @@ function completeTimedHoldSet(item){
   if (!isTimedHoldWorkoutEntry(entry)) return false;
 
   const idx = active.index;
-  const total = active.total;
-  const isLast = idx >= total - 1;
   const hasMoreSetsRemaining = hasMoreWorkoutSets(entry);
   const currentSetIndex = getCurrentWorkoutSetIndex(entry);
 
@@ -6031,29 +6029,7 @@ function completeTimedHoldSet(item){
   clearTimedHoldTick();
   saveActiveWorkoutEntryProgress(item);
 
-  if (hasMoreSetsRemaining){
-    STATE.currentWorkoutSetIndex = currentSetIndex + 1;
-    startWorkoutRestTimer(undefined, {
-      targetKind: "next_set",
-      nextEntryIndex: idx,
-    });
-    renderTodayPlan(item);
-    return true;
-  }
-
-  STATE.currentWorkoutSetIndex = 0;
-
-  if (isLast){
-    finishActiveWorkoutAndOpenReview(item);
-    return true;
-  }
-
-  STATE.currentWorkoutEntryIndex = idx + 1;
-  startWorkoutRestTimer(undefined, {
-    targetKind: "next_exercise",
-    nextEntryIndex: idx + 1,
-  });
-  renderTodayPlan(item);
+  advanceActiveWorkoutAfterCompletedSet(item, idx, currentSetIndex, hasMoreSetsRemaining);
   return true;
 }
 


### PR DESCRIPTION
## Summary

This PR continues issue #232 with a small cleanup in the timed hold completion flow.

It removes the separate post-set transition logic from `completeTimedHoldSet(item)` and reuses the shared transition helper that already drives standard workout set progression.

This makes timed hold completion advance through the workout the same way as the rest of the execution flow.

## What changed

Updated:

- `completeTimedHoldSet(item)`

Instead of maintaining its own transition logic for:

- next set
- next exercise
- final handoff to review

it now reuses:

- `advanceActiveWorkoutAfterCompletedSet(item, idx, currentSetIndex, hasMoreSetsRemaining)`

Also removed now-unused local variables from the timed hold completion path.

## Why this helps

The workout execution model should not have separate advancement behavior depending on whether the completed set was:

- a standard rep-based set
- or a timed hold set

Before this PR, timed hold completion still carried its own copy of the advancement logic. That made the flow more fragmented and increased the chance that timed hold behavior would drift away from the shared workout progression model.

After this PR, timed holds and standard sets move through the same post-set transition path.

## Scope

Included:

- frontend workout execution cleanup
- timed hold completion now reuses shared post-set transition helper
- removed dead local variables

Not included:

- no backend changes
- no UI redesign
- no mixed summary fix
- no manual workout stale review fix
- no broader workout engine rewrite

## Validation

Validated by checking frontend syntax and confirming that timed hold completion now routes through the shared post-set transition helper.

## Issue

Closes part of #232