### PR TITLE
Show protocol variant because interval mode should be understandable in the player

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -6622,6 +6622,8 @@ function renderIntervalProtocolPlaceholder(item, progress){
   const workSec = protocolState.workSec;
   const restSec = protocolState.restSec;
   const exerciseName = formatExerciseName(entry.exercise_id || "");
+  const protocolVariant = String(entry?.protocol_variant || "").trim().toLowerCase();
+  const protocolVariantLabel = protocolVariant === "on_off" ? tr("workout.protocol_variant_on_off") : "";
   const currentPhaseLabel = protocolState.isWorkRunning
     ? tr("workout.protocol_phase_work")
     : (protocolState.isRestRunning ? tr("workout.protocol_phase_rest") : tr("workout.hold_get_ready"));
@@ -6640,6 +6642,7 @@ function renderIntervalProtocolPlaceholder(item, progress){
       <div style="font-size:0.82rem; opacity:0.82; margin-bottom:8px; text-transform:uppercase; letter-spacing:0.08em">${esc(tr("workout.protocol_mode_label"))}</div>
       <div style="font-size:0.95rem; opacity:0.82; margin-bottom:12px; text-transform:uppercase; letter-spacing:0.04em">${esc(tr("workout.protocol_placeholder_title"))}</div>
       <div style="font-weight:800; font-size:2rem; line-height:1.1; margin-bottom:12px">${esc(exerciseName)}</div>
+      ${protocolVariantLabel ? `<div class="small" style="margin-bottom:10px; opacity:0.74">${esc(protocolVariantLabel)}</div>` : ""}
       ${protocolSummary ? `<div class="small" style="margin-bottom:12px; line-height:1.45; opacity:0.8">${esc(protocolSummary)}</div>` : ""}
       <div class="small" style="margin-bottom:8px; opacity:0.82; text-transform:uppercase; letter-spacing:0.08em">${esc(currentPhaseLabel)}</div>
       <div style="font-size:3.2rem; line-height:1; font-weight:800; color:${timerColor.replace(";", "")}; margin:8px 0 14px 0">${esc(String(displaySeconds))}<span style="font-size:1.2rem; font-weight:700; opacity:0.78"> s</span></div>

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -410,6 +410,7 @@
   "workout.protocol_phase_work": "Arbejde",
   "workout.protocol_phase_rest": "Hvile",
   "workout.protocol_complete_status": "Intervalprotokol gennemført.",
+  "workout.protocol_variant_on_off": "On/off-intervaller",
   "button.make_easier": "Gør lettere",
   "button.make_harder": "Gør hårdere",
   "button.remove_exercise": "Fjern øvelse",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -397,6 +397,7 @@
   "workout.protocol_phase_work": "Work",
   "workout.protocol_phase_rest": "Rest",
   "workout.protocol_complete_status": "Interval protocol completed.",
+  "workout.protocol_variant_on_off": "On/off intervals",
   "button.make_easier": "Make easier",
   "button.make_harder": "Make harder",
   "button.remove_exercise": "Remove exercise",


### PR DESCRIPTION
## Summary

This PR continues issue #222 by making the interval protocol variant visible inside the Workout Player UI.

Previous work added machine-readable protocol metadata, an isolated protocol branch, runtime behavior, round progression, and completion into review. This PR makes the active protocol variant visible to the user so the player communicates not only that protocol mode is active, but also which protocol style is being executed.

## What changed

Updated:

- `renderIntervalProtocolPlaceholder(item, progress)`

Added:

- `protocolVariant`
- `protocolVariantLabel`

Behavior now:

- when a protocol entry has `protocol_variant: "on_off"`, the Workout Player shows a small visible variant label in the protocol card

Added new i18n labels in Danish and English:

- `workout.protocol_variant_on_off`

## Why this helps

Issue #222 is about making protocol mode a real, understandable execution model inside the Workout Player.

Before this PR, the interval protocol variant existed in seed data but was not explicitly shown in the player UI.

After this PR, the protocol variant is visible during execution, which makes the mode more legible and better aligned with the machine-readable protocol model.

## Scope

Included:

- visible protocol variant label in protocol mode UI
- `on_off` variant labeling for interval protocol entries

Not included:

- no new runtime logic
- no new protocol variants such as Tabata or EMOM yet
- no backend changes

## Validation

Validated by checking frontend syntax and confirming that interval protocol entries with `protocol_variant: "on_off"` now display a visible variant label in the Workout Player.

## Issue

Closes part of #222