### PR TITLE
Clarify post-session next-step card because review should end with visible forward guidance

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -9250,6 +9250,7 @@ function buildNextPlannedSessionHtml(planItem){
 
   return `
     <div class="small" style="margin-top:10px; padding-top:10px; border-top:1px solid rgba(255,255,255,0.08)">
+      <div style="font-weight:700; margin-bottom:6px">${esc(tr("review.saved_next_label"))}</div>
       ${tomorrowLine}
       <div><strong>${esc(tr("review.next_planned_session_label"))}:</strong> ${esc(nextTraining.kindLabel || "")}</div>
       <div class="small" style="margin-top:4px">${esc(nextTraining.dateLabel || nextTraining.date || "")}</div>


### PR DESCRIPTION
## Summary

This PR starts issue #228 by making the existing post-session next-step block clearer as a forward-looking guidance card.

The frontend already had a compact next planned session block in the review ending. This PR does not change planning logic. It simply makes that block read more intentionally as the user’s likely next step after session completion.

## What changed

Updated:

- `buildNextPlannedSessionHtml(planItem)`

The next-step block now includes a clearer heading using:

- `review.saved_next_label`

This makes the guidance block easier to recognize as a forward-looking post-session state rather than just another small detail at the bottom of review.

## Why this helps

Issue #228 is about making the end-of-session experience feel clearer, calmer, and more direction-giving without overstating certainty.

Before this PR, the next planned session information existed, but its presentation was still understated.

After this PR, the same guidance becomes more visible and intentional while still staying compact and honest about being forward-looking guidance rather than a guaranteed next plan.

## Scope

Included:

- frontend refinement of the existing post-session next-step block
- clearer heading for forward guidance in review

Not included:

- no backend changes
- no recommendation-logic changes
- no new planning layer
- no review redesign beyond this guidance refinement

## Validation

Validated by checking frontend syntax and confirming that the post-session next-step block now renders with a clearer forward-guidance heading.

## Issue

Closes part of #228