### PR TITLE
Add manual local protection hold controls

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -3083,6 +3083,31 @@ function mountEquipmentEditorInline(){
 }
 
 
+const LOCAL_PROTECTION_HOLD_REGIONS = ["ankle_calf", "knee", "hip", "low_back", "shoulder", "elbow", "wrist"];
+
+function readLocalProtectionHoldsFromForm(){
+  const out = {};
+  LOCAL_PROTECTION_HOLD_REGIONS.forEach(region => {
+    const value = String(document.getElementById(`local_hold_${region}`)?.value || "").trim();
+    if (value === "caution" || value === "protect"){
+      out[region] = value;
+    }
+  });
+  return out;
+}
+
+function populateLocalProtectionHolds(settings){
+  const holds = settings && settings.local_protection_holds && typeof settings.local_protection_holds === "object"
+    ? settings.local_protection_holds
+    : {};
+  LOCAL_PROTECTION_HOLD_REGIONS.forEach(region => {
+    const el = document.getElementById(`local_hold_${region}`);
+    if (!el) return;
+    const value = String(holds[region] || "").trim();
+    el.value = value === "caution" || value === "protect" ? value : "";
+  });
+}
+
 function getInitialSetupSettingsSnapshot(){
   const settings = STATE.userSettings && typeof STATE.userSettings === "object" ? STATE.userSettings : {};
   const profile = settings.profile && typeof settings.profile === "object" ? { ...settings.profile } : {};
@@ -3092,6 +3117,10 @@ function getInitialSetupSettingsSnapshot(){
     : {};
   const equipmentIncrements = settings.equipment_increments && typeof settings.equipment_increments === "object"
     ? { ...settings.equipment_increments }
+    : {};
+
+  const localProtectionHolds = settings.local_protection_holds && typeof settings.local_protection_holds === "object"
+    ? { ...settings.local_protection_holds }
     : {};
 
   return {
@@ -3106,7 +3135,8 @@ function getInitialSetupSettingsSnapshot(){
         : {}
     },
     available_equipment: availableEquipment,
-    equipment_increments: equipmentIncrements
+    equipment_increments: equipmentIncrements,
+    local_protection_holds: localProtectionHolds
   };
 }
 
@@ -3239,6 +3269,7 @@ function populateEquipmentEditor(){
 
   setVal("eq_barbell_increment", increments.barbell ?? 10);
   setVal("eq_dumbbell_increment", increments.dumbbell ?? 5);
+  populateLocalProtectionHolds(settings);
 }
 
 function renderFirstRunSetupEditorState(){
@@ -3427,7 +3458,8 @@ async function handleEquipmentSettingsSubmit(ev){
       barbell: readNum("eq_barbell_increment", 10),
       dumbbell: readNum("eq_dumbbell_increment", 5),
       bodyweight: 0,
-    }
+    },
+    local_protection_holds: readLocalProtectionHoldsFromForm()
   };
 
   try{

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -926,5 +926,17 @@
   "history.weekly_rhythm_next_label": "Næste sandsynlige pas",
   "history.weekly_rhythm_none_completed": "Ingen gennemførte pas endnu i denne uge",
   "history.weekly_rhythm_no_completed_types": "Ingen endnu",
-  "review.next_likely_session_label": "Mest sandsynligt næste træning"
+  "review.next_likely_session_label": "Mest sandsynligt næste træning",
+  "profile.local_protection_holds_title": "Lokal beskyttelse",
+  "profile.local_protection_holds_help": "Hold et område i forsigtig eller beskyttet tilstand, hvis det stadig skal skånes på tværs af flere planlægningsdage.",
+  "local_protection.hold.none": "Ingen manuel hold",
+  "local_protection.hold.caution": "Forsigtig",
+  "local_protection.hold.protect": "Beskyt",
+  "local_protection.region.ankle_calf": "Ankel/læg",
+  "local_protection.region.knee": "Knæ",
+  "local_protection.region.hip": "Hofte",
+  "local_protection.region.low_back": "Lænd",
+  "local_protection.region.shoulder": "Skulder",
+  "local_protection.region.elbow": "Albue",
+  "local_protection.region.wrist": "Håndled"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -910,5 +910,17 @@
   "history.weekly_rhythm_next_label": "Next likely session",
   "history.weekly_rhythm_none_completed": "No completed sessions yet this week",
   "history.weekly_rhythm_no_completed_types": "None yet",
-  "review.next_likely_session_label": "Most likely next session"
+  "review.next_likely_session_label": "Most likely next session",
+  "profile.local_protection_holds_title": "Local protection",
+  "profile.local_protection_holds_help": "Keep a region in caution or protect state if it should still be protected across multiple planning days.",
+  "local_protection.hold.none": "No manual hold",
+  "local_protection.hold.caution": "Caution",
+  "local_protection.hold.protect": "Protect",
+  "local_protection.region.ankle_calf": "Ankle/calf",
+  "local_protection.region.knee": "Knee",
+  "local_protection.region.hip": "Hip",
+  "local_protection.region.low_back": "Low back",
+  "local_protection.region.shoulder": "Shoulder",
+  "local_protection.region.elbow": "Elbow",
+  "local_protection.region.wrist": "Wrist"
 }

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -608,6 +608,68 @@
             </label>
             </div>
 
