### PR TITLE
Fix local adjustment exercise identity rendering

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -7274,20 +7274,25 @@ def get_progression_ladder_for_exercise(exercise_id, exercise_map):
     if not exercise_id:
         return []
 
+    def clean_ladder(raw_ladder):
+        cleaned = []
+        seen = set()
+        for value in raw_ladder if isinstance(raw_ladder, list) else []:
+            item_id = str(value or "").strip()
+            if item_id and item_id in exercise_map and item_id not in seen:
+                seen.add(item_id)
+                cleaned.append(item_id)
+        return cleaned
+
     own_meta = exercise_map.get(exercise_id, {}) or {}
-    own_ladder = own_meta.get("progression_ladder", [])
-    if isinstance(own_ladder, list):
-        normalized = [str(x).strip() for x in own_ladder if str(x).strip()]
-        if exercise_id in normalized:
-            return normalized
+    own_ladder = clean_ladder(own_meta.get("progression_ladder", []))
+    if exercise_id in own_ladder:
+        return own_ladder
 
     for _, item in exercise_map.items():
         if not isinstance(item, dict):
             continue
-        ladder = item.get("progression_ladder", [])
-        if not isinstance(ladder, list):
-            continue
-        normalized = [str(x).strip() for x in ladder if str(x).strip()]
+        normalized = clean_ladder(item.get("progression_ladder", []))
         if exercise_id in normalized:
             return normalized
 

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -3737,7 +3737,13 @@ function formatExerciseCategory(value){
   return map[x] || x;
 }
 
+function formatUnknownExerciseName(exerciseId){
+  const id = String(exerciseId || "").trim();
+  return id ? `${tr("common.unknown_lower")}: ${id}` : tr("common.unknown_lower");
+}
+
 function formatExerciseName(exerciseId){
+  const id = String(exerciseId || "").trim();
   const mapped = {
     restitution_walk: tr("exercise.recovery_walk"),
     mobility: tr("session_type.mobility"),
@@ -3746,10 +3752,10 @@ function formatExerciseName(exerciseId){
     cardio_session: tr("session_type.cardio"),
     cardio_base: tr("exercise.cardio_base")
   };
-  if (mapped[exerciseId]) return mapped[exerciseId];
+  if (mapped[id]) return mapped[id];
 
-  const exerciseMap = new Map((STATE.exercises || []).map(x => [x.id, x.name]));
-  return exerciseMap.get(exerciseId) || tr("exercise.planned_session");
+  const exerciseMap = new Map((STATE.exercises || []).map(x => [String(x.id || "").trim(), x.name]));
+  return exerciseMap.get(id) || formatUnknownExerciseName(id);
 }
 
 function formatInputKindLabel(value){
@@ -5007,18 +5013,26 @@ function getProgressionLadderForExercise(exerciseId){
   const id = String(exerciseId || "").trim().toLowerCase();
   if (!id) return [];
 
+  const allExercises = Array.isArray(STATE.exercises) ? STATE.exercises : [];
+  const existingIds = new Set(allExercises.map(item => String(item?.id || "").trim().toLowerCase()).filter(Boolean));
+  const cleanLadder = (ladder) => {
+    return (Array.isArray(ladder) ? ladder : [])
+      .map(x => String(x || "").trim())
+      .filter(Boolean)
+      .filter(candidateId => existingIds.has(candidateId.toLowerCase()));
+  };
+
   const ownMeta = getExerciseMeta(id) || {};
-  const ownLadder = Array.isArray(ownMeta.progression_ladder) ? ownMeta.progression_ladder : [];
-  if (ownLadder.map(x => String(x || "").trim().toLowerCase()).includes(id)){
-    return ownLadder.map(x => String(x || "").trim()).filter(Boolean);
+  const ownLadder = cleanLadder(ownMeta.progression_ladder);
+  if (ownLadder.map(x => x.toLowerCase()).includes(id)){
+    return ownLadder;
   }
 
-  const allExercises = Array.isArray(STATE.exercises) ? STATE.exercises : [];
   for (const item of allExercises){
-    const ladder = Array.isArray(item?.progression_ladder) ? item.progression_ladder : [];
-    const normalized = ladder.map(x => String(x || "").trim().toLowerCase()).filter(Boolean);
+    const ladder = cleanLadder(item?.progression_ladder);
+    const normalized = ladder.map(x => x.toLowerCase());
     if (normalized.includes(id)){
-      return ladder.map(x => String(x || "").trim()).filter(Boolean);
+      return ladder;
     }
   }
 

--- a/tests/test_exercise_identity_rendering_contract.py
+++ b/tests/test_exercise_identity_rendering_contract.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app/frontend/app.js"
+BACKEND_APP = ROOT / "app/backend/app.py"
+
+
+def test_exercise_name_fallback_does_not_use_planned_session():
+    js = APP_JS.read_text()
+
+    assert 'return exerciseMap.get(exerciseId) || tr("exercise.planned_session");' not in js
+    assert "function formatUnknownExerciseName" in js
+
+
+def test_frontend_variant_swap_filters_missing_ladder_ids():
+    js = APP_JS.read_text()
+
+    assert "function getExerciseVariantSwap(exerciseId, direction)" in js
+    assert "const existingIds = new Set(allExercises.map" in js
+    assert "existingIds.has(candidateId.toLowerCase())" in js
+
+
+def test_backend_variant_swap_filters_missing_ladder_ids():
+    py = BACKEND_APP.read_text()
+
+    assert "def get_progression_ladder_for_exercise(exercise_id, exercise_map):" in py
+    assert "if item_id and item_id in exercise_map" in py
+
+
+if __name__ == "__main__":
+    test_exercise_name_fallback_does_not_use_planned_session()
+    test_frontend_variant_swap_filters_missing_ladder_ids()
+    test_backend_variant_swap_filters_missing_ladder_ids()
+    print("Exercise identity rendering contract tests passed")


### PR DESCRIPTION
## Summary
Fixes local adjustment variant rendering so invalid or missing exercise IDs do not render as generic “Planned session” cards.

## Problem
Repeated local easier/harder adjustments could follow progression ladder IDs that were not present in the active exercise catalog. When that happened, frontend rendering fell back to `exercise.planned_session`, making an invalid exercise look like a normal planned entry.

## What changed
- Frontend `formatExerciseName(...)` no longer falls back to `exercise.planned_session`
- Unknown exercise IDs now render diagnostically via `formatUnknownExerciseName(...)`
- Frontend progression ladders are filtered against actual `STATE.exercises`
- Backend progression ladders are filtered against actual `exercise_map`
- Added contract coverage for exercise identity rendering and ladder filtering

## Why
Local adjustment must never create or render a fake exercise identity. If a variant cannot resolve to a valid catalog exercise, it should not appear as a normal exercise card.

## Validation
- `node --check app/frontend/app.js`
- `python3 -m py_compile app/backend/app.py`
- `python3 tests/test_exercise_identity_rendering_contract.py`
- `python3 tests/test_load_based_local_adjustment_contract.py`
- `python3 tests/test_today_plan_contract.py`
- `python3 tests/test_today_plan_explanation_contract.py`
- `python3 tests/test_local_protection_scenarios.py`
- `git diff --check`

## Scope
- frontend exercise name rendering
- frontend progression ladder filtering
- backend progression ladder filtering
- no catalog expansion in this issue