### PR TITLE
Add session entry adapter because training sessions should support bundled blocks safely

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1881,7 +1881,7 @@ function buildForecastLeadText(planItem){
   }
 
   const sessionType = String(planItem.session_type || "").trim().toLowerCase();
-  const entries = Array.isArray(planItem.entries) ? planItem.entries : [];
+  const entries = getSessionEntries(planItem);
   const firstEntry = entries.length ? entries[0] : null;
   const firstExercise = String(firstEntry?.exercise_id || "").trim().toLowerCase();
   const targetReps = String(firstEntry?.target_reps || "").trim();
@@ -4317,7 +4317,8 @@ function toggleCardioReviewFields(item){
     return;
   }
 
-  const firstEntry = Array.isArray(item?.entries) && item.entries.length ? item.entries[0] : null;
+  const sessionEntries = getSessionEntries(item);
+  const firstEntry = sessionEntries.length ? sessionEntries[0] : null;
   const exId = String(firstEntry?.exercise_id || "").trim().toLowerCase();
 
   if (cardioKindEl && !cardioKindEl.value){
@@ -4394,7 +4395,8 @@ function renderSessionReview(item){
     return;
   }
 
-  if (!item || !Array.isArray(item.entries) || item.entries.length === 0){
+  const sessionEntries = getSessionEntries(item);
+  if (!item || sessionEntries.length === 0){
     root.innerHTML = `<li><div class="small">${esc(tr("after_training.no_exercises_to_review"))}</div></li>`;
     toggleCardioReviewFields(null);
     return;
@@ -4402,7 +4404,7 @@ function renderSessionReview(item){
 
   toggleCardioReviewFields(item);
 
-  root.innerHTML = item.entries.map((entry, idx) => {
+  root.innerHTML = sessionEntries.map((entry, idx) => {
     const setCount = Math.max(1, Number(entry.sets || 1));
     const meta = getReviewExerciseMeta(entry.exercise_id);
     const inputKind = String(meta?.input_kind || "");
@@ -4475,7 +4477,8 @@ function renderReviewSummary(item){
   const root = document.getElementById("reviewPlanSummary");
   if (!root) return;
 
-  if (!item || !Array.isArray(item.entries) || item.entries.length === 0){
+  const sessionEntries = getSessionEntries(item);
+  if (!item || sessionEntries.length === 0){
     root.innerHTML = `<div class="small">${esc(tr("after_training.no_plan_to_review"))}</div>`;
     return;
   }
@@ -4486,7 +4489,7 @@ function renderReviewSummary(item){
   if (sessionType) metaBits.push(sessionType);
   if (item.time_budget_min) metaBits.push(`${esc(item.time_budget_min)} min`);
   if (item.readiness_score != null) metaBits.push(`${esc(tr("overview.readiness"))}: ${esc(String(item.readiness_score))}`);
-  metaBits.push(`${esc(String(item.entries.length))} ${esc(item.entries.length === 1 ? tr("common.exercise_singular") : tr("common.exercise_plural"))}`);
+  metaBits.push(`${esc(String(sessionEntries.length))} ${esc(sessionEntries.length === 1 ? tr("common.exercise_singular") : tr("common.exercise_plural"))}`);
 
   root.innerHTML = `
     <div class="review-summary-card">
@@ -4499,7 +4502,7 @@ function renderReviewSummary(item){
       ${completionSummaryText ? `<div class="small review-summary-outcome">${esc(completionSummaryText)}</div>` : ""}
       <div class="small review-summary-outcome">${esc(tr("review.summary_session_label"))}</div>
       <div class="small review-summary-list">
-        ${item.entries.map(entry => {
+        ${sessionEntries.map(entry => {
           const bits = [];
           if (entry.sets) bits.push(tr("exercise.sets_count", { count: esc(entry.sets) }));
           if (entry.target_reps) bits.push(tr("exercise.target_label", { value: formatTarget(entry.target_reps) }));
@@ -5352,7 +5355,7 @@ async function applyVariantSwap(entry, direction){
 }
 
 function removePlanEntryByIndex(item, idx){
-  const entries = Array.isArray(item?.entries) ? item.entries : [];
+  const entries = getSessionEntries(item);
   if (idx < 0 || idx >= entries.length) return;
   entries.splice(idx, 1);
   renderTodayPlan(item);
@@ -5718,6 +5721,22 @@ function bindExerciseViewer(){
 }
 
 
+
+function getSessionEntries(item){
+  if (!item || typeof item !== "object") return [];
+  if (Array.isArray(item.entries)) return item.entries;
+
+  const blocks = Array.isArray(item.session_blocks) ? item.session_blocks : [];
+  const flattened = [];
+  for (const block of blocks){
+    if (!block || typeof block !== "object") continue;
+    const blockEntries = Array.isArray(block.entries) ? block.entries : [];
+    for (const entry of blockEntries){
+      if (entry && typeof entry === "object") flattened.push(entry);
+    }
+  }
+  return flattened;
+}
 
 function formatTrainingDays(days){
   if (!Array.isArray(days) || !days.length) return "";


### PR DESCRIPTION
## Summary

This PR starts issue #225 by adding a lightweight frontend read adapter for session entries.

The current app assumes one flat `item.entries` structure in several forecast, review, and Workout Player readers. This PR introduces a small adapter layer so future bundled training sessions can expose ordered session blocks without immediately forcing a broad player rewrite.

## What changed

Added:

- `getSessionEntries(item)`

Behavior:

- returns `item.entries` when present
- otherwise flattens `item.session_blocks[*].entries` into one ordered readable entry list

Updated core readers to use the adapter in selected places:

- forecast lead text
- cardio review field setup
- session review rendering
- review summary rendering
- plan entry removal path

## Why this helps

Issue #225 is about introducing a lightweight training-session composition layer that can bundle multiple ordered workout blocks into one playable session.

Before this PR, key frontend readers were tightly coupled to a flat `item.entries` assumption.

After this PR, the frontend has an initial composition-aware read layer that can support bundled session blocks while preserving the current flat-entry behavior as the default fallback.

## Scope

Included:

- lightweight `getSessionEntries(item)` adapter
- selected frontend readers moved from direct `item.entries` access to adapter-based reads
- ordered flattening of `session_blocks[*].entries`

Not included:

- no backend `session_blocks` production yet
- no block-aware player transitions yet
- no block boundary UI yet
- no block-aware mutation/removal model yet

## Validation

Validated by checking frontend syntax and confirming that the selected forecast/review/session readers now read through the adapter layer instead of hardcoding flat `item.entries` access.

## Issue

Closes part of #225