### PR TITLE
Add explicit early-stop outcome because workout completion flow should handle intentional early endings

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6084,6 +6084,10 @@ function getWorkoutCompletionStatusText(context = {}){
     return "Workout blev afsluttet delvist. Klar til review.";
   }
 
+  if (outcome === "ended_early"){
+    return "Workout blev afsluttet før tid. Klar til review.";
+  }
+
   return "";
 }
 
@@ -6097,6 +6101,10 @@ function getWorkoutCompletionSummaryText(context = {}){
 
   if (outcome === "partial"){
     return "Session blev afsluttet delvist i workout playeren.";
+  }
+
+  if (outcome === "ended_early"){
+    return "Session blev afsluttet før tid i workout playeren.";
   }
 
   return "";
@@ -6559,6 +6567,7 @@ function renderActiveWorkoutCard(item){
         <div style="margin-bottom:18px">${loggingHtml}</div>
         <div style="margin-top:auto; display:flex; gap:10px; flex-wrap:wrap">
           <button type="button" id="nextWorkoutEntryBtn" style="padding:18px 18px; font-size:1.1rem; font-weight:800; width:100%">${esc(nextActionLabel)}</button>
+          <button type="button" id="finishWorkoutEarlyBtn" class="secondary" style="width:100%; padding:14px 16px; font-size:0.98rem">${esc(tr("button.finish_workout"))}</button>
           <button type="button" class="secondary" data-exercise-viewer="${esc(entry.exercise_id || "")}" style="width:100%; padding:14px 16px; font-size:0.98rem">${esc(tr("button.view_exercise"))}</button>
         </div>
       </li>
@@ -6602,6 +6611,15 @@ function renderActiveWorkoutCard(item){
         saveActiveWorkoutEntryProgress(item);
 
         advanceActiveWorkoutAfterCompletedSet(item, idx, currentSetIndex, hasMoreSetsRemaining && !isCardioEntry);
+      });
+
+      document.getElementById("finishWorkoutEarlyBtn")?.addEventListener("click", () => {
+        if (isTimedHoldWorkoutEntry(entry) && (getTimedHoldRemainingSeconds(entry) > 0 || getTimedHoldPrepRemainingSeconds(entry) > 0)){
+          return;
+        }
+
+        saveActiveWorkoutEntryProgress(item);
+        finishActiveWorkoutAndOpenReview(item, { outcome: "ended_early", source: "finish_workout_early_button" });
       });
 }
 


### PR DESCRIPTION
## Summary

This PR continues issue #224 by adding an explicit early-stop outcome to the workout player completion flow.

The current workout flow already handles normal completion and some imperfect paths, but it still lacked a dedicated way for the user to intentionally end a workout early while preserving a coherent review handoff.

This PR adds that explicit path.

## What changed

Updated:

- `getWorkoutCompletionStatusText(context = {})`
- `getWorkoutCompletionSummaryText(context = {})`

Both now support:

- `ended_early`

Updated:

- `renderActiveWorkoutCard(item)`

The active workout player now includes a dedicated early-stop action:

- `finishWorkoutEarlyBtn`

Added behavior:

- saves current workout progress before ending
- transitions into review through the existing completion handoff
- records:
  - `outcome: "ended_early"`
  - `source: "finish_workout_early_button"`

## Why this helps

Issue #224 is about making session completion, logging, and review handoff coherent across real workout outcomes, including imperfect ones.

Before this PR, the player improved several completion paths, but still lacked a dedicated intentional early-stop route. Users could reach imperfect endings indirectly, but not through a clean explicit action.

After this PR, the workout player supports a deliberate early-stop path that still produces a coherent review handoff and usable session outcome.

## Scope

Included:

- frontend workout-player early-stop action
- explicit `ended_early` completion outcome
- review/handoff text now supports that outcome

Not included:

- no backend changes
- no broader abort taxonomy beyond this new explicit path
- no full review redesign
- no persistence-model redesign yet

## Validation

Validated by checking frontend syntax and confirming that the active workout player now supports an explicit early-stop path which saves progress and transitions into review with `ended_early` outcome context.

## Issue

Closes part of #224