### PR TITLE
Track workout completion context because review handoff should preserve how the session ended

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6052,7 +6052,15 @@ function clearWorkoutRuntimeArtifacts(item){
   }
 }
 
-function finishActiveWorkoutAndOpenReview(item){
+function setWorkoutCompletionContext(context = {}){
+  STATE.workoutCompletionContext = {
+    outcome: String(context?.outcome || "").trim(),
+    source: String(context?.source || "").trim(),
+  };
+}
+
+function finishActiveWorkoutAndOpenReview(item, completionContext = {}){
+  setWorkoutCompletionContext(completionContext);
   STATE.workoutInProgress = false;
   STATE.currentWorkoutEntryIndex = 0;
   STATE.currentWorkoutSetIndex = 0;
@@ -6078,7 +6086,7 @@ function advanceActiveWorkoutAfterCompletedSet(item, idx, currentSetIndex, hasMo
   const entries = Array.isArray(item?.entries) ? item.entries : [];
   const isLast = idx >= entries.length - 1;
   if (isLast){
-    finishActiveWorkoutAndOpenReview(item);
+    finishActiveWorkoutAndOpenReview(item, { outcome: "completed", source: "advance_after_completed_set" });
     return;
   }
 
@@ -6162,6 +6170,7 @@ function removeCurrentWorkoutEntry(item){
   entries.splice(idx, 1);
 
   if (!entries.length){
+    setWorkoutCompletionContext({ outcome: "removed_last_entry", source: "remove_current_workout_entry" });
     STATE.workoutInProgress = false;
     STATE.currentWorkoutEntryIndex = 0;
     renderTodayPlan(item);


### PR DESCRIPTION
## Summary

This PR starts issue #224 by introducing a small shared completion-context layer for workout review handoff.

The workout player already has a first automatic execution flow, but completion still risks feeling abrupt because review handoff does not explicitly preserve how the workout ended.

This change introduces a shared workout completion context so the handoff into review can carry explicit outcome information instead of acting like a generic transition.

## What changed

Added:

- `setWorkoutCompletionContext(context = {})`

Updated:

- `finishActiveWorkoutAndOpenReview(item, completionContext = {})`

This now records completion context before transitioning the player into review.

Also updated current completion paths so they explicitly record outcome/source:

- normal last-step completion now marks:
  - `outcome: "completed"`
  - `source: "advance_after_completed_set"`
- removing the final remaining workout entry now marks:
  - `outcome: "removed_last_entry"`
  - `source: "remove_current_workout_entry"`

## Why this helps

Issue #224 is about making workout completion, logging, and review handoff feel like one coherent end-of-session flow.

Before this PR, different completion paths could land in review without preserving explicit context about how the workout ended.

After this PR, the player establishes a shared completion-context model that future review/logging refinements can build on.

## Scope

Included:

- frontend workout completion-context tracking
- shared completion-context helper
- explicit context on current normal and abrupt review-handoff paths

Not included:

- no backend changes
- no persistence changes yet
- no review UI redesign yet
- no partial/aborted logging model yet
- no final session-summary redesign yet

## Validation

Validated by checking frontend syntax and confirming that the relevant completion paths now set explicit workout completion context before review handoff.

## Issue

Closes part of #224