### PR TITLE
Treat removed final workout entry as partial completion because imperfect endings should map to session outcomes

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6068,8 +6068,8 @@ function getWorkoutCompletionStatusText(context = {}){
     return "Workout fuldført. Klar til review.";
   }
 
-  if (outcome === "removed_last_entry"){
-    return "Workout sluttede, da sidste øvelse blev fjernet. Klar til review.";
+  if (outcome === "partial"){
+    return "Workout blev afsluttet delvist. Klar til review.";
   }
 
   return "";
@@ -6083,8 +6083,8 @@ function getWorkoutCompletionSummaryText(context = {}){
     return "Session blev fuldført i workout playeren.";
   }
 
-  if (outcome === "removed_last_entry"){
-    return "Session sluttede, efter den sidste resterende øvelse blev fjernet.";
+  if (outcome === "partial"){
+    return "Session blev afsluttet delvist i workout playeren.";
   }
 
   return "";
@@ -6205,7 +6205,7 @@ function removeCurrentWorkoutEntry(item){
   entries.splice(idx, 1);
 
   if (!entries.length){
-    const completionContext = { outcome: "removed_last_entry", source: "remove_current_workout_entry" };
+    const completionContext = { outcome: "partial", source: "remove_current_workout_entry" };
     setWorkoutCompletionContext(completionContext);
     const completionStatusText = getWorkoutCompletionStatusText(completionContext);
     if (completionStatusText){


### PR DESCRIPTION
## Summary

This PR continues issue #224 by reframing the “remove final workout entry” path as a partial session completion outcome.

Previous work introduced workout completion context plus handoff/review messaging. This PR makes that outcome model more product-facing by mapping the current imperfect ending path to a real session outcome instead of a low-level technical event name.

## What changed

Updated:

- `removeCurrentWorkoutEntry(item)`

When the final remaining workout entry is removed and the player transitions into review, the workout now records:

- `outcome: "partial"`

instead of:

- `outcome: "removed_last_entry"`

Updated supporting outcome text helpers:

- `getWorkoutCompletionStatusText(context = {})`
- `getWorkoutCompletionSummaryText(context = {})`

They now describe this path as a partial session completion.

## Why this helps

Issue #224 is about making session completion and review handoff coherent across real workout outcomes, including imperfect ones.

Before this PR, the current imperfect ending path used a technical event-style outcome name that described what happened in code, but not what kind of session result the user ended up with.

After this PR, that path maps to a clearer session-level outcome: partial completion.

## Scope

Included:

- frontend outcome-model refinement
- partial completion mapping for the current final-entry removal path
- updated handoff/review text for that outcome

Not included:

- no backend changes
- no dedicated abort control yet
- no broader partial-completion model yet
- no persistence changes yet
- no review form redesign yet

## Validation

Validated by checking frontend syntax and confirming that the final-entry removal path now maps to `partial` and that related review/handoff text reflects that outcome.

## Issue

Closes part of #224