### PR TITLE
Clarify timed hold transition because duration mode should stay coherent into rest

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6050,6 +6050,8 @@ function completeTimedHoldSet(item){
   const active = getActiveWorkoutEntry(item);
   if (!active || !active.entry) return false;
 
+  STATE.workoutTimedTransitionState = "hold_completed";
+
   const entry = active.entry;
   if (!isTimedHoldWorkoutEntry(entry)) return false;
 
@@ -6412,6 +6414,9 @@ function renderWorkoutRestState(item, active){
   const nextAfterRestLabel = isNextExerciseRest
     ? tr("workout.rest.after_rest_next_exercise")
     : tr("workout.rest.after_rest_next_set");
+  const timedTransitionLabel = STATE.workoutTimedTransitionState === "hold_completed"
+    ? tr("workout.timed_transition_label")
+    : "";
 
   const setProgressLabel = isNextExerciseRest && nextEntry
     ? tr("workout.set_progress", { current: "1", total: String(getWorkoutPlannedSetCount(nextEntry)) })
@@ -6443,6 +6448,7 @@ function renderWorkoutRestState(item, active){
         <div style="font-size:0.82rem; opacity:${progressOpacity}; margin-bottom:8px; text-transform:uppercase; letter-spacing:0.08em">${esc(phaseLabel)}</div>\n        <div style="font-size:0.95rem; opacity:${progressOpacity}; margin-bottom:12px; text-transform:uppercase; letter-spacing:0.04em">\n        ${esc(playerLabels.progressLabel)}\n      </div>
       ${nextExerciseLabel}
       <div style="font-size:1.05rem; font-weight:700; margin-bottom:10px">${esc(playerLabels.setProgressLabel)}</div>
+      ${timedTransitionLabel ? `<div class="small" style="margin-bottom:8px; opacity:0.86">${esc(timedTransitionLabel)}</div>` : ""}
       <div class="small" style="margin-bottom:8px; opacity:0.8">${esc(nextAfterRestLabel)}</div>
       <div style="font-weight:800; font-size:2rem; line-height:1.1; margin-bottom:12px">${esc(playerLabels.exerciseName)}</div>
         <div style="font-weight:700; font-size:1.05rem; margin-bottom:12px; color:${statusColor}">${esc(statusLabel)}</div>
@@ -6458,6 +6464,7 @@ function renderWorkoutRestState(item, active){
 
   document.getElementById("resumeWorkoutRestBtn")?.addEventListener("click", () => {
     clearWorkoutRestTimer();
+    STATE.workoutTimedTransitionState = "";
     if (isNextExerciseRest && nextEntryIndex >= 0){
       STATE.currentWorkoutEntryIndex = nextEntryIndex;
       STATE.currentWorkoutSetIndex = 0;
@@ -6470,6 +6477,10 @@ function renderWorkoutRestState(item, active){
     STATE.workoutRestTimerEndsAt = Number(STATE.workoutRestTimerEndsAt || 0) + (30 * 1000);
     renderTodayPlan(item);
   });
+
+  if (restDone && STATE.workoutTimedTransitionState === "hold_completed"){
+    STATE.workoutTimedTransitionState = "";
+  }
 
   if (STATE.workoutRestTimerActive){
     const runtimeNonce = Number(STATE.workoutRuntimeNonce || 0);

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -396,6 +396,7 @@
   "workout.rest.after_rest_next_exercise": "Efter hvile: næste øvelse",
   "workout.timed_mode_label": "Tidsøvelse",
   "workout.timed_target_label": "Mål: {seconds} sek",
+  "workout.timed_transition_label": "Hold færdigt · hvile før næste trin",
   "button.make_easier": "Gør lettere",
   "button.make_harder": "Gør hårdere",
   "button.remove_exercise": "Fjern øvelse",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -383,6 +383,7 @@
   "workout.rest.after_rest_next_exercise": "After rest: next exercise",
   "workout.timed_mode_label": "Timed exercise",
   "workout.timed_target_label": "Target: {seconds} sec",
+  "workout.timed_transition_label": "Hold complete · rest before next step",
   "button.make_easier": "Make easier",
   "button.make_harder": "Make harder",
   "button.remove_exercise": "Remove exercise",


### PR DESCRIPTION
## Summary

This PR continues issue #221 by making the transition from active timed hold into rest feel more explicit and mode-aware.

Timed exercise mode already had timed execution, clearer mode identity, and target-duration context. This PR adds a small transition signal so the move from completed hold into rest reads more clearly as part of the same timed-exercise flow.

## What changed

Updated:

- `completeTimedHoldSet(item)`
- `renderWorkoutRestState(item, active)`

Added:

- `STATE.workoutTimedTransitionState = "hold_completed"` when a timed hold completes
- `timedTransitionLabel` in rest state when the current rest follows a completed timed hold

The transition state is cleared when:
- the user resumes from rest
- or the rest state resolves

Added new i18n labels in Danish and English:

- `workout.timed_transition_label`

## Why this helps

Issue #221 is about making duration-based exercises feel like a coherent first-class timed mode.

Before this PR, timed holds completed correctly, but the user landed in rest without much explicit continuity from the hold they just finished.

After this PR, the rest phase communicates more clearly that the hold was completed and that the user is now resting before the next timed step.

## Scope

Included:

- frontend transition refinement for timed exercise mode
- explicit completion-to-rest context for timed holds
- new localized transition label

Not included:

- no backend changes
- no timer logic redesign
- no round progression redesign
- no broader Workout Player architecture changes

## Validation

Validated by checking frontend syntax and confirming that timed-hold completion now adds explicit transition context in the following rest state.

## Issue

Closes part of #221