### PR TITLE
Include substituted exercise origin because final logging should reflect replaced workout paths

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -7994,6 +7994,7 @@ session_type:
 
       return {
         exercise_id: entry.exercise_id || "",
+        substituted_from: entry.substituted_from || "",
         completed: String(form.session_completed.value) === "true",
         target_reps: entry.target_reps || "",
         achieved_reps: nonEmptySets[0]?.reps || String(existingResult.achieved_reps || "").trim(),


### PR DESCRIPTION
## Summary

This PR continues issue #224 by including substitution origin in final session-result logging.

The workout flow already supports substitution during execution, but final session-result payloads did not yet preserve where a substituted exercise came from. This PR closes that gap so replaced workout paths produce a more truthful final record.

## What changed

Updated the result payload built in:

- `handleSessionResultSubmit(ev)`

Each result entry now includes:

- `substituted_from: entry.substituted_from || ""`

when available.

## Why this helps

Issue #224 is about making completion, logging, and review handoff coherent across real workout outcomes, including imperfect or adjusted session paths.

Before this PR, a substituted exercise could appear in the final saved result without preserving its original exercise context.

After this PR, final logging better reflects what actually happened during execution, including replaced exercise paths.

## Scope

Included:

- frontend session-result payload refinement
- substitution origin is now included in final logged result entries

Not included:

- no backend changes in this PR
- no review UI changes yet for substitution display
- no broader abort/ended-early outcome yet
- no persistence-model redesign yet

## Validation

Validated by checking frontend syntax and confirming that final session-result payload entries now include `substituted_from` when present on workout entries.

## Issue

Closes part of #224