### PR TITLE
Clarify local easier/harder adjustment scope

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -7155,6 +7155,7 @@ function buildTodayPlanEntryCardsHtml(item, isPlannedRestDay){
           ${entry.target_reps ? `${!(String(entry.exercise_id || "").trim().toLowerCase().startsWith("cardio_") || String(entry.exercise_id || "").trim().toLowerCase() === "cardio_session") && entry.sets ? " · " : ""}${tr("exercise.target_label", { value: formatTarget(entry.target_reps) })}` : ""}
         </div>
         ${extras.map(x => `<div class="small" style="margin-top:6px">${esc(x)}</div>`).join("")}
+        <div class="small" style="margin-top:8px; opacity:0.78">${esc(tr("today_plan.local_adjustment_scope_help"))}</div>
         <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">
           <button type="button" class="secondary" data-exercise-viewer="${esc(entry.exercise_id || "")}" style="width:auto;padding:8px 12px">${esc(tr("button.view_exercise"))}</button>
           <button type="button" class="secondary" data-plan-entry-easier="${esc(String(index))}" style="width:auto;padding:8px 12px">${esc(tr("button.make_easier"))}</button>

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -938,5 +938,6 @@
   "local_protection.region.low_back": "Lænd",
   "local_protection.region.shoulder": "Skulder",
   "local_protection.region.elbow": "Albue",
-  "local_protection.region.wrist": "Håndled"
+  "local_protection.region.wrist": "Håndled",
+  "today_plan.local_adjustment_scope_help": "Justerer kun denne øvelse i dag. Programskift og loaded alternativer håndteres via programanbefalinger."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -922,5 +922,6 @@
   "local_protection.region.low_back": "Low back",
   "local_protection.region.shoulder": "Shoulder",
   "local_protection.region.elbow": "Elbow",
-  "local_protection.region.wrist": "Wrist"
+  "local_protection.region.wrist": "Wrist",
+  "today_plan.local_adjustment_scope_help": "Adjusts only this exercise today. Program switches and loaded alternatives are handled through program recommendations."
 }

--- a/tests/test_local_adjustment_scope_help_contract.py
+++ b/tests/test_local_adjustment_scope_help_contract.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app/frontend/app.js"
+DA = ROOT / "app/frontend/i18n/da.json"
+EN = ROOT / "app/frontend/i18n/en.json"
+
+
+def test_today_plan_entry_cards_explain_local_adjustment_scope():
+    js = APP_JS.read_text()
+
+    assert 'tr("today_plan.local_adjustment_scope_help")' in js
+    assert 'data-plan-entry-easier' in js
+    assert 'data-plan-entry-harder' in js
+
+
+def test_local_adjustment_scope_help_is_translated():
+    da = DA.read_text()
+    en = EN.read_text()
+
+    assert '"today_plan.local_adjustment_scope_help"' in da
+    assert '"today_plan.local_adjustment_scope_help"' in en
+    assert "Justerer kun denne øvelse i dag" in da
+    assert "Adjusts only this exercise today" in en
+
+
+if __name__ == "__main__":
+    test_today_plan_entry_cards_explain_local_adjustment_scope()
+    test_local_adjustment_scope_help_is_translated()
+    print("Local adjustment scope help contract tests passed")


### PR DESCRIPTION
## Summary
Clarifies what local `Make easier` / `Make harder` means in the today-plan UI.

## Problem
For bodyweight push variants, `Make harder` can feel ambiguous. Users may expect it to move toward a loaded program exercise such as bench press, while the current behavior is local exercise adjustment within the current entry.

## What changed
- Added a short help text under today-plan entry actions
- Clarifies that easier/harder adjusts only the current exercise for today
- Clarifies that program switches and loaded alternatives are handled through program recommendations
- Added contract coverage for the help text and translations

## Why
This avoids overloading local adjustment with program-level meaning while making current behavior more understandable.

## Validation
- `node --check app/frontend/app.js`
- `python3 -m json.tool app/frontend/i18n/da.json`
- `python3 -m json.tool app/frontend/i18n/en.json`
- `python3 tests/test_local_adjustment_scope_help_contract.py`
- `python3 tests/test_today_plan_contract.py`
- `python3 tests/test_today_plan_explanation_contract.py`
- `python3 tests/test_load_based_local_adjustment_contract.py`
- `git diff --check`

## Scope
- frontend copy only
- i18n keys
- no engine behavior change
- no backend change