### PR TITLE
Compact timed exercise header because duration mode should read as one execution state

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4136,10 +4136,11 @@ function buildWorkoutSetFields(entry, idx, setIdx){
       ? "background:rgba(74,222,128,0.08); border:1px solid rgba(74,222,128,0.22);"
       : "background:rgba(255,255,255,0.03);";
 
+    const timedModeHeader = `${tr("workout.timed_mode_label")} · ${tr("exercise.set_label", { number: setIdx + 1 })}`;
+
     return `
       <div class="card" style="margin-top:8px; padding:10px 12px; border-radius:18px; ${cardTone}">
-        <div class="small" style="margin-bottom:6px; opacity:0.82; text-transform:uppercase; letter-spacing:0.08em">${esc(tr("workout.timed_mode_label"))}</div>
-        <div class="small" style="margin-bottom:8px; opacity:0.82">${tr("exercise.set_label", { number: setIdx + 1 })}</div>
+        <div class="small" style="margin-bottom:8px; opacity:0.82; text-transform:uppercase; letter-spacing:0.08em">${esc(timedModeHeader)}</div>
         ${prepLeadHtml}
         ${activeLeadHtml}
         <div class="small" style="margin-bottom:8px; opacity:0.78">${esc(statusLabel)}</div>


### PR DESCRIPTION
## Summary

This PR continues issue #221 by making the timed exercise card header read more clearly as one unified execution state.

The previous step added an explicit timed-exercise mode label. This PR keeps the same information but compacts the top hierarchy so the card feels more like a first-class duration mode and less like a stack of separate labels.

## What changed

Updated:

- `buildWorkoutSetFields(entry, idx, setIdx)`

For timed exercise cards (`inputKind === "time"`), the card now builds:

- `timedModeHeader`

This combines:

- `workout.timed_mode_label`
- `exercise.set_label`

into one compact top line.

## Why this helps

Issue #221 is about making duration-based exercises feel like a true timer-first execution mode.

Before this PR, timed mode identity and set/round context were shown as separate stacked lines.

After this PR, the top of the card reads more like a single coherent timed-mode header.

## Scope

Included:

- frontend hierarchy refinement for timed exercise cards
- compact combined header for timed mode plus set context

Not included:

- no backend changes
- no timer logic changes
- no round progression changes
- no broader timed-mode redesign

## Validation

Validated by checking frontend syntax and confirming that timed exercise cards now render mode identity and set context as one compact header line.

## Issue

Closes part of #221