### PR TITLE
Introduce guided workout player labels because rest state should read from shared execution messaging

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6247,6 +6247,15 @@ function saveActiveWorkoutEntryProgress(item){
   };
 }
 
+function getGuidedWorkoutPlayerLabels({ idx, total, exerciseName, actionText, setProgressLabel }){
+  return {
+    progressLabel: tr("workout.active_progress", { current: String(idx + 1), total: String(total) }),
+    exerciseName: exerciseName || "",
+    actionText: actionText || "",
+    setProgressLabel: setProgressLabel || "",
+  };
+}
+
 function renderWorkoutRestState(item, active){
   const root = document.getElementById("todayPlanList");
   if (!root) return;
@@ -6286,6 +6295,13 @@ function renderWorkoutRestState(item, active){
     ? formatPlanActionText(nextEntry)
     : formatPlanActionText(entry);
 
+  const playerLabels = getGuidedWorkoutPlayerLabels({
+    idx,
+    total,
+    exerciseName,
+    actionText,
+    setProgressLabel,
+  });
 
     const shellBackground = restDone ? "#0f1f14" : "#1c1710";
     const shellBorder = restDone ? "1px solid rgba(87, 214, 116, 0.32)" : "1px solid rgba(224, 170, 73, 0.26)";
@@ -6295,15 +6311,15 @@ function renderWorkoutRestState(item, active){
   root.innerHTML = `
       <li style="padding:20px 16px 28px 16px; min-height:62vh; display:flex; flex-direction:column; justify-content:center; border-radius:20px; background:${shellBackground}; border:${shellBorder}; box-shadow:0 18px 48px rgba(0,0,0,0.28)">
         <div style="font-size:0.95rem; opacity:${progressOpacity}; margin-bottom:12px; text-transform:uppercase; letter-spacing:0.04em">
-        ${esc(tr("workout.active_progress", { current: String(idx + 1), total: String(total) }))}
+        ${esc(playerLabels.progressLabel)}
       </div>
       ${nextExerciseLabel}
-      <div style="font-size:1.05rem; font-weight:700; margin-bottom:10px">${esc(setProgressLabel)}</div>
-      <div style="font-weight:800; font-size:2rem; line-height:1.1; margin-bottom:12px">${esc(exerciseName)}</div>
+      <div style="font-size:1.05rem; font-weight:700; margin-bottom:10px">${esc(playerLabels.setProgressLabel)}</div>
+      <div style="font-weight:800; font-size:2rem; line-height:1.1; margin-bottom:12px">${esc(playerLabels.exerciseName)}</div>
         <div style="font-weight:700; font-size:1.05rem; margin-bottom:12px; color:${statusColor}">${esc(statusLabel)}</div>
         <div style="font-size:3.2rem; line-height:1; font-weight:800; color:${timerColor}; margin:8px 0 18px 0">${esc(String(remainingSec))}<span style="font-size:1.2rem; font-weight:700; opacity:0.78"> s</span></div>
       <div class="small" style="line-height:1.5; margin-bottom:18px; opacity:0.78">
-        ${esc(actionText)}
+        ${esc(playerLabels.actionText)}
       </div>
       <div style="margin-top:auto; display:flex; gap:10px; flex-wrap:wrap">
         <button type="button" id="resumeWorkoutRestBtn" style="padding:16px 18px; font-size:1.05rem; font-weight:700; width:100%">${esc(primaryActionLabel)}</button>


### PR DESCRIPTION
## Summary

This PR continues issue #219 with a small refinement to guided workout player messaging.

It introduces a shared helper for core player labels and uses it in the workout rest-state renderer so the player reads more like one guided execution surface rather than a set of ad hoc label fragments.

## What changed

Added:

- `getGuidedWorkoutPlayerLabels({ idx, total, exerciseName, actionText, setProgressLabel })`

This helper derives a shared label bundle for guided workout player surfaces, including:

- overall workout progress label
- exercise name
- action text
- set progress label

Updated:

- `renderWorkoutRestState(item, active)`

It now builds and renders its core labels through the shared helper instead of composing those values inline.

## Why this helps

Issue #219 is about making the workout player feel deliberate during active use.

Before this PR, the rest-state renderer still assembled its own player-facing labels locally. That worked, but it kept the player messaging model fragmented.

After this PR, the rest state begins to rely on a shared player-label helper, which makes the guided workout experience a little more coherent and gives future active/rest messaging work a clearer base.

## Scope

Included:

- frontend guided workout player messaging cleanup
- shared player-label helper
- rest-state renderer updated to use shared messaging

Not included:

- no backend changes
- no active card redesign yet
- no new controls
- no manual workout stale review fix
- no mixed summary fix
- no full player rewrite

## Validation

Validated by checking frontend syntax and confirming that guided workout rest-state labels now route through the shared helper.

## Issue

Closes part of #219