+            <div style="margin:18px 0 6px; font-weight:700" data-i18n="profile.local_protection_holds_title">Lokal beskyttelse</div>
+            <div class="small" style="margin-bottom:10px" data-i18n="profile.local_protection_holds_help">Hold et område i forsigtig eller beskyttet tilstand, hvis det stadig skal skånes på tværs af flere planlægningsdage.</div>
+
+            <div style="display:grid; grid-template-columns:1fr; gap:10px; margin-bottom:16px">
+              <label>
+                <span data-i18n="local_protection.region.ankle_calf">Ankel/læg</span>
+                <select id="local_hold_ankle_calf" name="local_hold_ankle_calf">
+                  <option value="" data-i18n="local_protection.hold.none">Ingen manuel hold</option>
+                  <option value="caution" data-i18n="local_protection.hold.caution">Forsigtig</option>
+                  <option value="protect" data-i18n="local_protection.hold.protect">Beskyt</option>
+                </select>
+              </label>
+              <label>
+                <span data-i18n="local_protection.region.knee">Knæ</span>
+                <select id="local_hold_knee" name="local_hold_knee">
+                  <option value="" data-i18n="local_protection.hold.none">Ingen manuel hold</option>
+                  <option value="caution" data-i18n="local_protection.hold.caution">Forsigtig</option>
+                  <option value="protect" data-i18n="local_protection.hold.protect">Beskyt</option>
+                </select>
+              </label>
+              <label>
+                <span data-i18n="local_protection.region.hip">Hofte</span>
+                <select id="local_hold_hip" name="local_hold_hip">
+                  <option value="" data-i18n="local_protection.hold.none">Ingen manuel hold</option>
+                  <option value="caution" data-i18n="local_protection.hold.caution">Forsigtig</option>
+                  <option value="protect" data-i18n="local_protection.hold.protect">Beskyt</option>
+                </select>
+              </label>
+              <label>
+                <span data-i18n="local_protection.region.low_back">Lænd</span>
+                <select id="local_hold_low_back" name="local_hold_low_back">
+                  <option value="" data-i18n="local_protection.hold.none">Ingen manuel hold</option>
+                  <option value="caution" data-i18n="local_protection.hold.caution">Forsigtig</option>
+                  <option value="protect" data-i18n="local_protection.hold.protect">Beskyt</option>
+                </select>
+              </label>
+              <label>
+                <span data-i18n="local_protection.region.shoulder">Skulder</span>
+                <select id="local_hold_shoulder" name="local_hold_shoulder">
+                  <option value="" data-i18n="local_protection.hold.none">Ingen manuel hold</option>
+                  <option value="caution" data-i18n="local_protection.hold.caution">Forsigtig</option>
+                  <option value="protect" data-i18n="local_protection.hold.protect">Beskyt</option>
+                </select>
+              </label>
+              <label>
+                <span data-i18n="local_protection.region.elbow">Albue</span>
+                <select id="local_hold_elbow" name="local_hold_elbow">
+                  <option value="" data-i18n="local_protection.hold.none">Ingen manuel hold</option>
+                  <option value="caution" data-i18n="local_protection.hold.caution">Forsigtig</option>
+                  <option value="protect" data-i18n="local_protection.hold.protect">Beskyt</option>
+                </select>
+              </label>
+              <label>
+                <span data-i18n="local_protection.region.wrist">Håndled</span>
+                <select id="local_hold_wrist" name="local_hold_wrist">
+                  <option value="" data-i18n="local_protection.hold.none">Ingen manuel hold</option>
+                  <option value="caution" data-i18n="local_protection.hold.caution">Forsigtig</option>
+                  <option value="protect" data-i18n="local_protection.hold.protect">Beskyt</option>
+                </select>
+              </label>
+            </div>
+
             <div class="first-run-setup-section" data-first-run-step="equipment">
               <h4 style="margin:0 0 10px" data-i18n="onboarding.first_run.section.equipment_title">Equipment</h4>
               <p class="small" style="margin:0 0 12px" data-i18n="onboarding.first_run.section.equipment_body">Tell the app what you actually have available, plus the load increments it should use.</p>

