### PR TITLE
Add extra rest control because workout rest flow should support deliberate timer extension

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6432,7 +6432,7 @@ function renderWorkoutRestState(item, active){
         ${esc(playerLabels.actionText)}
       </div>
       <div style="margin-top:auto; display:flex; gap:10px; flex-wrap:wrap">
-        <button type="button" id="resumeWorkoutRestBtn" style="padding:16px 18px; font-size:1.05rem; font-weight:700; width:100%">${esc(primaryActionLabel)}</button>
+        <button type="button" id="resumeWorkoutRestBtn" style="padding:16px 18px; font-size:1.05rem; font-weight:700; width:100%">${esc(primaryActionLabel)}</button>\n        ${!restDone ? `<button type="button" id="addWorkoutRestBtn" class="secondary" style="width:100%; padding:14px 16px; font-size:0.98rem">${esc(tr("button.add_extra_rest"))}</button>` : ""}
       </div>
     </li>
   `;
@@ -6443,6 +6443,12 @@ function renderWorkoutRestState(item, active){
       STATE.currentWorkoutEntryIndex = nextEntryIndex;
       STATE.currentWorkoutSetIndex = 0;
     }
+    renderTodayPlan(item);
+  });
+
+  document.getElementById("addWorkoutRestBtn")?.addEventListener("click", () => {
+    if (restDone) return;
+    STATE.workoutRestTimerEndsAt = Number(STATE.workoutRestTimerEndsAt || 0) + (30 * 1000);
     renderTodayPlan(item);
   });
 

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -391,6 +391,7 @@
   "button.start_workout": "Start træning",
   "button.next_exercise": "Næste øvelse",
   "button.finish_workout": "Afslut træning",
+  "button.add_extra_rest": "Tilføj 30 sek hvile",
   "button.make_easier": "Gør lettere",
   "button.make_harder": "Gør hårdere",
   "button.remove_exercise": "Fjern øvelse",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -378,6 +378,7 @@
   "button.start_workout": "Start workout",
   "button.next_exercise": "Next exercise",
   "button.finish_workout": "Finish workout",
+  "button.add_extra_rest": "Add 30 sec rest",
   "button.make_easier": "Make easier",
   "button.make_harder": "Make harder",
   "button.remove_exercise": "Remove exercise",


### PR DESCRIPTION
## Summary

This PR starts issue #220 by adding a deliberate extra-rest control to the existing workout rest state.

The Workout Player already had a rest-timer foundation and a primary action for skipping rest or starting the next step early. This PR does not replace that flow. It extends it with one focused control for adding more rest time when the user needs it.

## What changed

Updated:

- `renderWorkoutRestState(item, active)`

The rest-state UI now shows a secondary control while rest is still active:

- `button.add_extra_rest`

Behavior:

- the button is shown only while rest is still running
- clicking it adds 30 seconds to `STATE.workoutRestTimerEndsAt`
- the rest state is immediately re-rendered

Added new i18n labels:

- `button.add_extra_rest` in Danish
- `button.add_extra_rest` in English

## Why this helps

Issue #220 is about making the existing timer flow feel clearer and more controllable during actual training.

Before this PR, the rest state mainly supported waiting or skipping forward.

After this PR, the user can also deliberately extend rest without leaving the player or breaking timer locality.

## Scope

Included:

- frontend rest-timer control refinement
- extra-rest button during active rest state
- local timer extension by 30 seconds

Not included:

- no backend changes
- no timer-architecture changes
- no global timer-state expansion
- no timed-hold redesign in this PR
- no sound/haptic additions

## Validation

Validated by checking frontend syntax and confirming that the workout rest state now supports adding 30 seconds of extra rest while the timer is active.

## Issue

Closes part of #220