### PR TITLE
Consolidate guided workout player content visibility because execution mode should control one shared content view

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -8287,6 +8287,37 @@ function applyGuidedWorkoutPlayerShell(isActive){
   });
 }
 
+
+function applyGuidedWorkoutPlayerContentVisibility(stepId){
+  const isWorkoutPlanStep = isGuidedWorkoutPlayerStep(stepId);
+  const todayPlanList = document.getElementById("todayPlanList");
+  const todayPlanTiming = document.getElementById("todayPlanTiming");
+  const todayPlanSummary = document.getElementById("todayPlanSummary");
+  const reviewSummary = document.getElementById("reviewPlanSummary");
+  const sessionResultForm = document.getElementById("sessionResultForm");
+  const reviewWrap = sessionResultForm ? sessionResultForm.closest(".card") : null;
+
+  if (todayPlanList){
+    todayPlanList.classList.toggle("wizard-step-hidden", stepId === "review");
+  }
+
+  if (todayPlanTiming){
+    todayPlanTiming.classList.toggle("wizard-step-hidden", stepId === "review" || isWorkoutPlanStep);
+  }
+
+  if (todayPlanSummary){
+    todayPlanSummary.classList.toggle("wizard-step-hidden", stepId === "review" || isWorkoutPlanStep);
+  }
+
+  if (reviewSummary){
+    reviewSummary.classList.toggle("wizard-step-hidden", stepId !== "review");
+  }
+
+  if (reviewWrap){
+    reviewWrap.classList.toggle("wizard-step-hidden", stepId !== "review");
+  }
+}
+
 function showWizardStep(stepId){
   CURRENT_STEP = stepId;
   const groups = getWizardSections();
@@ -8299,14 +8330,7 @@ function showWizardStep(stepId){
     });
   });
 
-  const sessionResultForm = document.getElementById("sessionResultForm");
-  const reviewWrap = sessionResultForm ? sessionResultForm.closest(".card") : null;
   const todayPlanSection = document.getElementById("todayPlanSection");
-  const todayPlanList = document.getElementById("todayPlanList");
-  const todayPlanTiming = document.getElementById("todayPlanTiming");
-  const todayPlanSummary = document.getElementById("todayPlanSummary");
-  const reviewSummary = document.getElementById("reviewPlanSummary");
-
   const isWorkoutPlanStep = isGuidedWorkoutPlayerStep(stepId);
 
   if (todayPlanSection){
@@ -8314,10 +8338,7 @@ function showWizardStep(stepId){
   }
 
   applyGuidedWorkoutPlayerShell(isWorkoutPlanStep);
-
-  if (todayPlanList){
-    todayPlanList.classList.toggle("wizard-step-hidden", stepId === "review");
-  }
+  applyGuidedWorkoutPlayerContentVisibility(stepId);
 
   if (stepId === "plan"){
     renderTodayPlan(STATE.currentTodayPlan || null);
@@ -8326,21 +8347,6 @@ function showWizardStep(stepId){
     renderSessionReview(STATE.currentTodayPlan || null);
   }
 
-  if (todayPlanTiming){
-    todayPlanTiming.classList.toggle("wizard-step-hidden", stepId === "review" || isGuidedWorkoutPlayerStep(stepId));
-  }
-
-  if (todayPlanSummary){
-    todayPlanSummary.classList.toggle("wizard-step-hidden", stepId === "review" || isGuidedWorkoutPlayerStep(stepId));
-  }
-
-  if (reviewSummary){
-    reviewSummary.classList.toggle("wizard-step-hidden", stepId !== "review");
-  }
-
-  if (reviewWrap){
-    reviewWrap.classList.toggle("wizard-step-hidden", stepId !== "review");
-  }
 
   updatePlanHeadingForStep(stepId);
   updateReviewHeadingForStep(stepId);


### PR DESCRIPTION
## Summary

This PR continues issue #219 by consolidating guided workout player content visibility into a shared helper.

Previous work introduced:

- a shared helper for deciding when the plan step is acting as guided workout player mode
- a shared helper for applying the outer workout-player shell

This PR follows through by centralizing the visibility rules for the player’s inner content surfaces.

## What changed

Added:

- `applyGuidedWorkoutPlayerContentVisibility(stepId)`

This helper now owns visibility behavior for:

- `todayPlanList`
- `todayPlanTiming`
- `todayPlanSummary`
- `reviewPlanSummary`
- the review form card wrapper

Updated:

- `showWizardStep(stepId)`

It now delegates player content visibility to the shared helper instead of toggling those elements inline.

## Why this helps

Issue #219 is about making approved-session execution feel like a dedicated guided workout player, not just a standard plan screen with scattered visibility rules.

Before this PR, content visibility for plan/review/player surfaces was still embedded directly inside `showWizardStep(...)`.

After this PR, the workout player has a more explicit content-visibility model, which makes the execution state easier to understand and easier to evolve.

## Scope

Included:

- frontend guided workout player content visibility cleanup
- shared helper for player content visibility
- reduced inline visibility toggles inside `showWizardStep(...)`

Not included:

- no backend changes
- no new workout controls
- no active card redesign
- no mixed summary fix
- no manual workout stale review fix
- no full guided player rewrite

## Validation

Validated by checking frontend syntax and confirming that plan/review/player content visibility now routes through the shared helper.

## Issue

Closes part of #219