### PR TITLE
Clarify next step after rest because timer states should be understandable at a glance

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6394,6 +6394,9 @@ function renderWorkoutRestState(item, active){
   const nextExerciseLabel = isNextExerciseRest && nextEntry
     ? `<div class="small" style="margin-bottom:8px">${esc(tr("workout.rest.next_exercise_label"))}</div>`
     : "";
+  const nextAfterRestLabel = isNextExerciseRest
+    ? tr("workout.rest.after_rest_next_exercise")
+    : tr("workout.rest.after_rest_next_set");
 
   const setProgressLabel = isNextExerciseRest && nextEntry
     ? tr("workout.set_progress", { current: "1", total: String(getWorkoutPlannedSetCount(nextEntry)) })
@@ -6425,6 +6428,7 @@ function renderWorkoutRestState(item, active){
         <div style="font-size:0.82rem; opacity:${progressOpacity}; margin-bottom:8px; text-transform:uppercase; letter-spacing:0.08em">${esc(phaseLabel)}</div>\n        <div style="font-size:0.95rem; opacity:${progressOpacity}; margin-bottom:12px; text-transform:uppercase; letter-spacing:0.04em">\n        ${esc(playerLabels.progressLabel)}\n      </div>
       ${nextExerciseLabel}
       <div style="font-size:1.05rem; font-weight:700; margin-bottom:10px">${esc(playerLabels.setProgressLabel)}</div>
+      <div class="small" style="margin-bottom:8px; opacity:0.8">${esc(nextAfterRestLabel)}</div>
       <div style="font-weight:800; font-size:2rem; line-height:1.1; margin-bottom:12px">${esc(playerLabels.exerciseName)}</div>
         <div style="font-weight:700; font-size:1.05rem; margin-bottom:12px; color:${statusColor}">${esc(statusLabel)}</div>
         <div style="font-size:3.2rem; line-height:1; font-weight:800; color:${timerColor}; margin:8px 0 18px 0">${esc(String(remainingSec))}<span style="font-size:1.2rem; font-weight:700; opacity:0.78"> s</span></div>

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -392,6 +392,8 @@
   "button.next_exercise": "Næste øvelse",
   "button.finish_workout": "Afslut træning",
   "button.add_extra_rest": "Tilføj 30 sek hvile",
+  "workout.rest.after_rest_next_set": "Efter hvile: næste sæt",
+  "workout.rest.after_rest_next_exercise": "Efter hvile: næste øvelse",
   "button.make_easier": "Gør lettere",
   "button.make_harder": "Gør hårdere",
   "button.remove_exercise": "Fjern øvelse",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -379,6 +379,8 @@
   "button.next_exercise": "Next exercise",
   "button.finish_workout": "Finish workout",
   "button.add_extra_rest": "Add 30 sec rest",
+  "workout.rest.after_rest_next_set": "After rest: next set",
+  "workout.rest.after_rest_next_exercise": "After rest: next exercise",
   "button.make_easier": "Make easier",
   "button.make_harder": "Make harder",
   "button.remove_exercise": "Remove exercise",


### PR DESCRIPTION
## Summary

This PR continues issue #220 by making the workout rest state more explicit about what happens after the timer ends.

The current rest flow already supports countdown, skip/early-start behavior, and extra rest. This PR does not change timer architecture. It adds a small guidance line so the user can immediately understand whether rest is leading into the next set or the next exercise.

## What changed

Updated:

- `renderWorkoutRestState(item, active)`

Added:

- `nextAfterRestLabel`

The rest-state card now shows one of:

- `workout.rest.after_rest_next_set`
- `workout.rest.after_rest_next_exercise`

Added new i18n labels in Danish and English for those states.

## Why this helps

Issue #220 is about making timer-driven workout states clearer and more understandable during real use.

Before this PR, the rest state already implied what would happen next, but the transition target was still somewhat implicit.

After this PR, the next state after rest is communicated more explicitly at a glance.

## Scope

Included:

- frontend refinement of the existing workout rest state
- explicit next-step guidance during rest
- new localized labels for next-set and next-exercise rest transitions

Not included:

- no backend changes
- no timer architecture changes
- no timed-hold redesign in this PR
- no sound/haptic changes

## Validation

Validated by checking frontend syntax and confirming that the workout rest state now shows an explicit “after rest” guidance line for next set vs next exercise.

## Issue

Closes part of #220