### PR TITLE
Enrich core barbell exercise metadata

### DIFF
--- a/app/data/seed/exercises.json
+++ b/app/data/seed/exercises.json
@@ -83,7 +83,7 @@
     "default_unit": "kg",
     "progression_step": 10,
     "start_weight": 30,
-    "notes": "Horizontal push.",
+    "notes": "Vandret pres med vægtstang. Bruges til loaded presstyrke, når skulder, albue og håndled kan arbejde kontrolleret.",
     "progression_mode": "double_progression",
     "recommended_step": 2.5,
     "load_increment": 10,
@@ -126,11 +126,23 @@
     ],
     "name_en": "Bench press",
     "category_en": "push",
-    "notes_en": "Horizontal press.",
+    "notes_en": "Loaded horizontal press with a barbell. Used for pressing strength when shoulder, elbow, and wrist can work under control.",
     "local_load_targets": [
       "shoulder",
       "elbow",
       "wrist"
+    ],
+    "form_cues": [
+      "Hold skulderbladene stabile på bænken",
+      "Sænk stangen kontrolleret mod brystet",
+      "Pres op uden at miste spænding i kroppen",
+      "Stop eller sænk vægten, hvis skulderen føles klemt"
+    ],
+    "form_cues_en": [
+      "Keep the shoulder blades stable on the bench",
+      "Lower the bar under control toward the chest",
+      "Press up without losing full-body tension",
+      "Stop or reduce the load if the shoulder feels pinched"
     ]
   },
   {
@@ -140,7 +152,7 @@
     "default_unit": "kg",
     "progression_step": 10,
     "start_weight": 40,
-    "notes": "Back and posterior chain.",
+    "notes": "Vandret træk med vægtstang. Bruges til rygstyrke, når rygpositionen kan holdes rolig under belastning.",
     "progression_mode": "double_progression",
     "recommended_step": 2.5,
     "load_increment": 10,
@@ -183,11 +195,23 @@
     ],
     "name_en": "Bent-over row",
     "category_en": "pull",
-    "notes_en": "Back and posterior chain.",
+    "notes_en": "Loaded horizontal pull with a barbell. Used for back strength when the torso position can stay controlled under load.",
     "local_load_targets": [
       "shoulder",
       "elbow",
       "low_back"
+    ],
+    "form_cues": [
+      "Hold ryggen rolig og brystet let fremme",
+      "Træk stangen mod kroppen uden at hive med lænden",
+      "Sænk stangen kontrolleret tilbage",
+      "Stop eller sænk vægten, hvis overkroppen begynder at gynge"
+    ],
+    "form_cues_en": [
+      "Keep the back steady and the chest slightly proud",
+      "Pull the bar toward the body without yanking through the lower back",
+      "Lower the bar back under control",
+      "Stop or reduce the load if the torso starts to swing"
     ]
   },
   {
@@ -197,7 +221,7 @@
     "default_unit": "kg",
     "progression_step": 10,
     "start_weight": 30,
-    "notes": "Vertical push.",
+    "notes": "Lodret pres med vægtstang. Bruges til loaded skulderpres, når presbevægelsen kan holdes stabil uden at overstrække lænden.",
     "progression_mode": "double_progression",
     "recommended_step": 2.5,
     "load_increment": 10,
@@ -235,7 +259,7 @@
     ],
     "name_en": "Overhead press",
     "category_en": "push",
-    "notes_en": "Vertical press.",
+    "notes_en": "Loaded vertical press with a barbell. Used for shoulder pressing when the press can stay stable without overextending the lower back.",
     "local_load_targets": [
       "shoulder",
       "elbow",
@@ -245,6 +269,18 @@
     "external_images": [
       "Barbell_Shoulder_Press/0.jpg",
       "Barbell_Shoulder_Press/1.jpg"
+    ],
+    "form_cues": [
+      "Start med stangen tæt på kroppen",
+      "Pres stangen op i en rolig linje",
+      "Hold ribben og lænd under kontrol",
+      "Stop eller sænk vægten, hvis du må læne dig hårdt bagud"
+    ],
+    "form_cues_en": [
+      "Start with the bar close to the body",
+      "Press the bar up in a controlled line",
+      "Keep the ribs and lower back under control",
+      "Stop or reduce the load if you have to lean hard backward"
     ]
   },
   {
@@ -254,7 +290,7 @@
     "default_unit": "kg",
     "progression_step": 10,
     "start_weight": 60,
-    "notes": "Romanian deadlift.",
+    "notes": "Hoftehængsel med vægtstang. Bruges til bagkæde og hoftestyrke, når bevægelsen kan styres uden at runde lænden.",
     "progression_mode": "double_progression",
     "recommended_step": 2.5,
     "load_increment": 10,
@@ -292,7 +328,7 @@
     ],
     "name_en": "RDL",
     "category_en": "posterior chain",
