### PR TITLE
Consolidate guided workout player shell because execution mode should apply one shared UI state

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -8245,6 +8245,48 @@ function isGuidedWorkoutPlayerStep(stepId){
   return stepId === "plan" && STATE.workoutInProgress === true;
 }
 
+function applyGuidedWorkoutPlayerShell(isActive){
+  const todayPlanSection = document.getElementById("todayPlanSection");
+  if (todayPlanSection){
+    todayPlanSection.classList.toggle("workout-mode-active", isActive);
+
+    if (isActive){
+      todayPlanSection.style.maxWidth = "none";
+      todayPlanSection.style.width = "100%";
+      todayPlanSection.style.background = "#050505";
+      todayPlanSection.style.border = "1px solid rgba(255,255,255,0.06)";
+      todayPlanSection.style.borderRadius = "24px";
+      todayPlanSection.style.padding = "12px";
+      todayPlanSection.style.boxShadow = "0 18px 48px rgba(0,0,0,0.35)";
+    } else {
+      todayPlanSection.style.maxWidth = "";
+      todayPlanSection.style.width = "";
+      todayPlanSection.style.background = "";
+      todayPlanSection.style.border = "";
+      todayPlanSection.style.borderRadius = "";
+      todayPlanSection.style.padding = "";
+      todayPlanSection.style.boxShadow = "";
+    }
+  }
+
+  document.body.classList.toggle("workout-mode-active", isActive);
+
+  [
+    "overviewStatusCard",
+    "systemStatusCard",
+    "authBar",
+    "appHeaderBar",
+    "appTagline",
+    "wizardNav",
+    "utilityNav",
+  ].forEach(id => {
+    const node = document.getElementById(id);
+    if (node){
+      node.classList.toggle("wizard-step-hidden", isActive);
+    }
+  });
+}
+
 function showWizardStep(stepId){
   CURRENT_STEP = stepId;
   const groups = getWizardSections();
@@ -8269,63 +8311,9 @@ function showWizardStep(stepId){
 
   if (todayPlanSection){
     todayPlanSection.classList.toggle("wizard-step-hidden", !(stepId === "plan" || stepId === "review"));
-    todayPlanSection.classList.toggle("workout-mode-active", isWorkoutPlanStep);
-
-    if (isWorkoutPlanStep){
-      todayPlanSection.style.maxWidth = "none";
-      todayPlanSection.style.width = "100%";
-      todayPlanSection.style.background = "#050505";
-      todayPlanSection.style.border = "1px solid rgba(255,255,255,0.06)";
-      todayPlanSection.style.borderRadius = "24px";
-      todayPlanSection.style.padding = "12px";
-      todayPlanSection.style.boxShadow = "0 18px 48px rgba(0,0,0,0.35)";
-    } else {
-      todayPlanSection.style.maxWidth = "";
-      todayPlanSection.style.width = "";
-      todayPlanSection.style.background = "";
-      todayPlanSection.style.border = "";
-      todayPlanSection.style.borderRadius = "";
-      todayPlanSection.style.padding = "";
-      todayPlanSection.style.boxShadow = "";
-    }
   }
 
-  document.body.classList.toggle("workout-mode-active", isWorkoutPlanStep);
-
-  const overviewStatusCard = document.getElementById("overviewStatusCard");
-  if (overviewStatusCard){
-    overviewStatusCard.classList.toggle("wizard-step-hidden", isWorkoutPlanStep);
-  }
-
-  const systemStatusCard = document.getElementById("systemStatusCard");
-  if (systemStatusCard){
-    systemStatusCard.classList.toggle("wizard-step-hidden", isWorkoutPlanStep);
-  }
-
-  const authBar = document.getElementById("authBar");
-  if (authBar){
-    authBar.classList.toggle("wizard-step-hidden", isWorkoutPlanStep);
-  }
-
-  const appHeaderBar = document.getElementById("appHeaderBar");
-  if (appHeaderBar){
-    appHeaderBar.classList.toggle("wizard-step-hidden", isWorkoutPlanStep);
-  }
-
-  const appTagline = document.getElementById("appTagline");
-  if (appTagline){
-    appTagline.classList.toggle("wizard-step-hidden", isWorkoutPlanStep);
-  }
-
-  const wizardNav = document.getElementById("wizardNav");
-  if (wizardNav){
-    wizardNav.classList.toggle("wizard-step-hidden", isWorkoutPlanStep);
-  }
-
-  const utilityNav = document.getElementById("utilityNav");
-  if (utilityNav){
-    utilityNav.classList.toggle("wizard-step-hidden", isWorkoutPlanStep);
-  }
+  applyGuidedWorkoutPlayerShell(isWorkoutPlanStep);
 
   if (todayPlanList){
     todayPlanList.classList.toggle("wizard-step-hidden", stepId === "review");


### PR DESCRIPTION
## Summary

This PR continues issue #219 by consolidating the guided workout player shell into a shared UI-state helper.

The previous step introduced a shared helper for deciding when the plan step is acting as guided workout player mode. This PR follows through on that by centralizing how that mode is actually applied to the interface.

## What changed

Added:

- `applyGuidedWorkoutPlayerShell(isActive)`

This helper now owns the shared guided workout player shell behavior, including:

- workout-mode styling on the plan section
- body-level workout-mode class
- hiding non-essential surrounding UI during active workout mode:
  - overview status
  - system status
  - auth bar
  - app header
  - tagline
  - wizard nav
  - utility nav

Updated:

- `showWizardStep(stepId)`

It now delegates workout-player shell application to the shared helper instead of handling that behavior inline.

## Why this helps

Issue #219 is about making approved-session execution feel like a dedicated guided workout player, not just a normal plan screen with scattered state toggles.

Before this PR, the shell behavior for active workout mode was still spread across `showWizardStep(...)` as a large block of inline DOM and style mutations.

After this PR, guided workout player mode has a clearer and more centralized shell application path, which makes the execution view easier to understand and easier to extend.

## Scope

Included:

- frontend guided workout player shell cleanup
- shared helper for applying workout-player UI mode
- reduced inline shell logic inside `showWizardStep(...)`

Not included:

- no backend changes
- no new workout controls
- no redesign of active card content
- no manual workout stale review fix
- no mixed summary fix
- no full player rewrite

## Validation

Validated by checking frontend syntax and confirming that guided workout player shell behavior now routes through the shared helper.

## Issue

Closes part of #219