### PR TITLE
Show target duration because timed exercise mode should center time as the primary unit

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4144,6 +4144,7 @@ function buildWorkoutSetFields(entry, idx, setIdx){
         ${prepLeadHtml}
         ${activeLeadHtml}
         <div class="small" style="margin-bottom:8px; opacity:0.78">${esc(statusLabel)}</div>
+        <div class="small" style="margin-bottom:6px; opacity:0.72">${esc(tr("workout.timed_target_label", { seconds: String(targetSec || displaySeconds || 0) }))}</div>
         <input type="hidden" name="review_set_reps_${idx}_${setIdx}" value="${esc(String(existingSeconds || targetSec || ""))}">
         <div style="font-size:2.2rem; font-weight:800; line-height:1; margin:8px 0 12px 0; ${timerTone}">${esc(String(displaySeconds))}<span style="font-size:1rem; font-weight:700; opacity:0.78"> s</span></div>
         <div class="small" style="margin-top:6px; opacity:0.72">${tr("exercise.load_bodyweight")}</div>

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -395,6 +395,7 @@
   "workout.rest.after_rest_next_set": "Efter hvile: næste sæt",
   "workout.rest.after_rest_next_exercise": "Efter hvile: næste øvelse",
   "workout.timed_mode_label": "Tidsøvelse",
+  "workout.timed_target_label": "Mål: {seconds} sek",
   "button.make_easier": "Gør lettere",
   "button.make_harder": "Gør hårdere",
   "button.remove_exercise": "Fjern øvelse",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -382,6 +382,7 @@
   "workout.rest.after_rest_next_set": "After rest: next set",
   "workout.rest.after_rest_next_exercise": "After rest: next exercise",
   "workout.timed_mode_label": "Timed exercise",
+  "workout.timed_target_label": "Target: {seconds} sec",
   "button.make_easier": "Make easier",
   "button.make_harder": "Make harder",
   "button.remove_exercise": "Remove exercise",


### PR DESCRIPTION
## Summary

This PR continues issue #221 by adding explicit target-duration context to timed exercise cards in the Workout Player.

Timed exercise mode already had timer behavior and clearer mode identity. This PR refines the card body so duration-based movements communicate their target time more clearly during execution.

## What changed

Updated:

- `buildWorkoutSetFields(entry, idx, setIdx)`

For timed exercise cards (`inputKind === "time"`), the card now shows:

- `workout.timed_target_label`

This adds a compact target-duration line above the main countdown.

Added new i18n labels in Danish and English:

- `Mål: {seconds} sek`
- `Target: {seconds} sec`

## Why this helps

Issue #221 is about making duration-based movements feel like a true first-class timed mode.

Before this PR, the card displayed a countdown but gave less explicit context about the intended duration target.

After this PR, timed exercise cards communicate more clearly that time is the primary execution unit and what the current duration goal is.

## Scope

Included:

- frontend body-hierarchy refinement for timed exercise cards
- explicit target-duration context in timed mode
- new localized target-duration label

Not included:

- no backend changes
- no timer logic changes
- no round progression changes
- no broader timed-mode redesign

## Validation

Validated by checking frontend syntax and confirming that timed exercise cards now render a target-duration line above the active countdown.

## Issue

Closes part of #221