### PR TITLE
Introduce guided workout player step helper because execution mode should be a distinct view state

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -8241,6 +8241,10 @@ function updatePlanHeadingForStep(stepId){
 }
 
 
+function isGuidedWorkoutPlayerStep(stepId){
+  return stepId === "plan" && STATE.workoutInProgress === true;
+}
+
 function showWizardStep(stepId){
   CURRENT_STEP = stepId;
   const groups = getWizardSections();
@@ -8261,7 +8265,7 @@ function showWizardStep(stepId){
   const todayPlanSummary = document.getElementById("todayPlanSummary");
   const reviewSummary = document.getElementById("reviewPlanSummary");
 
-  const isWorkoutPlanStep = stepId === "plan" && STATE.workoutInProgress;
+  const isWorkoutPlanStep = isGuidedWorkoutPlayerStep(stepId);
 
   if (todayPlanSection){
     todayPlanSection.classList.toggle("wizard-step-hidden", !(stepId === "plan" || stepId === "review"));
@@ -8335,11 +8339,11 @@ function showWizardStep(stepId){
   }
 
   if (todayPlanTiming){
-    todayPlanTiming.classList.toggle("wizard-step-hidden", stepId === "review" || (stepId === "plan" && STATE.workoutInProgress));
+    todayPlanTiming.classList.toggle("wizard-step-hidden", stepId === "review" || isGuidedWorkoutPlayerStep(stepId));
   }
 
   if (todayPlanSummary){
-    todayPlanSummary.classList.toggle("wizard-step-hidden", stepId === "review" || (stepId === "plan" && STATE.workoutInProgress));
+    todayPlanSummary.classList.toggle("wizard-step-hidden", stepId === "review" || isGuidedWorkoutPlayerStep(stepId));
   }
 
   if (reviewSummary){


### PR DESCRIPTION
## Summary

This PR starts issue #219 by introducing a small but important view-state cleanup for the guided workout player.

The workout execution flow already has a real active mode, but the UI was still treating it mostly as "plan step plus extra hiding logic". This change introduces a shared helper that makes guided workout player mode a more explicit view decision.

## What changed

Added:

- `isGuidedWorkoutPlayerStep(stepId)`

Updated `showWizardStep(...)` to use this shared helper when deciding whether the app is in guided workout player mode.

This now drives:

- workout-player styling on the plan section
- hiding of normal plan timing/summary elements during active workout mode
- the explicit distinction between ordinary plan view and guided execution view

## Why this helps

Issue #219 is about creating a dedicated guided workout player for approved sessions, not just making the plan screen look slightly different during training.

Before this PR, the player-mode decision was still embedded inline as:

- `stepId === "plan" && STATE.workoutInProgress`

in several places inside `showWizardStep(...)`.

After this PR, guided workout player mode has a shared view-state helper, which makes the intent clearer and gives future workout-player work a cleaner place to build from.

## Scope

Included:

- frontend view-state cleanup for guided workout player mode
- shared helper for determining when plan step is acting as workout player mode

Not included:

- no backend changes
- no UI redesign
- no new workout controls
- no manual workout state fix
- no mixed summary fix
- no full player layout rewrite

## Validation

Validated by checking frontend syntax and confirming that `showWizardStep(...)` now routes guided workout-player visibility decisions through the shared helper.

## Issue

Closes part of #219