### PR TITLE
Add protocol variant metadata because interval mode should distinguish on-off sessions explicitly

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -205,6 +205,7 @@
             "sets": 1,
             "reps": "6 x 1 min roligt/hurtigt",
             "protocol_mode": "interval",
+            "protocol_variant": "on_off",
             "protocol": {
               "rounds": 6,
               "work_sec": 60,
@@ -254,6 +255,7 @@
             "sets": 1,
             "reps": "6 x 2 min kontrolleret hurtigt / 1 min roligt",
             "protocol_mode": "interval",
+            "protocol_variant": "on_off",
             "protocol": {
               "rounds": 6,
               "work_sec": 120,


### PR DESCRIPTION
## Summary

This PR continues issue #222 by adding explicit protocol variant metadata to the first interval protocol entries in seed data.

The current protocol-mode work already distinguishes interval entries structurally via `protocol_mode`. This PR refines that shape so representative interval sessions also identify their specific protocol variant.

## What changed

Updated:

- `app/data/seed/programs.json`

For two representative `run_intervals` entries, the seed data now includes:

- `protocol_variant: "on_off"`

The existing fields remain unchanged:

- `protocol_mode: "interval"`
- `protocol.rounds`
- `protocol.work_sec`
- `protocol.rest_sec`

## Why this helps

Issue #222 references multiple protocol types, including fixed work/rest rounds.

Before this PR, the seed data identified interval protocol entries but did not explicitly distinguish which protocol variant they represented.

After this PR, the first machine-readable protocol entries now explicitly identify themselves as `on_off`, which makes later protocol-aware rendering and progression logic clearer and less dependent on inference.

## Scope

Included:

- explicit `protocol_variant` metadata for representative interval protocol entries
- clearer distinction between protocol family and protocol variant

Not included:

- no frontend variant-specific behavior yet
- no Tabata or EMOM-specific seed entries yet
- no runtime logic changes yet

## Validation

Validated by checking that `programs.json` remains valid JSON and that the diff is limited to the two selected interval protocol entries.

## Issue

Closes part of #222