### PR TITLE
Compact exercise guidance in workout mode because active technique help should stay player-native

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -5589,7 +5589,7 @@ function getExerciseViewerCopy(meta){
   return { name, notes, formCues };
 }
 
-function openExerciseViewer(exerciseId){
+function openExerciseViewer(exerciseId, options = {}){
   try {
     const modal = document.getElementById("exerciseViewerModal");
     const titleEl = document.getElementById("exerciseViewerTitle");
@@ -5602,11 +5602,14 @@ function openExerciseViewer(exerciseId){
 
     const meta = getExerciseMeta(exerciseId) || {};
     const viewerCopy = getExerciseViewerCopy(meta);
+    const isWorkoutMode = options?.mode === "workout";
     const name = viewerCopy.name || exerciseId || tr("exercise.viewer_title");
-    const images = getExerciseImages(exerciseId);
+    const allImages = getExerciseImages(exerciseId);
+    const images = isWorkoutMode ? allImages.slice(0, 1) : allImages;
     const notes = viewerCopy.notes;
     const category = String(meta.category || "").trim();
     const formCues = Array.isArray(viewerCopy.formCues) ? viewerCopy.formCues.filter(Boolean).map(x => String(x).trim()).filter(Boolean) : [];
+    const visibleFormCues = isWorkoutMode ? formCues.slice(0, 2) : formCues;
 
     titleEl.textContent = name;
 
@@ -5627,11 +5630,11 @@ function openExerciseViewer(exerciseId){
       </div>
     ` : "";
 
-    const cuesHtml = formCues.length ? `
+    const cuesHtml = visibleFormCues.length ? `
       <div style="margin-top:14px;padding:12px 14px;border-radius:14px;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08)">
         <div style="font-weight:700;margin-bottom:8px">${esc(tr("exercise.viewer_technique_focus"))}</div>
         <ul style="margin:0;padding-left:18px">
-          ${formCues.map(cue => `<li style="margin-bottom:6px">${esc(cue)}</li>`).join("")}
+          ${visibleFormCues.map(cue => `<li style="margin-bottom:6px">${esc(cue)}</li>`).join("")}
         </ul>
       </div>
     ` : "";
@@ -5670,7 +5673,10 @@ document.addEventListener("click", function(ev){
   const openBtn = ev.target.closest("[data-exercise-viewer]");
   if (openBtn){
     ev.preventDefault();
-    openExerciseViewer(openBtn.getAttribute("data-exercise-viewer"));
+    const isWorkoutMode = Boolean(STATE.workoutInProgress);
+    openExerciseViewer(openBtn.getAttribute("data-exercise-viewer"), {
+      mode: isWorkoutMode ? "workout" : "default",
+    });
     return;
   }
 


### PR DESCRIPTION
## Summary

This PR starts issue #223 by making the existing exercise viewer more compact when opened during an active workout.

The workout player already had an on-demand exercise guidance entry point, but the viewer still behaved like a more general-purpose detail layer. This PR keeps the existing viewer and overlay behavior, but introduces a lighter workout-mode presentation for in-session use.

## What changed

Updated:

- `openExerciseViewer(exerciseId, options = {})`

The viewer now supports a compact workout mode.

In workout mode it currently:

- limits images to the first available image
- limits visible form cues to the first two cues

Updated the click-open path so that guidance opened during active workout execution uses:

- `mode: "workout"`

while non-workout usage still opens with the default behavior.

## Why this helps

Issue #223 is about making technique guidance feel like a compact in-workout aid rather than a separate viewer bolted onto the workout flow.

Before this PR, the same viewer content shape was used everywhere.

After this PR, opening exercise guidance during active workout feels lighter and more execution-friendly while preserving the same modal/overlay model.

## Scope

Included:

- frontend refinement of the existing exercise viewer
- compact workout-mode behavior during active workout
- reuse of existing exercise metadata, images, notes, and cues

Not included:

- no timer-logic changes
- no workout-state changes
- no new exercise encyclopedia layer
- no redesign of the general viewer outside workout mode

## Validation

Validated by checking frontend syntax and confirming that exercise guidance opened during active workout now uses a more compact workout-mode presentation.

## Issue

Closes part of #223