### PR TITLE
Refine load-based easier/harder adjustments

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -5317,6 +5317,23 @@ function getAdjacentNumericOption(options, currentValue, direction){
   return null;
 }
 
+function getLoadFirstSetsAfterLoadStep(currentSets, setBounds, direction){
+  const bounds = setBounds && typeof setBounds === "object" ? setBounds : {};
+  const minSets = Math.max(1, Number(bounds.min || 1) || 1);
+  const maxSets = Math.max(minSets, Number(bounds.max || currentSets || minSets) || minSets);
+  const sets = Math.max(minSets, Math.min(maxSets, Number(currentSets || minSets) || minSets));
+
+  if (direction === "harder"){
+    return Math.max(minSets, sets - 1);
+  }
+
+  if (direction === "easier"){
+    return Math.min(maxSets, sets + 1);
+  }
+
+  return sets;
+}
+
 function shiftTargetPatternOneStep(target, entry, direction){
   const parsed = parseTargetPattern(target);
   if (!parsed) return "";
@@ -5535,13 +5552,19 @@ async function adjustPlanEntryAtIndex(item, idx, direction){
     if (nextLoad === currentLoad) return false;
 
     entry.target_load = formatKgLabel(nextLoad);
-    entry.sets = dir === "harder" ? setBounds.min : setBounds.max;
+    if (isLoadFirstProgressionExercise(entry)){
+      entry.sets = getLoadFirstSetsAfterLoadStep(currentSets, setBounds, dir);
+    } else {
+      entry.sets = dir === "harder" ? setBounds.min : setBounds.max;
+    }
 
     if (currentTarget){
       entry.target_reps = buildBoundaryTargetFromCurrentShape(entry, dir === "harder" ? "min" : "max");
     }
 
-    entry.manual_adjustment_reason = dir === "harder" ? "load_step_up_and_reset" : "load_step_down_and_reset";
+    entry.manual_adjustment_reason = isLoadFirstProgressionExercise(entry)
+      ? (dir === "harder" ? "load_step_up_and_modest_reset" : "load_step_down_and_modest_reset")
+      : (dir === "harder" ? "load_step_up_and_reset" : "load_step_down_and_reset");
     return true;
   };
 

--- a/tests/test_load_based_local_adjustment_contract.py
+++ b/tests/test_load_based_local_adjustment_contract.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app/frontend/app.js"
+
+
+def test_load_first_exercises_are_declared():
+    js = APP_JS.read_text()
+
+    assert "function isLoadFirstProgressionExercise(entry)" in js
+
+    for exercise_id in [
+        "squat",
+        "bench_press",
+        "overhead_press",
+        "barbell_row",
+        "romanian_deadlift",
+        "dumbbell_row",
+    ]:
+        assert f'"{exercise_id}"' in js
+
+
+def test_load_first_load_bounds_do_not_use_load_options_as_hard_max():
+    js = APP_JS.read_text()
+
+    assert "if (isLoadFirstProgressionExercise(entry))" in js
+    assert "max: fallback.max" in js
+
+
+def test_load_step_for_load_first_lifts_does_not_reset_harder_to_min_sets():
+    js = APP_JS.read_text()
+
+    assert 'manual_adjustment_reason = dir === "harder" ? "load_step_up_and_reset" : "load_step_down_and_reset"' not in js
+    assert "getLoadFirstSetsAfterLoadStep" in js
+    assert "load_step_up_and_modest_reset" in js
+
+
+if __name__ == "__main__":
+    test_load_first_exercises_are_declared()
+    test_load_first_load_bounds_do_not_use_load_options_as_hard_max()
+    test_load_step_for_load_first_lifts_does_not_reset_harder_to_min_sets()
+    print("Load-based local adjustment contract tests passed")


### PR DESCRIPTION
## Summary
Refines local easier/harder adjustment behavior for load-based lifts.

## Problem
Load-based lifts such as squat, bench press, overhead press, barbell row, Romanian deadlift, and dumbbell row should not behave like generic bodyweight/time exercises.

The previous load-step behavior reset sets too aggressively after load changes, which could produce unrealistic jumps such as:

- 50 kg · 5 sets · 6-8
- 60 kg · 1 set · 4-6

That is deterministic, but poor UX for major lifts.

## What changed
- Added `getLoadFirstSetsAfterLoadStep(...)`
- Load-first exercises now reduce or increase sets modestly by one step after a load change
- Non-load-first exercises keep the existing reset behavior
- Manual adjustment reasons now distinguish modest load-first reset from generic reset:
  - `load_step_up_and_modest_reset`
  - `load_step_down_and_modest_reset`

## Why
Major load-based lifts should feel like realistic local training adjustments instead of mechanical state-machine cycling.

## Validation
- `node --check app/frontend/app.js`
- `python3 tests/test_load_based_local_adjustment_contract.py`
- `python3 tests/test_today_plan_contract.py`
- `python3 tests/test_today_plan_explanation_contract.py`
- `python3 tests/test_manual_local_protection_ui_contract.py`
- `git diff --check`

## Scope
- frontend local adjustment logic
- deterministic contract test
- no backend changes
- bodyweight/time adjustment behavior intentionally unchanged