### PR TITLE
Consolidate active workout progress state because execution rendering should read one shared view

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6132,6 +6132,28 @@ function getActiveWorkoutEntry(item){
   };
 }
 
+function getActiveWorkoutProgressState(item){
+  const active = getActiveWorkoutEntry(item);
+  if (!active || !active.entry) return null;
+
+  const entry = active.entry;
+  const idx = active.index;
+  const total = active.total;
+  const plannedSetCount = getWorkoutPlannedSetCount(entry);
+  const currentSetIndex = getCurrentWorkoutSetIndex(entry);
+
+  return {
+    active,
+    entry,
+    idx,
+    total,
+    isLast: idx >= total - 1,
+    plannedSetCount,
+    currentSetIndex,
+    hasMoreSetsRemaining: currentSetIndex < (plannedSetCount - 1),
+  };
+}
+
 function removeCurrentWorkoutEntry(item){
   const entries = Array.isArray(item?.entries) ? item.entries : [];
   if (!entries.length) return;
@@ -6314,8 +6336,8 @@ function renderActiveWorkoutCard(item){
   const root = document.getElementById("todayPlanList");
   if (!root) return;
 
-  const active = getActiveWorkoutEntry(item);
-  if (!active || !active.entry){
+  const progress = getActiveWorkoutProgressState(item);
+  if (!progress || !progress.entry){
     STATE.workoutInProgress = false;
     STATE.currentWorkoutEntryIndex = 0;
     showWizardStep("review");
@@ -6323,18 +6345,12 @@ function renderActiveWorkoutCard(item){
   }
 
   if (isWorkoutRestState()){
-    renderWorkoutRestState(item, active);
+    renderWorkoutRestState(item, progress.active);
     return;
   }
 
-  const entry = active.entry;
-  const idx = active.index;
-  const total = active.total;
+  const { active, entry, idx, total, isLast, plannedSetCount, currentSetIndex, hasMoreSetsRemaining } = progress;
   const extras = formatPlanProgressionExtra(entry);
-  const isLast = idx >= total - 1;
-  const plannedSetCount = getWorkoutPlannedSetCount(entry);
-  const currentSetIndex = getCurrentWorkoutSetIndex(entry);
-  const hasMoreSetsRemaining = hasMoreWorkoutSets(entry);
   const meta = getReviewExerciseMeta(entry.exercise_id);
   const inputKind = String(meta?.input_kind || "");
   const isTime = inputKind === "time" || inputKind === "cardio_time";


### PR DESCRIPTION
## Summary

This PR rounds out the current issue #232 execution-model cleanup series with a small selector-style refinement in the active workout rendering flow.

It adds a shared helper for deriving active workout progress state and updates `renderActiveWorkoutCard()` to use that shared execution view instead of manually recomputing the same state inline.

## What changed

Added:

- `getActiveWorkoutProgressState(item)`

This helper derives a shared active workout progress view, including:

- active entry
- active entry index
- total entry count
- whether the current entry is the last one
- planned set count
- current set index
- whether more sets remain

Updated:

- `renderActiveWorkoutCard(item)`

It now reads from the shared progress selector instead of deriving the same execution state inline.

## Why this helps

Issue #232 has progressively reduced duplication and fragmented execution logic across the workout flow.

This PR helps complete that direction by making the active workout renderer depend on one shared execution-progress view rather than maintaining its own local derivation of the same state.

That makes the rendering path easier to read and gives the execution model a clearer structure.

## Scope

Included:

- frontend execution-model cleanup
- shared active workout progress selector
- simplified active workout rendering state derivation

Not included:

- no backend changes
- no UI redesign
- no manual workout stale review fix
- no mixed summary metric fix
- no full workout engine rewrite

## Validation

Validated by checking frontend syntax and confirming that `renderActiveWorkoutCard()` now uses the shared progress selector.

## Issue

Closes part of #232