### PR TITLE
Use likely next-session wording because post-session guidance should stay honest about uncertainty

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -9250,6 +9250,7 @@ function buildNextPlannedSessionHtml(planItem){
 
   return `
     <div class="small" style="margin-top:10px; padding-top:10px; border-top:1px solid rgba(255,255,255,0.08)">
+      <div style="font-weight:700; margin-bottom:6px">${esc(tr("review.saved_next_label"))}</div>
       ${tomorrowLine}
       <div><strong>${esc(tr("review.next_planned_session_label"))}:</strong> ${esc(nextTraining.kindLabel || "")}</div>
       <div class="small" style="margin-top:4px">${esc(nextTraining.dateLabel || nextTraining.date || "")}</div>

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -9252,7 +9252,7 @@ function buildNextPlannedSessionHtml(planItem){
     <div class="small" style="margin-top:10px; padding-top:10px; border-top:1px solid rgba(255,255,255,0.08)">
       <div style="font-weight:700; margin-bottom:6px">${esc(tr("review.saved_next_label"))}</div>
       ${tomorrowLine}
-      <div><strong>${esc(tr("review.next_planned_session_label"))}:</strong> ${esc(nextTraining.kindLabel || "")}</div>
+      <div><strong>${esc(tr("review.next_likely_session_label"))}:</strong> ${esc(nextTraining.kindLabel || "")}</div>
       <div class="small" style="margin-top:4px">${esc(nextTraining.dateLabel || nextTraining.date || "")}</div>
       ${nextTraining.note ? `<div class="small" style="margin-top:4px">${esc(nextTraining.note)}</div>` : ""}
     </div>

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -869,5 +869,6 @@
   "history.weekly_rhythm_latest_label": "Senest gennemført",
   "history.weekly_rhythm_next_label": "Næste sandsynlige pas",
   "history.weekly_rhythm_none_completed": "Ingen gennemførte pas endnu i denne uge",
-  "history.weekly_rhythm_no_completed_types": "Ingen endnu"
+  "history.weekly_rhythm_no_completed_types": "Ingen endnu",
+  "review.next_likely_session_label": "Mest sandsynligt næste træning"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -853,5 +853,6 @@
   "history.weekly_rhythm_latest_label": "Latest completed",
   "history.weekly_rhythm_next_label": "Next likely session",
   "history.weekly_rhythm_none_completed": "No completed sessions yet this week",
-  "history.weekly_rhythm_no_completed_types": "None yet"
+  "history.weekly_rhythm_no_completed_types": "None yet",
+  "review.next_likely_session_label": "Most likely next session"
 }


### PR DESCRIPTION
## Summary

This PR continues issue #228 by refining the wording of the post-session next-step card so it communicates likelihood more honestly.

The existing review-ending guidance already surfaced a compact next-step block. This PR keeps that structure, but adjusts the wording so it better matches the product’s dynamic planning model and avoids sounding more fixed than it really is.

## What changed

Added new i18n key:

- `review.next_likely_session_label`

Updated:

- `buildNextPlannedSessionHtml(planItem)`

The card now uses:

- “Most likely next session”
- “Mest sandsynligt næste træning”

instead of the more absolute “Next planned session” wording inside the review guidance card.

## Why this helps

Issue #228 is about making post-session next-step guidance clear, useful, and calm without pretending the next recommendation is guaranteed before the next check-in.

Before this PR, the guidance card risked sounding more fixed than intended.

After this PR, the wording better reflects that the card is forward-looking guidance, not a locked-in plan.

## Scope

Included:

- frontend wording refinement for the existing post-session next-step card
- new i18n label for likely next-session phrasing

Not included:

- no backend changes
- no recommendation-logic changes
- no new planning layer
- no review redesign beyond wording refinement

## Validation

Validated by checking frontend syntax and confirming that the post-session next-step card now uses likely-session wording in both Danish and English.

## Issue

Closes part of #228