### PR TITLE
Strengthen active timed-hold state because timer-led holds should feel distinct from prep

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4124,16 +4124,23 @@ function buildWorkoutSetFields(entry, idx, setIdx){
     const displaySeconds = isPrepTimer ? prepRemainingSec : (isActiveTimer ? remainingSec : (existingSeconds || targetSec || 0));
     const statusLabel = isPrepTimer
       ? tr("workout.hold_get_ready")
-      : (isActiveTimer ? tr("input_kind.time") : tr("input_kind.time"));
+      : (isActiveTimer ? tr("button.start_set") : tr("input_kind.time"));
     const prepLeadHtml = isPrepTimer
       ? `<div class="small" style="margin-bottom:6px; opacity:0.82; text-transform:uppercase; letter-spacing:0.08em">${esc(tr("workout.hold_get_ready"))}</div>`
       : "";
-    const timerTone = isPrepTimer ? "color:#f3c96b;" : "color:#bcd3ff;";
+    const activeLeadHtml = isActiveTimer
+      ? `<div class="small" style="margin-bottom:6px; opacity:0.86; text-transform:uppercase; letter-spacing:0.08em">${esc(tr("button.start_set"))}</div>`
+      : "";
+    const timerTone = isPrepTimer ? "color:#f3c96b;" : (isActiveTimer ? "color:#8ff0a4;" : "color:#bcd3ff;");
+    const cardTone = isActiveTimer
+      ? "background:rgba(74,222,128,0.08); border:1px solid rgba(74,222,128,0.22);"
+      : "background:rgba(255,255,255,0.03);";
 
     return `
-      <div class="card" style="margin-top:8px; padding:10px 12px; border-radius:18px; background:rgba(255,255,255,0.03)">
+      <div class="card" style="margin-top:8px; padding:10px 12px; border-radius:18px; ${cardTone}">
         <div class="small" style="margin-bottom:8px; opacity:0.82">${tr("exercise.set_label", { number: setIdx + 1 })}</div>
         ${prepLeadHtml}
+        ${activeLeadHtml}
         <div class="small" style="margin-bottom:8px; opacity:0.78">${esc(statusLabel)}</div>
         <input type="hidden" name="review_set_reps_${idx}_${setIdx}" value="${esc(String(existingSeconds || targetSec || ""))}">
         <div style="font-size:2.2rem; font-weight:800; line-height:1; margin:8px 0 12px 0; ${timerTone}">${esc(String(displaySeconds))}<span style="font-size:1rem; font-weight:700; opacity:0.78"> s</span></div>


### PR DESCRIPTION
## Summary

This PR continues issue #220 by making the active timed-hold state more visually distinct from the prep state in the Workout Player.

The timed-hold flow already supports prep, active hold, and completion transitions. Previous refinement improved prep visibility. This PR focuses on the active hold phase so timer-led exercises feel more like a real hold state and less like prep with a different button.

## What changed

Updated:

- `buildWorkoutSetFields(entry, idx, setIdx)`

For timed-hold workout fields, the UI now adds:

- `activeLeadHtml` during active hold
- stronger `timerTone` during active hold
- `cardTone` so the active hold card stands out more clearly from prep/default state

Behavior:

- active hold now has a more explicit lead state
- the countdown becomes more visually dominant during the hold itself
- prep and active hold are easier to distinguish at a glance

## Why this helps

Issue #220 is about making timer-driven workout states clearer and more coherent, especially for timed holds.

Before this PR, the active hold state still looked too close to prep.

After this PR, active hold becomes a more recognizable timer-first phase during execution.

## Scope

Included:

- frontend refinement of active timed-hold presentation
- stronger visual separation between prep and active hold

Not included:

- no backend changes
- no timer architecture changes
- no broader interval-system redesign
- no sound/haptic additions

## Validation

Validated by checking frontend syntax and confirming that active timed-hold state now renders with more distinct timer-first presentation than prep.

## Issue

Closes part of #220