### PR TITLE
Add interval protocol metadata because protocol mode needs machine-readable seed structure

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -203,7 +203,13 @@
           {
             "exercise_id": "run_intervals",
             "sets": 1,
-            "reps": "6 x 1 min roligt/hurtigt"
+            "reps": "6 x 1 min roligt/hurtigt",
+            "protocol_mode": "interval",
+            "protocol": {
+              "rounds": 6,
+              "work_sec": 60,
+              "rest_sec": 60
+            }
           }
         ]
       }
@@ -246,7 +252,13 @@
           {
             "exercise_id": "run_intervals",
             "sets": 1,
-            "reps": "6 x 2 min kontrolleret hurtigt / 1 min roligt"
+            "reps": "6 x 2 min kontrolleret hurtigt / 1 min roligt",
+            "protocol_mode": "interval",
+            "protocol": {
+              "rounds": 6,
+              "work_sec": 120,
+              "rest_sec": 60
+            }
           }
         ]
       },


### PR DESCRIPTION
## Summary

This PR starts issue #222 by adding a minimal machine-readable protocol shape to representative interval-running entries in the seed programs.

The current seed data already contains human-readable interval descriptions such as `6 x 1 min roligt/hurtigt`, but that is not sufficient as a durable source for a dedicated protocol-driven Workout Player mode.

This PR does not add protocol UI yet. It establishes the first small data foundation for that work.

## What changed

Updated:

- `app/data/seed/programs.json`

For two representative `run_intervals` entries, the seed data now includes:

- `protocol_mode: "interval"`
- `protocol.rounds`
- `protocol.work_sec`
- `protocol.rest_sec`

The existing human-readable `reps` strings remain in place.

## Why this helps

Issue #222 is about adding a dedicated interval protocol mode that should remain structurally separate from both ordinary set-based flow and single timed-hold mode.

Before this PR, interval entries were only described as free-text reps strings.

After this PR, selected interval entries now also provide a machine-readable protocol shape that later frontend/backend work can build on without parsing execution logic out of display text.

## Scope

Included:

- minimal seed-data protocol metadata for representative interval entries
- preservation of existing human-readable reps text
- first machine-readable basis for later protocol-mode execution work

Not included:

- no frontend protocol UI yet
- no backend protocol engine yet
- no interval execution logic changes yet
- no broad seed migration across all interval entries yet

## Validation

Validated by checking that `programs.json` remains valid JSON and that the diff is limited to the two selected `run_intervals` entries.

## Issue

Closes part of #222