### PR TITLE
Mark workout guidance as quick help because in-session technique support should feel distinct

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -5614,6 +5614,9 @@ function openExerciseViewer(exerciseId, options = {}){
     titleEl.textContent = name;
 
     const metaParts = [];
+    if (isWorkoutMode){
+      metaParts.push(tr("exercise.viewer_short_guide"));
+    }
     if (images.length){
       metaParts.push(`${images.length} billede${images.length === 1 ? "" : "r"}`);
     }


### PR DESCRIPTION
## Summary

This PR continues issue #223 by making exercise guidance opened during active workout feel more explicitly like quick in-session help.

The existing overlay already works during workout mode, and the previous step made its content more compact. This PR adds a small contextual signal in the viewer meta line so workout-time guidance feels more clearly like quick technique support rather than a general-purpose viewer state.

## What changed

Updated:

- `openExerciseViewer(exerciseId, options = {})`

When the viewer is opened in workout mode, the meta line now prepends:

- `exercise.viewer_short_guide`

This makes the overlay read more clearly as a quick help state during active execution.

## Why this helps

Issue #223 is about making technique guidance feel like a compact, on-demand part of the Workout Player rather than a separate viewer bolted onto the flow.

Before this PR, the compact workout-mode content existed, but the viewer still did not explicitly signal that it was quick in-session guidance.

After this PR, workout-mode guidance feels a bit more native and intentional without changing modal behavior or timer/workout state.

## Scope

Included:

- frontend refinement of the existing workout-mode viewer
- quick-help contextual label in workout-mode meta line

Not included:

- no timer changes
- no workout-state changes
- no new overlay system
- no redesign of the general viewer outside workout mode

## Validation

Validated by checking frontend syntax and confirming that workout-mode viewer openings now prepend the quick-help label in the meta line.

## Issue

Closes part of #223