### PR TITLE
Emit session blocks for manual overrides because bundled sessions need one real output path

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -3875,15 +3875,8 @@ def auth_whoami():
 
 
 def build_manual_override_today_plan_response(latest_checkin, checkin_date, readiness_score, manual_override):
-    override_entries = []
-    raw_entries = manual_override.get("entries", [])
-    if not isinstance(raw_entries, list):
-        raw_entries = []
-
-    for e in raw_entries:
-        if not isinstance(e, dict):
-            continue
-        override_entries.append({
+    def map_manual_override_entry(e):
+        return {
             "exercise_id": str(e.get("exercise_id", "")).strip(),
             "sets": e.get("sets", ""),
             "target_reps": str(e.get("reps", "")).strip(),
@@ -3896,9 +3889,46 @@ def build_manual_override_today_plan_response(latest_checkin, checkin_date, read
             "secondary_constraints": [],
             "next_target_reps": None,
             "substituted_from": None
-        })
+        }
+
+    override_entries = []
+    raw_entries = manual_override.get("entries", [])
+    if not isinstance(raw_entries, list):
+        raw_entries = []
+
+    for e in raw_entries:
+        if not isinstance(e, dict):
+            continue
+        override_entries.append(map_manual_override_entry(e))
 
 
+
+
+    session_blocks = []
+    raw_blocks = manual_override.get("session_blocks", [])
+    if isinstance(raw_blocks, list):
+        for idx, block in enumerate(raw_blocks):
+            if not isinstance(block, dict):
+                continue
+            raw_block_entries = block.get("entries", [])
+            if not isinstance(raw_block_entries, list):
+                raw_block_entries = []
+            mapped_entries = []
+            for entry in raw_block_entries:
+                if not isinstance(entry, dict):
+                    continue
+                mapped_entries.append(map_manual_override_entry(entry))
+            if not mapped_entries:
+                continue
+            session_blocks.append({
+                "id": str(block.get("id", "")).strip() or f"block_{idx + 1}",
+                "label": str(block.get("label", "")).strip(),
+                "kind": str(block.get("kind", "")).strip() or "default",
+                "entries": mapped_entries,
+            })
+
+    if session_blocks:
+        override_entries = flatten_session_block_entries(session_blocks)
 
     return jsonify({
         "ok": True,
@@ -3925,6 +3955,7 @@ def build_manual_override_today_plan_response(latest_checkin, checkin_date, read
             "families_selected": [],
             "training_day_context": {},
             "entries": override_entries,
+            "session_blocks": session_blocks,
             "source": "manual_override",
             "manual_override_workout_id": manual_override.get("id")
         }


### PR DESCRIPTION
## Summary

This PR continues issue #225 by making manual override today-plan responses the first real backend output path that can emit `session_blocks`.

Previous work introduced frontend read adapters, block visibility, and backend validation support for optional `session_blocks`. This PR makes bundled sessions real in one controlled today-plan source while preserving flat `entries` as the playback-safe fallback.

## What changed

Updated:

- `build_manual_override_today_plan_response(...)`

Added inside the builder:

- local `map_manual_override_entry(e)` helper
- optional mapping of `manual_override.session_blocks`

Behavior now:

- manual overrides can provide `session_blocks`
- each block is normalized into a clean today-plan block shape
- if blocks are present, flat `entries` are derived from block entries via `flatten_session_block_entries(...)`
- output includes both:
  - `session_blocks`
  - playback-safe flat `entries`

Existing manual override behavior remains intact when no `session_blocks` are provided.

## Why this helps

Issue #225 is about introducing a lightweight training-session composition layer that can bundle multiple ordered workout parts into one coherent session.

Before this PR, bundled session structure was tolerated by frontend and validation paths but was not actually emitted by any real today-plan source.

After this PR, manual override becomes the first real backend output path that can produce bundled sessions while preserving the current flat execution model.

## Scope

Included:

- bundled `session_blocks` support in manual override today-plan output
- normalized block entry mapping
- flat `entries` fallback preserved for current playback

Not included:

- no broad autoplan emission of `session_blocks` yet
- no block-aware playback transitions yet
- no block boundary execution logic yet
- no block-aware mutation/removal behavior yet

## Validation

Validated by compiling `app/backend/app.py` and confirming that manual override today-plan responses can now include `session_blocks` while still emitting flat `entries` for the current player flow.

## Issue

Closes part of #225