### PR TITLE
Mark timed exercises as a distinct mode because duration-based work should feel first-class

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4138,6 +4138,7 @@ function buildWorkoutSetFields(entry, idx, setIdx){
 
     return `
       <div class="card" style="margin-top:8px; padding:10px 12px; border-radius:18px; ${cardTone}">
+        <div class="small" style="margin-bottom:6px; opacity:0.82; text-transform:uppercase; letter-spacing:0.08em">${esc(tr("workout.timed_mode_label"))}</div>
         <div class="small" style="margin-bottom:8px; opacity:0.82">${tr("exercise.set_label", { number: setIdx + 1 })}</div>
         ${prepLeadHtml}
         ${activeLeadHtml}

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -394,6 +394,7 @@
   "button.add_extra_rest": "Tilføj 30 sek hvile",
   "workout.rest.after_rest_next_set": "Efter hvile: næste sæt",
   "workout.rest.after_rest_next_exercise": "Efter hvile: næste øvelse",
+  "workout.timed_mode_label": "Tidsøvelse",
   "button.make_easier": "Gør lettere",
   "button.make_harder": "Gør hårdere",
   "button.remove_exercise": "Fjern øvelse",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -381,6 +381,7 @@
   "button.add_extra_rest": "Add 30 sec rest",
   "workout.rest.after_rest_next_set": "After rest: next set",
   "workout.rest.after_rest_next_exercise": "After rest: next exercise",
+  "workout.timed_mode_label": "Timed exercise",
   "button.make_easier": "Make easier",
   "button.make_harder": "Make harder",
   "button.remove_exercise": "Remove exercise",


### PR DESCRIPTION
## Summary

This PR starts issue #221 by making timed exercises more explicitly visible as their own execution mode inside the Workout Player.

The frontend already had timed-exercise foundations, including prep, active hold, and completion behavior. This PR does not change that logic. It adds a small but important mode signal so duration-based movements read more clearly as timed exercises rather than as ordinary set cards with a countdown attached.

## What changed

Updated:

- `buildWorkoutSetFields(entry, idx, setIdx)`

For timed exercise cards (`inputKind === "time"`), the card now renders a mode label:

- `workout.timed_mode_label`

Added new i18n labels in Danish and English:

- `Tidsøvelse`
- `Timed exercise`

## Why this helps

Issue #221 is about making duration-based movements feel like a true first-class execution mode in the Workout Player.

Before this PR, the timed card had timer behavior but still looked too close to a general set card.

After this PR, timed exercises signal their identity more clearly at the UI level without changing progression or timer logic.

## Scope

Included:

- frontend timed-exercise mode labeling
- new localized mode label for timed exercise cards

Not included:

- no backend changes
- no timer architecture changes
- no round progression changes
- no broader timed-mode redesign yet

## Validation

Validated by checking frontend syntax and confirming that timed workout cards now render an explicit timed-mode label.

## Issue

Closes part of #221