### PR TITLE
Reflect workout completion outcome in review summary because session closure should stay visible at handoff

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4466,6 +4466,7 @@ function renderReviewSummary(item){
   }
 
   const sessionType = formatSessionType(item.session_type || "");
+  const completionSummaryText = getWorkoutCompletionSummaryText(STATE.workoutCompletionContext || {});
   const metaBits = [];
   if (sessionType) metaBits.push(sessionType);
   if (item.time_budget_min) metaBits.push(`${esc(item.time_budget_min)} min`);
@@ -4480,6 +4481,7 @@ function renderReviewSummary(item){
         <div class="review-summary-pill small">${esc(tr("review.summary_closure_label"))}</div>
         ${metaBits.map(bit => `<div class="review-summary-pill small">${esc(bit)}</div>`).join("")}
       </div>
+      ${completionSummaryText ? `<div class="small review-summary-outcome">${esc(completionSummaryText)}</div>` : ""}
       <div class="small review-summary-outcome">${esc(tr("review.summary_session_label"))}</div>
       <div class="small review-summary-list">
         ${item.entries.map(entry => {
@@ -6068,6 +6070,21 @@ function getWorkoutCompletionStatusText(context = {}){
 
   if (outcome === "removed_last_entry"){
     return "Workout sluttede, da sidste øvelse blev fjernet. Klar til review.";
+  }
+
+  return "";
+}
+
+
+function getWorkoutCompletionSummaryText(context = {}){
+  const outcome = String(context?.outcome || "").trim();
+
+  if (outcome === "completed"){
+    return "Session blev fuldført i workout playeren.";
+  }
+
+  if (outcome === "removed_last_entry"){
+    return "Session sluttede, efter den sidste resterende øvelse blev fjernet.";
   }
 
   return "";


### PR DESCRIPTION
## Summary

This PR continues issue #224 by carrying workout completion outcome into the review summary itself.

Previous work introduced workout completion context and a lightweight handoff status message. This PR extends that by letting the review summary reflect how the session ended, so completion context remains visible inside the review surface rather than disappearing after the transition.

## What changed

Added:

- `getWorkoutCompletionSummaryText(context = {})`

This helper derives a short summary-level completion text from workout completion context.

Updated:

- `renderReviewSummary(item)`

It now reads `STATE.workoutCompletionContext` and renders a lightweight completion outcome line when known.

Current handled outcomes include:

- `completed`
- `removed_last_entry`

## Why this helps

Issue #224 is about making session completion, logging, and review handoff feel continuous and coherent.

Before this PR, completion context existed and handoff status messaging had improved, but the review summary itself still remained largely generic.

After this PR, the review summary reflects session closure more directly, which makes the transition into review feel more intentional and easier to understand.

## Scope

Included:

- frontend review-summary refinement
- shared helper for completion-summary text
- review summary now reflects current workout completion context

Not included:

- no backend changes
- no persistence changes yet
- no partial/aborted outcome handling yet
- no review form redesign
- no final logging-model redesign yet

## Validation

Validated by checking frontend syntax and confirming that review summary now renders a completion outcome line when workout completion context is available.

## Issue

Closes part of #224