### PR TITLE
Fix mixed rep and timed hold workout summary

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4775,10 +4775,13 @@ function renderSessionResultSummary(summary, fallbackResults = null){
       .map(setItem => Number(String(setItem?.reps || "").match(/\d+/)?.[0] || 0))
       .filter(x => x > 0);
   });
-  const totalTimedSeconds = timedSetSeconds.reduce((sum, x) => sum + x, 0);
+  const summaryTotalTimedSeconds = Number(summary.total_time_under_tension_sec || 0);
+  const totalTimedSeconds = summaryTotalTimedSeconds > 0 ? summaryTotalTimedSeconds : timedSetSeconds.reduce((sum, x) => sum + x, 0);
   const timedCandidateCount = timedSummaryCandidates.length;
   const hasTimedOnlyPlan = timedCandidateCount > 0 && timedStrengthResults.length === timedCandidateCount;
-  const shouldUseTimedSummary = timedSetSeconds.length > 0 || hasTimedOnlyPlan;
+  const hasMixedRepAndTimedWork = totalReps > 0 && totalTimedSeconds > 0;
+  const hasTimedOnlyWork = totalTimedSeconds > 0 && totalReps === 0;
+  const shouldUseTimedSummary = hasTimedOnlyWork || hasTimedOnlyPlan;
 
   const normalizedNextStepHint = String(nextStepHint || "").trim().toLowerCase();
 
@@ -4808,17 +4811,30 @@ function renderSessionResultSummary(summary, fallbackResults = null){
       }).join("<br>")}</div>`
     : "";
 
-  const performanceBlock = shouldUseTimedSummary
-    ? `${esc(tr("after_training.completed_exercises_label"))}: ${esc(String(completedExercises))}/${esc(String(totalExercises))}<br>
+  const timedHoldTimesText = timedSetSeconds.length ? timedSetSeconds.join(" / ") : "-";
+  const timedPerformanceBlock = `${esc(tr("after_training.completed_exercises_label"))}: ${esc(String(completedExercises))}/${esc(String(totalExercises))}<br>
       ${esc(tr("review.summary_sets_label"))}: ${esc(String(totalSets))}<br>
-      ${esc(tr("review.summary_hold_times_label"))}: ${esc(timedSetSeconds.length ? timedSetSeconds.join(" / ") : "-")} sek<br>
+      ${esc(tr("review.summary_hold_times_label"))}: ${esc(timedHoldTimesText)} sek<br>
       ${esc(tr("review.summary_total_hold_time_label"))}: ${esc(String(totalTimedSeconds))} sek<br>
-      ${esc(tr("review.summary_failure_markers_label"))}: ${esc(String(hitFailureCount))}`
-    : `${esc(tr("after_training.completed_exercises_label"))}: ${esc(String(completedExercises))}/${esc(String(totalExercises))}<br>
+      ${esc(tr("review.summary_failure_markers_label"))}: ${esc(String(hitFailureCount))}`;
+
+  const standardPerformanceBlock = `${esc(tr("after_training.completed_exercises_label"))}: ${esc(String(completedExercises))}/${esc(String(totalExercises))}<br>
       ${esc(tr("review.summary_sets_label"))}: ${esc(String(totalSets))}<br>
       ${esc(tr("review.summary_reps_label"))}: ${esc(String(totalReps))}<br>
       ${esc(tr("review.summary_volume_label"))}: ${esc(String(estimatedVolume))}<br>
       ${esc(tr("review.summary_failure_markers_label"))}: ${esc(String(hitFailureCount))}`;
+
+  const mixedPerformanceBlock = `${esc(tr("after_training.completed_exercises_label"))}: ${esc(String(completedExercises))}/${esc(String(totalExercises))}<br>
+      ${esc(tr("review.summary_sets_label"))}: ${esc(String(totalSets))}<br>
+      ${esc(tr("review.summary_reps_label"))}: ${esc(String(totalReps))}<br>
+      ${esc(tr("review.summary_volume_label"))}: ${esc(String(estimatedVolume))}<br>
+      ${esc(tr("review.summary_hold_times_label"))}: ${esc(timedHoldTimesText)} sek<br>
+      ${esc(tr("review.summary_total_hold_time_label"))}: ${esc(String(totalTimedSeconds))} sek<br>
+      ${esc(tr("review.summary_failure_markers_label"))}: ${esc(String(hitFailureCount))}`;
+
+  const performanceBlock = hasMixedRepAndTimedWork
+    ? mixedPerformanceBlock
+    : (shouldUseTimedSummary ? timedPerformanceBlock : standardPerformanceBlock);
 
   root.innerHTML = `
     <div class="review-summary-card">

--- a/tests/test_mixed_session_summary_contract.py
+++ b/tests/test_mixed_session_summary_contract.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app/frontend/app.js"
+
+
+def test_mixed_strength_summary_has_separate_rendering_path():
+    js = APP_JS.read_text()
+
+    assert "const hasMixedRepAndTimedWork = totalReps > 0 && totalTimedSeconds > 0;" in js
+    assert "const hasTimedOnlyWork = totalTimedSeconds > 0 && totalReps === 0;" in js
+    assert "hasMixedRepAndTimedWork" in js
+
+
+def test_mixed_strength_summary_keeps_rep_and_hold_metrics():
+    js = APP_JS.read_text()
+
+    assert "const mixedPerformanceBlock" in js
+    assert 'tr("review.summary_reps_label")' in js
+    assert 'tr("review.summary_volume_label")' in js
+    assert 'tr("review.summary_total_hold_time_label")' in js
+
+
+def test_timed_summary_can_use_backend_total_time_under_tension():
+    js = APP_JS.read_text()
+
+    assert "const summaryTotalTimedSeconds = Number(summary.total_time_under_tension_sec || 0);" in js
+    assert "summaryTotalTimedSeconds > 0 ? summaryTotalTimedSeconds : timedSetSeconds.reduce" in js
+
+
+if __name__ == "__main__":
+    test_mixed_strength_summary_has_separate_rendering_path()
+    test_mixed_strength_summary_keeps_rep_and_hold_metrics()
+    test_timed_summary_can_use_backend_total_time_under_tension()
+    print("Mixed session summary contract tests passed")


### PR DESCRIPTION
## Summary
Fixes post-workout summary rendering for mixed strength sessions containing both rep-based work and timed holds.

## Problem
A single timed hold exercise could cause the entire strength summary to render through the timed-summary path. This hid normal rep/load metrics and produced confusing output such as tiny hold-time totals or misleading “time per set” summaries.

## What changed
- Added explicit mixed rep + timed hold rendering path
- Preserved normal rep/load summary for rep-only sessions
- Preserved timed summary for timed-only sessions
- Uses backend `total_time_under_tension_sec` as the primary total hold-time source when available
- Added contract coverage for mixed summary behavior

## Validation
- `node --check app/frontend/app.js`
- `python3 -m py_compile tests/test_mixed_session_summary_contract.py`
- `python3 tests/test_mixed_session_summary_contract.py`
- `python3 tests/test_today_plan_contract.py`
- `python3 tests/test_today_plan_explanation_contract.py`
- `python3 tests/test_load_based_local_adjustment_contract.py`
- `python3 tests/test_local_protection_scenarios.py`
- `git diff --check`

## Scope
- frontend summary rendering only
- no backend changes
- no persistence/data model changes