### PR TITLE
Show substituted exercise paths in saved summary because review should reflect replaced workout results

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4647,6 +4647,17 @@ function renderSessionResultSummary(summary, fallbackResults = null){
       })
     : progressFlags;
 
+  const resultListHtml = summaryResults.length
+    ? `<div class="small review-summary-list">${summaryResults.map(result => {
+        const exerciseName = formatExerciseName(result?.exercise_id || "");
+        const substitutedFrom = String(result?.substituted_from || "").trim();
+        const substitutionBit = substitutedFrom
+          ? ` · ${tr("exercise.substituted_from")}: ${formatExerciseName(substitutedFrom)}`
+          : "";
+        return `${esc(exerciseName)}${esc(substitutionBit)}`;
+      }).join("<br>")}</div>`
+    : "";
+
   const performanceBlock = shouldUseTimedSummary
     ? `${esc(tr("after_training.completed_exercises_label"))}: ${esc(String(completedExercises))}/${esc(String(totalExercises))}<br>
       ${esc(tr("review.summary_sets_label"))}: ${esc(String(totalSets))}<br>
@@ -4674,6 +4685,7 @@ function renderSessionResultSummary(summary, fallbackResults = null){
       <div class="small review-summary-outcome">
         ${esc(tr("review.saved_next_label"))}: ${esc(nextStepHint || tr("common.no_recommendation"))}
       </div>
+      ${resultListHtml}
       ${visibleExplanationBits.length ? `<div class="small review-summary-outcome">${esc(visibleExplanationBits.join(" · "))}</div>` : ""}
       ${visibleProgressFlags.length ? `<div class="small review-summary-outcome">${esc(visibleProgressFlags.map(formatProgressFlag).join(", "))}</div>` : ""}
       ${buildNextPlannedSessionHtml(STATE.currentTodayPlan || null)}


### PR DESCRIPTION
## Summary

This PR continues issue #224 by making substituted exercise paths visible in the saved session result summary.

Previous work ensured that substitution origin was preserved in final session-result payloads. This PR carries that truth through into the saved review summary so replaced workout paths remain visible after save.

## What changed

Updated:

- `renderSessionResultSummary(summary, fallbackResults = null)`

For saved strength summaries, it now builds and renders a lightweight result list based on `summary.results`.

Each listed result can show:

- the completed exercise name
- `exercise.substituted_from` when present

## Why this helps

Issue #224 is about making completion, logging, and review handoff coherent across real workout outcomes, including adjusted and imperfect paths.

Before this PR, substitution origin could be logged in saved results, but the saved summary still did not visibly reflect replaced exercise paths.

After this PR, the saved summary better reflects what actually happened during execution.

## Scope

Included:

- frontend saved-summary refinement
- saved result list for strength summaries
- substitution origin is now visible in saved review when present

Not included:

- no backend changes
- no abort/ended-early outcome yet
- no broader review redesign
- no persistence-model redesign yet

## Validation

Validated by checking frontend syntax and confirming that saved session summaries now render substituted exercise paths when `substituted_from` is present in summary results.

## Issue

Closes part of #224