### PR TITLE
Prioritize technique cues in workout mode because active guidance should stay scan-friendly

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -5626,7 +5626,8 @@ function openExerciseViewer(exerciseId, options = {}){
 
     metaEl.textContent = metaParts.join(" · ");
 
-    const notesHtml = notes ? `
+    const shouldShowNotes = Boolean(notes) && (!isWorkoutMode || !visibleFormCues.length);
+    const notesHtml = shouldShowNotes ? `
       <div style="margin-top:14px;padding:12px 14px;border-radius:14px;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08)">
         <div style="font-weight:700;margin-bottom:8px">${esc(tr("exercise.viewer_short_guide"))}</div>
         <div class="small" style="line-height:1.5">${esc(notes)}</div>


### PR DESCRIPTION
## Summary

This PR continues issue #223 by making workout-mode exercise guidance more scan-friendly during active execution.

The existing viewer already supports a compact workout mode. This PR refines the content hierarchy so technique cues are prioritized over longer guide text when the user is actively training.

## What changed

Updated:

- `openExerciseViewer(exerciseId, options = {})`

Added:

- `shouldShowNotes`

Behavior now:

- if workout mode is active and technique cues are available, the longer notes block is not shown
- if cues are not available, notes can still be shown as fallback
- outside workout mode, the previous notes behavior remains available

## Why this helps

Issue #223 is about making exercise guidance feel like compact, on-demand workout help rather than a general reading surface.

Before this PR, workout-mode guidance could still show both longer notes and cues together, which made the overlay denser than necessary during active use.

After this PR, workout-time guidance becomes easier to scan quickly and close without losing focus.

## Scope

Included:

- frontend content-priority refinement for workout-mode viewer
- cues now take priority over longer notes during active workout

Not included:

- no timer changes
- no workout-state changes
- no new viewer system
- no redesign of the general viewer outside workout mode

## Validation

Validated by checking frontend syntax and confirming that workout-mode guidance now suppresses longer notes when technique cues are already available.

## Issue

Closes part of #223