### PR TITLE
Consolidate guided workout player primary actions because work and rest states should share CTA language

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6256,6 +6256,20 @@ function getGuidedWorkoutPlayerLabels({ idx, total, exerciseName, actionText, se
   };
 }
 
+function getGuidedWorkoutPlayerPrimaryActionLabel({ mode, restDone = false, isNextExerciseRest = false, hasMoreSetsRemaining = false, isLast = false }){
+  if (mode === "rest"){
+    if (!restDone) return tr("button.skip_rest");
+    return tr(isNextExerciseRest ? "button.start_next_exercise" : "button.start_next_set");
+  }
+
+  if (mode === "active"){
+    if (hasMoreSetsRemaining) return tr("button.next_set");
+    return tr(isLast ? "button.finish_workout" : "button.next_exercise");
+  }
+
+  return "";
+}
+
 function renderWorkoutRestState(item, active){
   const root = document.getElementById("todayPlanList");
   if (!root) return;
@@ -6275,9 +6289,11 @@ function renderWorkoutRestState(item, active){
     ? tr(isNextExerciseRest ? "workout.rest.ready_next_exercise" : "workout.rest.ready_next_set")
     : tr("workout.rest.resting");
 
-  const primaryActionLabel = !restDone
-    ? tr("button.skip_rest")
-    : tr(isNextExerciseRest ? "button.start_next_exercise" : "button.start_next_set");
+  const primaryActionLabel = getGuidedWorkoutPlayerPrimaryActionLabel({
+    mode: "rest",
+    restDone,
+    isNextExerciseRest,
+  });
 
   const nextExerciseLabel = isNextExerciseRest && nextEntry
     ? `<div class="small" style="margin-bottom:8px">${esc(tr("workout.rest.next_exercise_label"))}</div>`
@@ -6423,9 +6439,11 @@ function renderActiveWorkoutCard(item){
     `;
   }
 
-    const nextActionLabel = hasMoreSetsRemaining
-      ? tr("button.next_set")
-      : (isLast ? tr("button.finish_workout") : tr("button.next_exercise"));
+    const nextActionLabel = getGuidedWorkoutPlayerPrimaryActionLabel({
+      mode: "active",
+      hasMoreSetsRemaining,
+      isLast,
+    });
 
     const playerLabels = getGuidedWorkoutPlayerLabels({
       idx,


### PR DESCRIPTION
## Summary

This PR continues issue #219 by consolidating guided workout player primary action labels into a shared helper.

The guided player already had shared step state, shell behavior, content visibility, and shared core labels. This PR extends that consistency to the main action copy shown in active and rest states.

## What changed

Added:

- `getGuidedWorkoutPlayerPrimaryActionLabel({ mode, restDone, isNextExerciseRest, hasMoreSetsRemaining, isLast })`

This helper derives the primary action label for guided workout player surfaces.

Updated:

- `renderWorkoutRestState(item, active)`
- `renderActiveWorkoutCard(item)`

Both now route their main CTA label through the shared helper.

## Why this helps

Issue #219 is about making approved-session execution feel like one coherent guided workout player.

Before this PR, active and rest states still decided their primary action labels independently. That worked, but it kept the player’s action language split across separate local rules.

After this PR, the main CTA copy for both states comes from one shared helper, which makes the player feel more intentional and gives future CTA refinements one place to build from.

## Scope

Included:

- frontend guided workout player CTA cleanup
- shared helper for primary action label logic
- active/rest player states now share CTA language source

Not included:

- no backend changes
- no new controls
- no full active-card redesign
- no manual workout stale review fix
- no mixed summary fix
- no full guided player rewrite

## Validation

Validated by checking frontend syntax and confirming that active and rest player states now derive their primary action labels through the shared helper.

## Issue

Closes part of #219