### PR TITLE
Add workout completion handoff status because review should reflect how the session ended

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6059,8 +6059,26 @@ function setWorkoutCompletionContext(context = {}){
   };
 }
 
+function getWorkoutCompletionStatusText(context = {}){
+  const outcome = String(context?.outcome || "").trim();
+
+  if (outcome === "completed"){
+    return "Workout fuldført. Klar til review.";
+  }
+
+  if (outcome === "removed_last_entry"){
+    return "Workout sluttede, da sidste øvelse blev fjernet. Klar til review.";
+  }
+
+  return "";
+}
+
 function finishActiveWorkoutAndOpenReview(item, completionContext = {}){
   setWorkoutCompletionContext(completionContext);
+  const completionStatusText = getWorkoutCompletionStatusText(completionContext);
+  if (completionStatusText){
+    setText("sessionResultStatus", completionStatusText);
+  }
   STATE.workoutInProgress = false;
   STATE.currentWorkoutEntryIndex = 0;
   STATE.currentWorkoutSetIndex = 0;
@@ -6170,7 +6188,12 @@ function removeCurrentWorkoutEntry(item){
   entries.splice(idx, 1);
 
   if (!entries.length){
-    setWorkoutCompletionContext({ outcome: "removed_last_entry", source: "remove_current_workout_entry" });
+    const completionContext = { outcome: "removed_last_entry", source: "remove_current_workout_entry" };
+    setWorkoutCompletionContext(completionContext);
+    const completionStatusText = getWorkoutCompletionStatusText(completionContext);
+    if (completionStatusText){
+      setText("sessionResultStatus", completionStatusText);
+    }
     STATE.workoutInProgress = false;
     STATE.currentWorkoutEntryIndex = 0;
     renderTodayPlan(item);

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6052,7 +6052,15 @@ function clearWorkoutRuntimeArtifacts(item){
   }
 }
 
-function finishActiveWorkoutAndOpenReview(item){
+function setWorkoutCompletionContext(context = {}){
+  STATE.workoutCompletionContext = {
+    outcome: String(context?.outcome || "").trim(),
+    source: String(context?.source || "").trim(),
+  };
+}
+
+function finishActiveWorkoutAndOpenReview(item, completionContext = {}){
+  setWorkoutCompletionContext(completionContext);
   STATE.workoutInProgress = false;
   STATE.currentWorkoutEntryIndex = 0;
   STATE.currentWorkoutSetIndex = 0;
@@ -6078,7 +6086,7 @@ function advanceActiveWorkoutAfterCompletedSet(item, idx, currentSetIndex, hasMo
   const entries = Array.isArray(item?.entries) ? item.entries : [];
   const isLast = idx >= entries.length - 1;
   if (isLast){
-    finishActiveWorkoutAndOpenReview(item);
+    finishActiveWorkoutAndOpenReview(item, { outcome: "completed", source: "advance_after_completed_set" });
     return;
   }
 
@@ -6162,6 +6170,7 @@ function removeCurrentWorkoutEntry(item){
   entries.splice(idx, 1);
 
   if (!entries.length){
+    setWorkoutCompletionContext({ outcome: "removed_last_entry", source: "remove_current_workout_entry" });
     STATE.workoutInProgress = false;
     STATE.currentWorkoutEntryIndex = 0;
     renderTodayPlan(item);


### PR DESCRIPTION
## Summary

This PR continues issue #224 by adding lightweight completion-status feedback at workout review handoff.

The previous step introduced shared workout completion context in frontend state. This PR builds on that by converting that context into a small user-facing handoff message when the workout ends and review opens.

## What changed

Added:

- `getWorkoutCompletionStatusText(context = {})`

This helper derives a lightweight status message from workout completion context.

Updated:

- `finishActiveWorkoutAndOpenReview(item, completionContext = {})`
- `removeCurrentWorkoutEntry(item)`

Relevant completion paths now set `sessionResultStatus` with a short handoff message before opening review.

Current handled outcomes include:

- `completed`
- `removed_last_entry`

## Why this helps

Issue #224 is about making session completion, logging, and review handoff feel like one coherent end-of-session flow.

Before this PR, completion context existed internally but review handoff still risked feeling abrupt because the user was not explicitly told how the workout had just ended.

After this PR, the handoff into review gives lightweight, understandable feedback that connects the end of execution to the beginning of review.

## Scope

Included:

- frontend completion-handoff feedback
- shared helper for completion-status text
- review handoff now reflects current known completion outcomes

Not included:

- no backend changes
- no persistence changes yet
- no full review redesign
- no partial/aborted outcome handling yet
- no final session-summary redesign yet

## Validation

Validated by checking frontend syntax and confirming that current review-handoff paths now show completion-status feedback based on workout completion context.

## Issue

Closes part of #224