### PR TITLE
Show session block counts because bundled sessions should be visible in plan and review

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4485,10 +4485,12 @@ function renderReviewSummary(item){
 
   const sessionType = formatSessionType(item.session_type || "");
   const completionSummaryText = getWorkoutCompletionSummaryText(STATE.workoutCompletionContext || {});
+  const sessionBlocks = getSessionBlocks(item);
   const metaBits = [];
   if (sessionType) metaBits.push(sessionType);
   if (item.time_budget_min) metaBits.push(`${esc(item.time_budget_min)} min`);
   if (item.readiness_score != null) metaBits.push(`${esc(tr("overview.readiness"))}: ${esc(String(item.readiness_score))}`);
+  if (sessionBlocks.length > 1) metaBits.push(tr("session.blocks_count", { count: String(sessionBlocks.length) }));
   metaBits.push(`${esc(String(sessionEntries.length))} ${esc(sessionEntries.length === 1 ? tr("common.exercise_singular") : tr("common.exercise_plural"))}`);
 
   root.innerHTML = `
@@ -5721,6 +5723,22 @@ function bindExerciseViewer(){
 }
 
 
+
+function getSessionBlocks(item){
+  if (!item || typeof item !== "object") return [];
+  if (Array.isArray(item.session_blocks) && item.session_blocks.length){
+    return item.session_blocks.filter(block => block && typeof block === "object");
+  }
+
+  const entries = getSessionEntries(item);
+  if (!entries.length) return [];
+  return [{
+    id: "main",
+    label: "",
+    kind: "default",
+    entries,
+  }];
+}
 
 function getSessionEntries(item){
   if (!item || typeof item !== "object") return [];
@@ -7249,6 +7267,10 @@ function renderTodayPlan(item){
       "todayPlanSummary",
       compactSummaryLead
     );
+  const sessionBlocks = getSessionBlocks(item);
+  if (sessionBlocks.length > 1){
+    setText("todayPlanMeta", tr("session.blocks_count", { count: String(sessionBlocks.length) }));
+  }
 
     if (STATE.workoutInProgress){
       setText("todayPlanTiming", "");
@@ -7259,7 +7281,8 @@ function renderTodayPlan(item){
       return;
     }
 
-    const hasEntries = Array.isArray(item?.entries) && item.entries.length > 0;
+  const sessionEntries = getSessionEntries(item);
+  const hasEntries = sessionEntries.length > 0;
     const isRestitutionPlan = String(item?.session_type || "").trim().toLowerCase() === "restitution";
     const missingTrainingTypes = String(item?.plan_variant || "").trim() === "missing_training_types";
     const showPlannedRestChoiceCard = isPlannedRestDay && !missingTrainingTypes;

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -126,6 +126,7 @@
   "review.session_review": "Review af træning",
   "session_type.mobility": "Mobilitet",
   "session_type.run": "Løb",
+  "session.blocks_count": "{count} blokke",
   "session_type.strength": "Styrke",
   "settings.strength_weights": "Styrke med vægte",
   "today_plan.title": "Dagens plan",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -113,6 +113,7 @@
   "review.session_review": "Training review",
   "session_type.mobility": "Mobility",
   "session_type.run": "Run",
+  "session.blocks_count": "{count} blocks",
   "session_type.strength": "Strength",
   "settings.strength_weights": "Strength with weights",
   "today_plan.title": "Today's plan",


### PR DESCRIPTION
## Summary

This PR continues issue #225 by making bundled session blocks visible in the frontend UI.

The previous step introduced a lightweight entry adapter so the frontend could read either flat `entries` or ordered `session_blocks[*].entries`. This PR adds a lightweight block-aware UI layer so bundled sessions can become visible as structured sessions in plan and review surfaces.

## What changed

Added:

- `getSessionBlocks(item)`

Behavior:

- returns `item.session_blocks` when present
- otherwise falls back to one synthetic default block containing `getSessionEntries(item)`

Updated UI:

- `renderReviewSummary(item)` now shows block count when a session contains multiple blocks
- `renderTodayPlan(item)` now shows block count in plan meta when multiple blocks exist
- `renderTodayPlan(item)` now derives `hasEntries` via `getSessionEntries(item)`

Added new i18n labels in Danish and English:

- `session.blocks_count`

## Why this helps

Issue #225 is about supporting one coherent playable session that may contain multiple ordered workout parts.

Before this PR, the frontend could read bundled session entries through the adapter layer, but the block structure itself was still invisible in the UI.

After this PR, bundled sessions can be represented as multi-block sessions in plan and review surfaces without changing playback flow yet.

## Scope

Included:

- lightweight `getSessionBlocks(item)` helper
- block-count visibility in plan and review UI
- plan entry presence derived through session entry adapter

Not included:

- no backend production of `session_blocks` yet
- no block-aware playback transitions yet
- no block boundary navigation yet
- no mutation/removal behavior by block yet

## Validation

Validated by checking frontend syntax and confirming that plan/review surfaces can now display block counts when `session_blocks` are present, while preserving current fallback behavior for flat sessions.

## Issue

Closes part of #225