--- a/tests/test_manual_local_protection_ui_contract.py
+++ b/tests/test_manual_local_protection_ui_contract.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+import json
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REGIONS = [
+    "ankle_calf",
+    "knee",
+    "hip",
+    "low_back",
+    "shoulder",
+    "elbow",
+    "wrist",
+]
+
+
+def test_manual_local_protection_controls_exist_once():
+    html = (ROOT / "app/frontend/index.html").read_text()
+
+    assert "profile.local_protection_holds_title" in html
+    assert "profile.local_protection_holds_help" in html
+
+    for region in REGIONS:
+        assert html.count(f'id="local_hold_{region}"') == 1
+        assert html.count(f'name="local_hold_{region}"') == 1
+
+    assert "name=local_hold_" not in html
+    assert "lo\ncal_protection" not in html
+
+
+def test_manual_local_protection_settings_payload_contract():
+    js = (ROOT / "app/frontend/app.js").read_text()
+
+    assert "LOCAL_PROTECTION_HOLD_REGIONS" in js
+    assert "function readLocalProtectionHoldsFromForm()" in js
+    assert "function populateLocalProtectionHolds(settings)" in js
+    assert "local_protection_holds: readLocalProtectionHoldsFromForm()" in js
+    assert "populateLocalProtectionHolds(settings);" in js
+
+
+def test_manual_local_protection_i18n_keys_exist():
+    required_keys = {
+        "profile.local_protection_holds_title",
+        "profile.local_protection_holds_help",
+        "local_protection.hold.none",
+        "local_protection.hold.caution",
+        "local_protection.hold.protect",
+        "local_protection.region.ankle_calf",
+        "local_protection.region.knee",
+        "local_protection.region.hip",
+        "local_protection.region.low_back",
+        "local_protection.region.shoulder",
+        "local_protection.region.elbow",
+        "local_protection.region.wrist",
+    }
+
+    for lang in ("da", "en"):
+        data = json.loads((ROOT / f"app/frontend/i18n/{lang}.json").read_text())
+        missing = sorted(required_keys - set(data))
+        assert not missing, (lang, missing)


### PR DESCRIPTION
## Summary
Adds frontend controls for manual local protection holds in the existing profile/equipment settings flow.

## Problem
Backend already supports `local_protection_holds`, and local state already applies manual holds as a protection floor. However, users had no clear UI for setting, downgrading, or clearing those holds.

## What changed
- Added local protection hold controls for:
  - ankle/calf
  - knee
  - hip
  - low back
  - shoulder
  - elbow
  - wrist
- Each region can be set to:
  - no manual hold
  - caution
  - protect
- Added form population from existing `STATE.userSettings.local_protection_holds`
- Added save payload support for `local_protection_holds`
- Added Danish and English i18n labels
- Added static UI contract coverage for controls, payload wiring, and i18n keys

## Why
Manual holds should survive across planning cycles and be manageable by the user, instead of only existing as backend state. This makes local protection reviewable and reversible.

## Validation
- `python3 -m py_compile tests/test_manual_local_protection_ui_contract.py`
- `python3 tests/test_manual_local_protection_ui_contract.py`
- `node --check app/frontend/app.js`
- `python3 -m json.tool app/frontend/i18n/da.json`
- `python3 -m json.tool app/frontend/i18n/en.json`
- `git diff --check`

## Scope
- frontend settings UI
- i18n
- static UI contract test
- no backend runtime changes