### PR TITLE
Expose local protection explanations in forecast and daily plan

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -4257,6 +4257,55 @@ def build_today_plan_priority_decision(
     return None
 
 
+
+def shape_strength_ctx_for_local_protection(strength_ctx, user_id, readiness_score, fatigue_score, time_budget_min, user_settings=None):
+    ctx = dict(strength_ctx) if isinstance(strength_ctx, dict) else {}
+    protect_regions = get_local_protect_regions(user_id, regions=("knee", "ankle_calf", "low_back"))
+    if not protect_regions:
+        return ctx
+
+    starter_capacity_profile = get_starter_capacity_profile(user_settings)
+    readiness_val = int(readiness_score or 0)
+    fatigue_val = int(fatigue_score or 0)
+    protected = set(protect_regions)
+
+    current_variant = str(ctx.get("plan_variant", "default") or "default").strip()
+    current_reason = str(ctx.get("reason", "") or "").strip()
+
+    if current_variant == "local_protection_restitution":
+        return ctx
+
+    if len(protected) >= 2:
+        return {
+            "ok": True,
+            "template_id": "restitution_easy",
+            "plan_entries": build_restitution_plan(time_budget_min, starter_capacity_profile=starter_capacity_profile),
+            "plan_variant": "local_protection_restitution",
+            "reason": f"lokal beskyttelse i {', '.join(sorted(protected))} former dagen til restitution",
+        }
+
+    if protected.intersection({"knee", "ankle_calf"}) and (readiness_val <= 4 or fatigue_val >= 2):
+        return {
+            "ok": True,
+            "template_id": "restitution_easy",
+            "plan_entries": build_restitution_plan(time_budget_min, starter_capacity_profile=starter_capacity_profile),
+            "plan_variant": "local_protection_restitution",
+            "reason": f"lokal beskyttelse i {', '.join(sorted(protected))} gør restitution mere sammenhængende end et reduceret pas",
+        }
+
+    if "low_back" in protected:
+        if current_variant not in ("light_strength", "local_light_strength", "local_protection_restitution"):
+            ctx["plan_variant"] = "local_light_strength"
+            if current_reason:
+                ctx["reason"] = f"{current_reason} · lokal beskyttelse i low_back nedjusterede passet til lettere styrke"
+            else:
+                ctx["reason"] = "lokal beskyttelse i low_back nedjusterede passet til lettere styrke"
+        elif current_reason and "low_back" not in current_reason:
+            ctx["reason"] = f"{current_reason} · lokal beskyttelse i low_back er aktiv"
+
+    return ctx
+
+
 def build_today_plan_training_decision(
     auth_user,
     checkin_date,
@@ -4298,6 +4347,14 @@ def build_today_plan_training_decision(
         user_settings=user_settings,
         user_id=auth_user.get("user_id"),
         selected_program_id=selected_strength_program_id,
+    )
+    strength_ctx = shape_strength_ctx_for_local_protection(
+        strength_ctx=strength_ctx,
+        user_id=auth_user.get("user_id"),
+        readiness_score=readiness_score,
+        fatigue_score=fatigue_score,
+        time_budget_min=time_budget_min,
+        user_settings=user_settings,
     )
 
     training_day_prefs = get_training_day_preferences(user_settings)

--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -2656,6 +2656,7 @@ def choose_cardio_session(user_id, readiness=None, time_budget_min=None, recover
         "duration_min": int(duration),
         "reason": reason[:6],
         "metrics": metrics,
+        "protected_regions": protect_regions,
     }
 
 
@@ -2710,12 +2711,20 @@ def build_autoplan_cardio(user_id, readiness=None, time_budget_min=None, recover
         }
     }
 
+    metrics = picked.get("metrics", {}) if isinstance(picked.get("metrics", {}), dict) else {}
+    protected_regions = picked.get("protected_regions", [])
+    if not isinstance(protected_regions, list):
+        protected_regions = []
+    protected_regions = [str(x).strip() for x in protected_regions if str(x).strip()]
+
     return {
         "session_type": "løb",
         "template_mode": "autoplan_cardio_v0_1",
         "cardio_kind": kind,
         "reason": picked.get("reason", []),
         "entries": [entry],
+        "local_protection_override": bool(protected_regions),
+        "protected_regions": protected_regions,
     }
 
 
@@ -4460,6 +4469,8 @@ def build_today_plan_training_decision(
                     "template_mode": cardio_plan.get("template_mode"),
                     "families_selected": [],
                     "selected_endurance_program_id": selected_endurance_program_id,
+                    "local_protection_override": bool(cardio_plan.get("local_protection_override")),
+                    "protected_regions": cardio_plan.get("protected_regions", []),
                 }
 
             if not plan_entries:
@@ -4537,7 +4548,9 @@ def build_today_plan_training_decision(
             reason = "styrke fravalgt · cardio vælges"
             autoplan_meta = {
                 "template_mode": cardio_plan.get("template_mode") if isinstance(cardio_plan, dict) else None,
-                "families_selected": []
+                "families_selected": [],
+                "local_protection_override": bool(cardio_plan.get("local_protection_override")) if isinstance(cardio_plan, dict) else False,
+                "protected_regions": cardio_plan.get("protected_regions", []) if isinstance(cardio_plan, dict) else [],
             }
         else:
             session_type = "restitution"
@@ -4569,7 +4582,9 @@ def build_today_plan_training_decision(
             reason = "styrke fravalgt · cardio vælges"
             autoplan_meta = {
                 "template_mode": cardio_plan.get("template_mode") if isinstance(cardio_plan, dict) else None,
-                "families_selected": []
+                "families_selected": [],
+                "local_protection_override": bool(cardio_plan.get("local_protection_override")) if isinstance(cardio_plan, dict) else False,
+                "protected_regions": cardio_plan.get("protected_regions", []) if isinstance(cardio_plan, dict) else [],
             }
         else:
             session_type = "restitution"

--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -3288,15 +3288,28 @@ def build_strength_plan(programs, exercises, latest_strength, time_budget_min, f
             "reason": "missing_program_template"
         }
 
-    latest_day = normalize_program_day_label(latest_strength.get("program_day_label", "") if latest_strength else "")
-    next_day_key = "day_a"
-    if latest_day == "day_a":
-        next_day_key = "day_b"
-    elif latest_day == "day_b":
-        next_day_key = "day_a"
+    current_program_id = str(program.get("id", "")).strip()
+    latest_program_id = str(latest_strength.get("program_id", "") if latest_strength else "").strip()
+    latest_day = ""
+    if latest_program_id and current_program_id and latest_program_id == current_program_id:
+        latest_day = normalize_program_day_label(latest_strength.get("program_day_label", "") if latest_strength else "")
+
+    program_days = [
+        day for day in program.get("days", [])
+        if isinstance(day, dict) and str(day.get("label", "")).strip()
+    ]
+    normalized_program_days = [
+        normalize_program_day_label(day.get("label"))
+        for day in program_days
+    ]
+
+    next_day_key = normalized_program_days[0] if normalized_program_days else "day_a"
+    if latest_day and latest_day in normalized_program_days:
+        latest_idx = normalized_program_days.index(latest_day)
+        next_day_key = normalized_program_days[(latest_idx + 1) % len(normalized_program_days)]
 
     selected_day = None
-    for day in program.get("days", []):
+    for day in program_days:
         if normalize_program_day_label(day.get("label")) == next_day_key:
             selected_day = day
             break

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2126,8 +2126,10 @@ function renderForecastHero(planItem, latestCheckin){
   }
 
   const reasonParts = [bits.join(" · "), formatPlanReason(planItem.reason || "")].filter(Boolean);
+  const localProtectionExplanation = String(planItem?.local_protection_explanation || "").trim();
     const forecastReasonText = [
       reasonParts.join(" · "),
+      localProtectionExplanation ? `${tr("today_plan.local_protection_label")}: ${localProtectionExplanation}` : "",
       nextGuidanceMessage
     ].filter(Boolean).join("\n");
 
@@ -7181,6 +7183,7 @@ function buildTodayPlanHeroCardHtml({
   variantLabel,
   timeBudgetMin,
   planContextBits,
+  localProtectionExplanation,
 }){
   const metaBits = [
     !isPlannedRestDay ? (variantLabel || "") : "",
@@ -7189,6 +7192,7 @@ function buildTodayPlanHeroCardHtml({
 
   const recoveryBit = planContextBits[0] || "";
   const secondaryBits = planContextBits.slice(1);
+  const localProtectionText = String(localProtectionExplanation || "").trim();
 
   return `
     <li>
@@ -7201,6 +7205,7 @@ function buildTodayPlanHeroCardHtml({
       ${heroLead ? `<div class="small today-plan-hero-lead">${esc(heroLead)}</div>` : ""}
       ${recoveryBit ? `<div class="small today-plan-hero-context">${esc(recoveryBit)}</div>` : ""}
       ${secondaryBits.map(bit => `<div class="small today-plan-hero-context">${esc(bit)}</div>`).join("")}
+      ${localProtectionText ? `<div class="small today-plan-hero-context" style="margin-top:10px; padding:10px 12px; border-radius:12px; background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08)"><strong>${esc(tr("today_plan.local_protection_label"))}:</strong> ${esc(localProtectionText)}</div>` : ""}
       ${heroActions}
     </li>
   `;
@@ -7388,6 +7393,7 @@ function renderTodayPlan(item){
       variantLabel,
       timeBudgetMin: item.time_budget_min,
       planContextBits,
+      localProtectionExplanation: item?.local_protection_explanation || "",
     });
 
     const recoveryCard = "";

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -471,6 +471,7 @@
   "today_plan.no_plan_yet_after_checkin": "Ingen plan endnu. Første plan bliver genereret efter dit check-in.",
   "today_plan.no_plan_yet_help": "Du har ingen plan endnu. Lav et check-in, så opretter systemet dit første datapunkt og dagens træning.",
   "today_plan.no_plan_yet_short": "Ingen plan endnu.",
+  "today_plan.local_protection_label": "Lokal beskyttelse",
   "today_plan.recovery_label": "Recovery: {value}",
   "today_plan.rest_day_title": "Planlagt hviledag",
   "today_plan.rest_day_planned_today": "Planlagt hviledag i dag.",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -458,6 +458,7 @@
   "today_plan.no_plan_yet_after_checkin": "No plan yet. The first plan will be generated after your check-in.",
   "today_plan.no_plan_yet_help": "You have no plan yet. Do a check-in to create your first data point and today's training.",
   "today_plan.no_plan_yet_short": "No plan yet.",
+  "today_plan.local_protection_label": "Local protection",
   "today_plan.recovery_label": "Recovery: {value}",
   "today_plan.rest_day_title": "Planned rest day",
   "today_plan.rest_day_planned_today": "Planned rest day today.",


### PR DESCRIPTION
## Summary
Expose clear local protection explanations in the user-facing daily plan flow, including cardio autoplan cases.

## Problem
The backend already produced a `local_protection_explanation` in some cases, but the UI did not surface it clearly. In addition, cardio autoplan paths dropped the local protection context before it reached the explanation layer, so users could get a softened cardio recommendation without any explicit explanation.

## What changed

### Frontend
- forecast now shows a dedicated local protection line when present
- the daily plan hero now shows a visible "Local protection" explanation block
- added i18n labels for the new UI text in Danish and English

### Backend
- cardio selection now returns `protected_regions`
- cardio autoplan now carries:
  - `local_protection_override`
  - `protected_regions`
- today-plan cardio decision paths now preserve that metadata in `autoplan_meta`
- this allows `build_local_protection_explanation(...)` to work for cardio cases as well

## Result
Users can now see when local protection shaped the plan, including cases where:
- a run is softened
- cardio is chosen more conservatively
- local irritation signals are influencing the plan

## Validation
- `node --check app/frontend/app.js`
- `python3 -m py_compile app/backend/app.py`
- backend restarted successfully
- health check returned OK
- verified live for user 5 with active knee protection:
  - forecast showed local protection explanation
  - daily plan showed a local protection explanation block
  - explanation referenced the knee irritation signal