### PR TITLE
Compact post-session next-step card because forward guidance should read as one calm state

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -9243,6 +9243,12 @@ function buildNextPlannedSessionHtml(planItem){
 
   const tomorrow = info.tomorrow;
   const nextTraining = info.nextTraining;
+  const nextDateText = String(nextTraining.dateLabel || nextTraining.date || "").trim();
+  const nextLikelyLine = [
+    tr("review.next_likely_session_label"),
+    nextTraining.kindLabel || "",
+    nextDateText,
+  ].filter(Boolean).join(" · ");
 
   const tomorrowLine = tomorrow && tomorrow.kind === "rest"
     ? `<div class="small" style="margin-bottom:6px">${esc(tr("review.tomorrow_rest_label"))} · ${esc(tomorrow.dateLabel || "")}</div>`
@@ -9252,8 +9258,7 @@ function buildNextPlannedSessionHtml(planItem){
     <div class="small" style="margin-top:10px; padding-top:10px; border-top:1px solid rgba(255,255,255,0.08)">
       <div style="font-weight:700; margin-bottom:6px">${esc(tr("review.saved_next_label"))}</div>
       ${tomorrowLine}
-      <div><strong>${esc(tr("review.next_likely_session_label"))}:</strong> ${esc(nextTraining.kindLabel || "")}</div>
-      <div class="small" style="margin-top:4px">${esc(nextTraining.dateLabel || nextTraining.date || "")}</div>
+      <div style="font-weight:600">${esc(nextLikelyLine)}</div>
       ${nextTraining.note ? `<div class="small" style="margin-top:4px">${esc(nextTraining.note)}</div>` : ""}
     </div>
   `;


### PR DESCRIPTION
## Summary

This PR continues issue #228 by making the post-session next-step card more compact and more intentional as a single forward-guidance state.

The existing card already surfaced the likely next session and its timing. This PR does not change recommendation logic. It simply restructures the presentation so the card reads more clearly as one calm next-step block.

## What changed

Updated:

- `buildNextPlannedSessionHtml(planItem)`

The card now builds a compact main guidance line by combining:

- likely next-session label
- next session kind
- next session date

The optional note remains below as a secondary rationale line.

## Why this helps

Issue #228 is about making the end-of-session experience feel clearer, calmer, and more direction-giving without overstating certainty.

Before this PR, the next-step card still read more like separate small text lines.

After this PR, the same information is presented as a more coherent forward-guidance block while staying compact and honest.

## Scope

Included:

- frontend refinement of the existing post-session next-step card
- compact guidance-line structure for likely next session plus timing

Not included:

- no backend changes
- no recommendation-logic changes
- no new planning layer
- no broader review redesign

## Validation

Validated by checking frontend syntax and confirming that the post-session next-step card now renders likely next session type and timing as a single compact guidance line.

## Issue

Closes part of #228