### PR TITLE
Allow session blocks in today plans because bundled sessions need backend-safe structure

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -4901,6 +4901,21 @@ def build_next_guidance(today_plan_item, completed_today=False):
 
 
 
+def flatten_session_block_entries(session_blocks):
+    if not isinstance(session_blocks, list):
+        return []
+    flattened = []
+    for block in session_blocks:
+        if not isinstance(block, dict):
+            continue
+        block_entries = block.get("entries", [])
+        if not isinstance(block_entries, list):
+            continue
+        for entry in block_entries:
+            if isinstance(entry, dict):
+                flattened.append(entry)
+    return flattened
+
 def validate_today_plan_item(item):
     if not isinstance(item, dict):
         return {
@@ -4914,9 +4929,14 @@ def validate_today_plan_item(item):
 
     session_type = str(item.get("session_type", "")).strip().lower()
     plan_variant = str(item.get("plan_variant", "")).strip().lower()
+    session_blocks = item.get("session_blocks", [])
+    if not isinstance(session_blocks, list):
+        session_blocks = []
     entries = item.get("entries", [])
     if not isinstance(entries, list):
         entries = []
+    if not entries and session_blocks:
+        entries = flatten_session_block_entries(session_blocks)
 
     has_entries = bool(entries)
     has_exercise_entries = any(
@@ -4939,7 +4959,11 @@ def validate_today_plan_item(item):
         invalid_reason = "unknown session_type"
 
     if not invalid:
-        return item
+        fixed_item = dict(item)
+        fixed_item["entries"] = entries
+        if session_blocks:
+            fixed_item["session_blocks"] = session_blocks
+        return fixed_item
 
     logger.warning(
         "today_plan_consistency_fallback session_type=%s reason=%s",


### PR DESCRIPTION
## Summary

This PR continues issue #225 by making `session_blocks` a valid backend shape for today-plan items while preserving flat `entries` as the playback-safe fallback.

Previous work introduced frontend read adapters and lightweight block visibility. This PR makes bundled sessions real in the backend validation path without forcing the Workout Player to become block-aware yet.

## What changed

Added:

- `flatten_session_block_entries(session_blocks)`

Updated:

- `validate_today_plan_item(item)`

Behavior now:

- `session_blocks` is accepted as an optional field on today-plan items
- when `entries` is missing or empty, backend validation derives flat `entries` from `session_blocks[*].entries`
- validated items preserve `session_blocks` in output when present
- existing flat `entries` behavior remains unchanged

## Why this helps

Issue #225 is about introducing a lightweight session-bundling layer for coherent playable training sessions.

Before this PR, today-plan validation only understood flat `entries`, which meant bundled sessions had no backend-safe structural path.

After this PR, the backend can represent bundled session structure while still preserving the flat entry list needed by the current player flow.

## Scope

Included:

- backend helper for flattening session block entries
- today-plan validation support for optional `session_blocks`
- preservation of flat `entries` as execution fallback

Not included:

- no backend planner emits `session_blocks` yet
- no block-aware playback transitions yet
- no block boundary execution logic yet
- no mutation/removal behavior by block yet

## Validation

Validated by compiling `app/backend/app.py` and confirming that today-plan validation now accepts `session_blocks`, derives flat `entries` when needed, and preserves `session_blocks` in output.

## Issue

Closes part of #225