### PR TITLE
Clarify bodyweight push-up canonical path

### DIFF
--- a/app/data/seed/exercises.json
+++ b/app/data/seed/exercises.json
@@ -954,7 +954,7 @@
     "default_unit": "reps",
     "progression_step": 0,
     "start_weight": 0,
-    "notes": "Harder push variant focusing on triceps.",
+    "notes": "Sværere push-up variant med smal håndplacering og større tricepskrav. Brug den først når almindelige push-ups er stabile.",
     "progression_mode": "reps_only",
     "recommended_step": 0,
     "load_increment": 0,
@@ -982,7 +982,7 @@
     ],
     "name_en": "Diamond push-ups",
     "category_en": "push",
-    "notes_en": "Harder push variation with extra triceps focus.",
+    "notes_en": "Harder push-up variation with a close hand position and greater triceps demand. Use it only when regular push-ups are stable.",
     "local_load_targets": [
       "shoulder",
       "elbow",
@@ -992,6 +992,18 @@
     "external_images": [
       "Push-Ups_-_Close_Triceps_Position/0.jpg",
       "Push-Ups_-_Close_Triceps_Position/1.jpg"
+    ],
+    "form_cues": [
+      "Hold kroppen i én linje",
+      "Placer hænderne tættere sammen under brystet",
+      "Sænk dig roligt uden at skuldrene falder frem",
+      "Stop eller vælg almindelige push-ups, hvis albuer eller håndled føles pressede"
+    ],
+    "form_cues_en": [
+      "Keep the body in one line",
+      "Place the hands closer together under the chest",
+      "Lower under control without letting the shoulders roll forward",
+      "Stop or use regular push-ups if elbows or wrists feel overloaded"
     ]
   },
   {

--- a/tests/test_bodyweight_deduplication_contract.py
+++ b/tests/test_bodyweight_deduplication_contract.py
@@ -1,0 +1,94 @@
+import json
+from pathlib import Path
+from collections import defaultdict
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXERCISES = ROOT / "app/data/seed/exercises.json"
+PROGRAMS = ROOT / "app/data/seed/programs.json"
+
+CANONICAL_PUSH_FAMILY = [
+    "incline_push_ups",
+    "push_ups",
+    "diamond_push_ups",
+]
+
+NON_CANONICAL_PUSH_DUPLICATES = {
+    "incline_push_up",
+    "pushups",
+    "push_up_wide",
+    "incline_push_up_medium",
+    "incline_push_up_wide",
+    "incline_push_up_close_grip",
+    "push_ups_close_triceps_position",
+}
+
+
+def _exercise_map():
+    items = json.loads(EXERCISES.read_text())
+    return {
+        str(item.get("id", "")).strip(): item
+        for item in items
+        if isinstance(item, dict) and str(item.get("id", "")).strip()
+    }
+
+
+def _program_refs():
+    programs = json.loads(PROGRAMS.read_text())
+    refs = defaultdict(int)
+
+    for program in programs:
+        days = program.get("days", [])
+        if not isinstance(days, list):
+            continue
+
+        for day in days:
+            entries = day.get("exercises", []) if isinstance(day, dict) else []
+            if not isinstance(entries, list):
+                continue
+
+            for entry in entries:
+                exercise_id = str(entry.get("exercise_id", "")).strip()
+                if exercise_id:
+                    refs[exercise_id] += 1
+
+    return refs
+
+
+def test_canonical_pushup_family_exists_and_is_ladder_backed():
+    exercises = _exercise_map()
+
+    for exercise_id in CANONICAL_PUSH_FAMILY:
+        assert exercise_id in exercises, exercise_id
+
+    ladder = exercises["push_ups"].get("progression_ladder", [])
+    for exercise_id in CANONICAL_PUSH_FAMILY:
+        assert exercise_id in ladder, exercise_id
+
+
+def test_canonical_pushup_family_has_viewer_guidance():
+    exercises = _exercise_map()
+
+    for exercise_id in CANONICAL_PUSH_FAMILY:
+        item = exercises[exercise_id]
+        assert len(str(item.get("notes", "")).strip()) >= 50, exercise_id
+        assert len(str(item.get("notes_en", "")).strip()) >= 50, exercise_id
+
+        cues = item.get("form_cues")
+        cues_en = item.get("form_cues_en")
+        assert isinstance(cues, list) and len(cues) >= 3, exercise_id
+        assert isinstance(cues_en, list) and len(cues_en) >= 3, exercise_id
+
+
+def test_non_canonical_pushup_duplicates_are_not_program_referenced():
+    refs = _program_refs()
+
+    for exercise_id in NON_CANONICAL_PUSH_DUPLICATES:
+        assert refs.get(exercise_id, 0) == 0, (exercise_id, refs.get(exercise_id, 0))
+
+
+if __name__ == "__main__":
+    test_canonical_pushup_family_exists_and_is_ladder_backed()
+    test_canonical_pushup_family_has_viewer_guidance()
+    test_non_canonical_pushup_duplicates_are_not_program_referenced()
+    print("Bodyweight deduplication contract tests passed")


### PR DESCRIPTION
## Summary
Adds a conservative bodyweight deduplication pass for the push-up family.

## Problem
The catalog contains overlapping legacy/imported push-up-style bodyweight entries. Some canonical entries are referenced by programs or progression ladders, while several imported variants are currently unreferenced.

The goal is to improve coherence without unsafe broad id replacement or schema changes.

## What changed
- Enriched `diamond_push_ups`, which is part of the canonical `push_ups` progression ladder
- Added Danish and English notes
- Added Danish and English form cues
- Added a contract test documenting the canonical push-up family:
  - `incline_push_ups`
  - `push_ups`
  - `diamond_push_ups`
- Added test coverage confirming known non-canonical push-up duplicates are not program-referenced

## Validation
- `python3 -m json.tool app/data/seed/exercises.json`
- `python3 -m py_compile tests/test_bodyweight_deduplication_contract.py`
- `python3 tests/test_bodyweight_deduplication_contract.py`
- `python3 tests/test_exercise_metadata_enrichment_contract.py`
- `git diff --check`

## Scope
- data/content only
- no runtime changes
- no schema changes
- no program reference changes
- no exercise id migration
- no deletion of duplicate entries