-    "notes_en": "Romanian deadlift.",
+    "notes_en": "Loaded hip hinge with a barbell. Used for posterior-chain and hip strength when the movement can stay controlled without rounding the lower back.",
     "local_load_targets": [
       "hip",
       "low_back"
@@ -301,6 +337,18 @@
     "external_images": [
       "Barbell_Deadlift/0.jpg",
       "Barbell_Deadlift/1.jpg"
+    ],
+    "form_cues": [
+      "Skub hofterne tilbage før knæene bøjer meget",
+      "Hold stangen tæt på benene",
+      "Sænk kun så langt ryggen kan holdes rolig",
+      "Stop eller sænk vægten, hvis lænden begynder at runde"
+    ],
+    "form_cues_en": [
+      "Push the hips back before the knees bend much",
+      "Keep the bar close to the legs",
+      "Lower only as far as the back can stay steady",
+      "Stop or reduce the load if the lower back starts to round"
     ]
   },
   {

--- a/tests/test_exercise_metadata_enrichment_contract.py
+++ b/tests/test_exercise_metadata_enrichment_contract.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXERCISES = ROOT / "app/data/seed/exercises.json"
+
+TARGETS = {
+    "bench_press",
+    "barbell_row",
+    "overhead_press",
+    "romanian_deadlift",
+}
+
+
+def _exercise_map():
+    items = json.loads(EXERCISES.read_text())
+    return {
+        str(item.get("id", "")).strip(): item
+        for item in items
+        if isinstance(item, dict) and str(item.get("id", "")).strip()
+    }
+
+
+def test_core_barbell_exercises_have_app_friendly_notes():
+    exercises = _exercise_map()
+
+    for exercise_id in TARGETS:
+        item = exercises[exercise_id]
+        notes = str(item.get("notes", "")).strip()
+        notes_en = str(item.get("notes_en", "")).strip()
+
+        assert len(notes) >= 50, (exercise_id, notes)
+        assert len(notes_en) >= 50, (exercise_id, notes_en)
+        assert len(notes) <= 180, (exercise_id, notes)
+        assert len(notes_en) <= 180, (exercise_id, notes_en)
+
+
+def test_core_barbell_exercises_have_short_form_cues_in_both_languages():
+    exercises = _exercise_map()
+
+    for exercise_id in TARGETS:
+        item = exercises[exercise_id]
+        cues = item.get("form_cues")
+        cues_en = item.get("form_cues_en")
+
+        assert isinstance(cues, list), exercise_id
+        assert isinstance(cues_en, list), exercise_id
+        assert 3 <= len(cues) <= 5, (exercise_id, cues)
+        assert 3 <= len(cues_en) <= 5, (exercise_id, cues_en)
+
+        for cue in cues + cues_en:
+            text = str(cue).strip()
+            assert text, exercise_id
+            assert len(text) <= 95, (exercise_id, text)
+
+
+def test_core_barbell_enrichment_preserves_planning_metadata():
+    exercises = _exercise_map()
+
+    expected = {
+        "bench_press": ("horizontal_push", "load_reps", ["shoulder", "elbow", "wrist"]),
+        "barbell_row": ("horizontal_pull", "load_reps", ["shoulder", "elbow", "low_back"]),
+        "overhead_press": ("vertical_push", "load_reps", ["shoulder", "elbow", "wrist"]),
+        "romanian_deadlift": ("hinge", "load_reps", ["hip", "low_back"]),
+    }
+
+    for exercise_id, (movement_pattern, input_kind, local_targets) in expected.items():
+        item = exercises[exercise_id]
+        assert item.get("movement_pattern") == movement_pattern, exercise_id
+        assert item.get("input_kind") == input_kind, exercise_id
+        assert item.get("local_load_targets") == local_targets, exercise_id
+
+
+if __name__ == "__main__":
+    test_core_barbell_exercises_have_app_friendly_notes()
+    test_core_barbell_exercises_have_short_form_cues_in_both_languages()
+    test_core_barbell_enrichment_preserves_planning_metadata()
+    print("Exercise metadata enrichment contract tests passed")


### PR DESCRIPTION
## Summary
Adds the first controlled exercise metadata enrichment pass for core barbell exercises.

## Problem
Several important imported/catalog exercises had thin notes and no form cues, which made them less useful for planning, review, and exercise viewing.

## What changed
Enriched:
- bench_press
- barbell_row
- overhead_press
- romanian_deadlift

Added:
- clearer `notes`
- clearer `notes_en`
- short `form_cues`
- short `form_cues_en`

## Why
These four exercises are central load-based strength entries and should provide practical, app-friendly guidance aligned with the exercise content standard.

## Validation
- `python3 -m json.tool app/data/seed/exercises.json`
- `python3 -m py_compile tests/test_exercise_metadata_enrichment_contract.py`
- `python3 tests/test_exercise_metadata_enrichment_contract.py`
- `git diff --check`

## Scope
- data/content only
- no runtime changes
- no schema changes
- no progression changes
- no load option changes
- no local protection metadata changes