### PR TITLE
Fix manual workout review identity handoff

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4443,15 +4443,32 @@ function toggleCardioReviewFields(item){
   updateCardioPacePreview();
 }
 
+function markUnsavedWorkoutReviewHandoff(item){
+  if (item && typeof item === "object"){
+    item._unsaved_workout_review_handoff = true;
+  }
+}
+
+function hasUnsavedWorkoutReviewHandoff(item){
+  return Boolean(item && typeof item === "object" && item._unsaved_workout_review_handoff === true);
+}
+
+function clearUnsavedWorkoutReviewHandoff(item){
+  if (item && typeof item === "object"){
+    delete item._unsaved_workout_review_handoff;
+  }
+}
+
 function renderSessionReview(item){
   if (STATE.restDayReviewLocked !== true) {
     STATE.restDayReviewLocked = false;
   }
   const root = document.getElementById("sessionReviewList");
   const form = document.getElementById("sessionResultForm");
-  const completedTodayItem = !STATE.editingSessionResultId ? getCompletedSessionToday(STATE.sessionResults || []) : null;
-  const todayCheckin = !STATE.editingSessionResultId ? getTodayCheckin(STATE.checkins || [], STATE.latestCheckin || null, STATE.currentTodayPlan || null) : null;
-  const acknowledgedRestDayItem = !STATE.editingSessionResultId ? getAcknowledgedRestDayCheckin(todayCheckin, STATE.currentTodayPlan || null) : null;
+  const hasUnsavedReviewHandoff = hasUnsavedWorkoutReviewHandoff(item);
+  const completedTodayItem = !STATE.editingSessionResultId && !hasUnsavedReviewHandoff ? getCompletedSessionToday(STATE.sessionResults || []) : null;
+  const todayCheckin = !STATE.editingSessionResultId && !hasUnsavedReviewHandoff ? getTodayCheckin(STATE.checkins || [], STATE.latestCheckin || null, STATE.currentTodayPlan || null) : null;
+  const acknowledgedRestDayItem = !STATE.editingSessionResultId && !hasUnsavedReviewHandoff ? getAcknowledgedRestDayCheckin(todayCheckin, STATE.currentTodayPlan || null) : null;
   const isClosedDay = Boolean(completedTodayItem || acknowledgedRestDayItem);
 
   if (form){
@@ -6328,6 +6345,7 @@ function finishActiveWorkoutAndOpenReview(item, completionContext = {}){
   STATE.currentWorkoutEntryIndex = 0;
   STATE.currentWorkoutSetIndex = 0;
   clearWorkoutRuntimeArtifacts(item);
+  markUnsavedWorkoutReviewHandoff(item);
   renderReviewSummary(item);
   renderSessionReview(item);
   showWizardStep("review");
@@ -8479,6 +8497,7 @@ session_type:
       setText("sessionResultStatus", "summary_debug_error: " + (err?.message || String(err)));
     }
 
+    clearUnsavedWorkoutReviewHandoff(plan);
     form.reset();
     form.session_completed.value = "true";
     await refreshAll();

--- a/tests/test_manual_workout_review_identity_contract.py
+++ b/tests/test_manual_workout_review_identity_contract.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app/frontend/app.js"
+
+
+def test_finish_active_workout_marks_unsaved_review_handoff():
+    js = APP_JS.read_text()
+
+    assert "function markUnsavedWorkoutReviewHandoff(item)" in js
+    assert "markUnsavedWorkoutReviewHandoff(item);" in js
+    assert "function hasUnsavedWorkoutReviewHandoff(item)" in js
+
+
+def test_session_review_does_not_close_day_for_unsaved_workout_handoff():
+    js = APP_JS.read_text()
+
+    assert "const hasUnsavedReviewHandoff = hasUnsavedWorkoutReviewHandoff(item);" in js
+    assert "const completedTodayItem = !STATE.editingSessionResultId && !hasUnsavedReviewHandoff" in js
+    assert "const acknowledgedRestDayItem = !STATE.editingSessionResultId && !hasUnsavedReviewHandoff" in js
+
+
+def test_successful_session_save_clears_unsaved_review_handoff():
+    js = APP_JS.read_text()
+
+    assert "clearUnsavedWorkoutReviewHandoff(plan);" in js
+
+
+if __name__ == "__main__":
+    test_finish_active_workout_marks_unsaved_review_handoff()
+    test_session_review_does_not_close_day_for_unsaved_workout_handoff()
+    test_successful_session_save_clears_unsaved_review_handoff()
+    print("Manual workout review identity contract tests passed")


### PR DESCRIPTION
## Summary
Fixes manual workout review handoff so completing an active workout opens the editable review for that exact unsaved session instead of a stale completed-day summary.

## Problem
When a completed session already existed in local state, `renderSessionReview(...)` could close the review form and render the stored completed-session summary even after a new active manual workout had just been completed.

That broke the expected 1:1 relationship between:
- active workout execution
- editable review state
- saved session result payload

## What changed
- Added an unsaved workout review handoff marker on the active plan object
- `finishActiveWorkoutAndOpenReview(...)` marks the plan before rendering review
- `renderSessionReview(...)` ignores completed-day/rest-day closure when that unsaved handoff is active
- successful session save clears the handoff marker
- added contract coverage for the handoff behavior

## Validation
- `node --check app/frontend/app.js`
- `python3 -m py_compile tests/test_manual_workout_review_identity_contract.py`
- `python3 tests/test_manual_workout_review_identity_contract.py`
- `python3 tests/test_today_plan_contract.py`
- `python3 tests/test_today_plan_explanation_contract.py`
- `python3 tests/test_load_based_local_adjustment_contract.py`
- `python3 tests/test_local_protection_scenarios.py`
- `git diff --check`

## Scope
- frontend review handoff only
- no backend changes
- no change to normal completed-day summary behavior
- no new global state