### PR TITLE
Shape protocol start state because interval mode should begin as a real execution flow

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6500,12 +6500,13 @@ function renderIntervalProtocolPlaceholder(item, progress){
 
   const entry = progress.entry;
   const protocol = entry?.protocol && typeof entry.protocol === "object" ? entry.protocol : {};
-  const rounds = Number(protocol.rounds || 0);
+  const rounds = Math.max(1, Number(protocol.rounds || 1));
   const workSec = Number(protocol.work_sec || 0);
   const restSec = Number(protocol.rest_sec || 0);
+  const prepSec = 5;
   const exerciseName = formatExerciseName(entry.exercise_id || "");
   const protocolSummary = [
-    rounds > 0 ? tr("workout.protocol_rounds_label", { value: String(rounds) }) : "",
+    tr("workout.protocol_round_progress_label", { current: "1", total: String(rounds) }),
     workSec > 0 ? tr("workout.protocol_work_label", { value: String(workSec) }) : "",
     restSec > 0 ? tr("workout.protocol_rest_label", { value: String(restSec) }) : "",
   ].filter(Boolean).join(" · ");
@@ -6515,8 +6516,10 @@ function renderIntervalProtocolPlaceholder(item, progress){
       <div style="font-size:0.82rem; opacity:0.82; margin-bottom:8px; text-transform:uppercase; letter-spacing:0.08em">${esc(tr("workout.protocol_mode_label"))}</div>
       <div style="font-size:0.95rem; opacity:0.82; margin-bottom:12px; text-transform:uppercase; letter-spacing:0.04em">${esc(tr("workout.protocol_placeholder_title"))}</div>
       <div style="font-weight:800; font-size:2rem; line-height:1.1; margin-bottom:12px">${esc(exerciseName)}</div>
-      ${protocolSummary ? `<div class="small" style="margin-bottom:14px; line-height:1.45; opacity:0.8">${esc(protocolSummary)}</div>` : ""}
-      <div class="small" style="line-height:1.5; margin-bottom:18px; opacity:0.78">${esc(tr("workout.protocol_placeholder_copy"))}</div>
+      ${protocolSummary ? `<div class="small" style="margin-bottom:12px; line-height:1.45; opacity:0.8">${esc(protocolSummary)}</div>` : ""}
+      <div class="small" style="margin-bottom:8px; opacity:0.82; text-transform:uppercase; letter-spacing:0.08em">${esc(tr("workout.hold_get_ready"))}</div>
+      <div style="font-size:3.2rem; line-height:1; font-weight:800; color:#ffd88a; margin:8px 0 14px 0">${esc(String(prepSec))}<span style="font-size:1.2rem; font-weight:700; opacity:0.78"> s</span></div>
+      <div class="small" style="line-height:1.5; margin-bottom:18px; opacity:0.78">${esc(tr("workout.protocol_next_phase_work"))}</div>
       <div style="margin-top:auto; display:flex; gap:10px; flex-wrap:wrap">
         <button type="button" id="startProtocolPlaceholderBtn" class="secondary" style="width:100%; padding:14px 16px; font-size:0.98rem">${esc(tr("button.start_workout"))}</button>
       </div>

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -404,6 +404,8 @@
   "workout.protocol_rounds_label": "Runder: {value}",
   "workout.protocol_work_label": "Arbejde: {value} sek",
   "workout.protocol_rest_label": "Hvile: {value} sek",
+  "workout.protocol_round_progress_label": "Runde {current}/{total}",
+  "workout.protocol_next_phase_work": "Næste fase: arbejde",
   "button.make_easier": "Gør lettere",
   "button.make_harder": "Gør hårdere",
   "button.remove_exercise": "Fjern øvelse",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -391,6 +391,8 @@
   "workout.protocol_rounds_label": "Rounds: {value}",
   "workout.protocol_work_label": "Work: {value} sec",
   "workout.protocol_rest_label": "Rest: {value} sec",
+  "workout.protocol_round_progress_label": "Round {current}/{total}",
+  "workout.protocol_next_phase_work": "Next phase: work",
   "button.make_easier": "Make easier",
   "button.make_harder": "Make harder",
   "button.remove_exercise": "Remove exercise",


### PR DESCRIPTION
## Summary

This PR continues issue #222 by upgrading the interval protocol placeholder into a protocol-style start state inside the Workout Player.

The previous step created a distinct protocol routing branch. This PR keeps that isolation, but makes the first visible state feel more like the beginning of real protocol execution rather than a static placeholder message.

## What changed

Updated:

- `renderIntervalProtocolPlaceholder(item, progress)`

The protocol card now shows:

- round progress as `Round 1/N`
- work/rest metadata in the same summary line
- a visible prep countdown placeholder (`5 s`)
- a clearer next-phase cue (`Next phase: work`)

Added new i18n labels in Danish and English:

- `workout.protocol_round_progress_label`
- `workout.protocol_next_phase_work`

## Why this helps

Issue #222 is about creating a protocol-first execution model, not just displaying protocol metadata in a passive card.

Before this PR, interval protocol entries routed into a distinct branch, but the rendered state still behaved mostly like an informational placeholder.

After this PR, the protocol branch starts to resemble a real execution entry state with prep, round context, and next-phase orientation.

## Scope

Included:

- frontend refinement of the isolated protocol branch
- protocol-style start-state presentation
- clearer round and next-phase context

Not included:

- no live alternating work/rest timer engine yet
- no protocol progression state machine yet
- no protocol completion/review handling changes yet
- no backend execution engine changes yet

## Validation

Validated by checking frontend syntax and confirming that interval protocol entries now render a more execution-like protocol start state instead of a purely informational placeholder.

## Issue

Closes part of #222