### PR TITLE
Title: Clean up today-plan adjustment code after final easier/harder refinements

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -5444,10 +5444,13 @@ async function applyVariantSwap(entry, direction){
     const resolved = await resolveLocalAdjustmentVariant(entry, direction);
     if (resolved?.changed && resolved?.exercise_id){
       const nextExerciseId = String(resolved.exercise_id || "").trim();
+
       entry.substituted_from = resolved.substituted_from || currentExerciseId;
       entry.exercise_id = nextExerciseId;
       entry.local_regression_reason = resolved.reason || "";
-      entry.manual_adjustment_reason = direction === "harder" ? "variant_step_up_backend" : "variant_step_down_backend";
+      entry.manual_adjustment_reason = direction === "harder"
+        ? "variant_step_up_backend"
+        : "variant_step_down_backend";
 
       const setBounds = getEntrySetBounds(entry);
       entry.sets = direction === "harder" ? setBounds.min : setBounds.max;
@@ -5455,9 +5458,20 @@ async function applyVariantSwap(entry, direction){
       const meta = getExerciseMeta(nextExerciseId) || {};
       const inputKind = String(meta.input_kind || "").trim().toLowerCase();
       if (entry.target_reps){
-        entry.target_reps = buildBoundaryTargetFromCurrentShape(entry, direction === "harder" ? "min" : "max");
-      } else if (inputKind === "time" || inputKind === "cardio_time" || inputKind === "bodyweight_reps" || inputKind === "load_reps"){
-        entry.target_reps = buildBoundaryTargetFromCurrentShape(entry, direction === "harder" ? "min" : "max");
+        entry.target_reps = buildBoundaryTargetFromCurrentShape(
+          entry,
+          direction === "harder" ? "min" : "max"
+        );
+      } else if (
+        inputKind === "time" ||
+        inputKind === "cardio_time" ||
+        inputKind === "bodyweight_reps" ||
+        inputKind === "load_reps"
+      ){
+        entry.target_reps = buildBoundaryTargetFromCurrentShape(
+          entry,
+          direction === "harder" ? "min" : "max"
+        );
       }
 
       if (meta.supports_load !== true){
@@ -5474,7 +5488,9 @@ async function applyVariantSwap(entry, direction){
 
   entry.substituted_from = currentExerciseId;
   entry.exercise_id = nextExerciseId;
-  entry.manual_adjustment_reason = direction === "harder" ? "variant_step_up_frontend_fallback" : "variant_step_down_frontend_fallback";
+  entry.manual_adjustment_reason = direction === "harder"
+    ? "variant_step_up_frontend_fallback"
+    : "variant_step_down_frontend_fallback";
 
   const setBounds = getEntrySetBounds(entry);
   entry.sets = direction === "harder" ? setBounds.min : setBounds.max;
@@ -5482,9 +5498,20 @@ async function applyVariantSwap(entry, direction){
   const meta = getExerciseMeta(nextExerciseId) || {};
   const inputKind = String(meta.input_kind || "").trim().toLowerCase();
   if (entry.target_reps){
-    entry.target_reps = buildBoundaryTargetFromCurrentShape(entry, direction === "harder" ? "min" : "max");
-  } else if (inputKind === "time" || inputKind === "cardio_time" || inputKind === "bodyweight_reps" || inputKind === "load_reps"){
-    entry.target_reps = buildBoundaryTargetFromCurrentShape(entry, direction === "harder" ? "min" : "max");
+    entry.target_reps = buildBoundaryTargetFromCurrentShape(
+      entry,
+      direction === "harder" ? "min" : "max"
+    );
+  } else if (
+    inputKind === "time" ||
+    inputKind === "cardio_time" ||
+    inputKind === "bodyweight_reps" ||
+    inputKind === "load_reps"
+  ){
+    entry.target_reps = buildBoundaryTargetFromCurrentShape(
+      entry,
+      direction === "harder" ? "min" : "max"
+    );
   }
 
   if (meta.supports_load !== true){
@@ -5497,6 +5524,7 @@ async function applyVariantSwap(entry, direction){
 function removePlanEntryByIndex(item, idx){
   const entries = getSessionEntries(item);
   if (idx < 0 || idx >= entries.length) return;
+
   entries.splice(idx, 1);
   renderTodayPlan(item);
 }
@@ -5520,12 +5548,14 @@ async function adjustPlanEntryAtIndex(item, idx, direction){
 
   const setBounds = getEntrySetBounds(entry);
   const currentSets = Math.max(1, Number(entry.sets || setBounds.min || 1) || 1);
-
   const currentTarget = String(entry.target_reps || "").trim();
   const currentLoad = parseKgNumber(entry.target_load);
   const loadBounds = getEntryLoadBounds(entry);
   const loadOptions = Array.isArray(loadBounds.options) ? loadBounds.options : [];
-  const hasLoadChannel = currentLoad != null && (loadOptions.length > 0 || getEntryLoadStep(entry) > 0);
+  const hasLoadChannel = currentLoad != null && (
+    loadOptions.length > 0 ||
+    getEntryLoadStep(entry) > 0
+  );
   const currentTargetAtMin = targetRepsAtBound(currentTarget, entry, "min");
   const currentTargetAtMax = targetRepsAtBound(currentTarget, entry, "max");
 
@@ -5533,18 +5563,28 @@ async function adjustPlanEntryAtIndex(item, idx, direction){
 
   const tryTargetStep = () => {
     if (!currentTarget) return false;
-    const nextTarget = clampTargetRepsString(shiftTargetPatternOneStep(currentTarget, entry, dir), entry);
+
+    const nextTarget = clampTargetRepsString(
+      shiftTargetPatternOneStep(currentTarget, entry, dir),
+      entry
+    );
     if (!nextTarget || nextTarget === currentTarget) return false;
+
     entry.target_reps = nextTarget;
-    entry.manual_adjustment_reason = dir === "harder" ? "target_step_up" : "target_step_down";
+    entry.manual_adjustment_reason = dir === "harder"
+      ? "target_step_up"
+      : "target_step_down";
     return true;
   };
 
   const trySetStep = () => {
     const nextSets = getAdjacentNumericOption(setBounds.options, currentSets, dir);
     if (nextSets == null || nextSets === currentSets) return false;
+
     entry.sets = nextSets;
-    entry.manual_adjustment_reason = dir === "harder" ? "set_step_up" : "set_step_down";
+    entry.manual_adjustment_reason = dir === "harder"
+      ? "set_step_up"
+      : "set_step_down";
     return true;
   };
 
@@ -5559,13 +5599,17 @@ async function adjustPlanEntryAtIndex(item, idx, direction){
     if (nextLoad == null){
       const step = getEntryLoadStep(entry);
       if (!step || currentLoad == null) return false;
-      nextLoad = dir === "harder" ? currentLoad + step : currentLoad - step;
+
+      nextLoad = dir === "harder"
+        ? currentLoad + step
+        : currentLoad - step;
     }
 
     if (nextLoad < loadBounds.min || nextLoad > loadBounds.max) return false;
     if (nextLoad === currentLoad) return false;
 
     entry.target_load = formatKgLabel(nextLoad);
+
     if (isLoadFirstProgressionExercise(entry)){
       entry.sets = getLoadFirstSetsAfterLoadStep(currentSets, setBounds, dir);
     } else {
@@ -5573,24 +5617,40 @@ async function adjustPlanEntryAtIndex(item, idx, direction){
     }
 
     if (currentTarget){
-      entry.target_reps = buildBoundaryTargetFromCurrentShape(entry, dir === "harder" ? "min" : "max");
+      entry.target_reps = buildBoundaryTargetFromCurrentShape(
+        entry,
+        dir === "harder" ? "min" : "max"
+      );
     }
 
     entry.manual_adjustment_reason = isLoadFirstProgressionExercise(entry)
-      ? (dir === "harder" ? "load_step_up_and_modest_reset" : "load_step_down_and_modest_reset")
-      : (dir === "harder" ? "load_step_up_and_reset" : "load_step_down_and_reset");
+      ? (
+          dir === "harder"
+            ? "load_step_up_and_modest_reset"
+            : "load_step_down_and_modest_reset"
+        )
+      : (
+          dir === "harder"
+            ? "load_step_up_and_reset"
+            : "load_step_down_and_reset"
+        );
     return true;
   };
 
   const tryVolumeCycleSetStep = () => {
     if (!isLoadFirstProgressionExercise(entry)) return false;
+
     const nextSets = getAdjacentNumericOption(setBounds.options, currentSets, dir);
     if (nextSets == null || nextSets === currentSets) return false;
 
     entry.sets = nextSets;
     if (currentTarget){
-      entry.target_reps = buildBoundaryTargetFromCurrentShape(entry, dir === "harder" ? "min" : "max");
+      entry.target_reps = buildBoundaryTargetFromCurrentShape(
+        entry,
+        dir === "harder" ? "min" : "max"
+      );
     }
+
     entry.manual_adjustment_reason = dir === "harder"
       ? "set_step_up_and_reset_target"
       : "set_step_down_and_expand_target";


### PR DESCRIPTION
## Summary

Cleans up the today-plan local adjustment code after the final easier/harder refinements.

This PR does not change behavior. It only improves readability and structure around the final local adjustment mutation flow.

## Changes

- Reformatted `applyVariantSwap(...)` for clearer backend/fallback variant handling
- Reformatted `removePlanEntryByIndex(...)`
- Reformatted `adjustPlanEntryAtIndex(...)`
- Split dense inline expressions across readable lines
- Kept the easier/harder adjustment behavior unchanged
- Kept scope limited to `app/frontend/app.js`

## Validation

- `node --check app/frontend/app.js` passes
- Diff only touches frontend local adjustment cleanup code
- No backend, data, i18n, selector, storage, or rendering HTML changes

## Notes

`pytest` is not currently available in the local environment and is not declared in the repo requirements, so the newly added Python contract tests were not run locally as part of this cleanup.

Closes #698