### PR TITLE
Upgrade strength template metadata schema

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -92,6 +92,30 @@
       "completes planned sessions consistently for multiple weeks",
       "tolerates current exercises and recovery demands without difficulty",
       "needs more progression headroom than the entry template provides"
+    ],
+    "primary_goals": [
+      "general_strength",
+      "general_health"
+    ],
+    "secondary_goals": [
+      "habit",
+      "low_barrier",
+      "fat_loss_support",
+      "hybrid_support"
+    ],
+    "recovery_sensitivity": "moderate",
+    "hybrid_profile": "strength_supports_mixed_training",
+    "recommended_use_cases": [
+      "beginner_user",
+      "short_sessions",
+      "home_training",
+      "low_barrier_start",
+      "concurrent_running"
+    ],
+    "excluded_use_cases": [
+      "intermediate_strength_progression",
+      "hypertrophy_priority",
+      "high_frequency_training"
     ]
   },
   {
@@ -180,6 +204,26 @@
       "barbell",
       "base",
       "strength_priority"
+    ],
+    "primary_goals": [
+      "general_strength"
+    ],
+    "secondary_goals": [
+      "general_health",
+      "barbell_base"
+    ],
+    "recovery_sensitivity": "moderate",
+    "hybrid_profile": "strength_first",
+    "recommended_use_cases": [
+      "novice_or_intermediate_strength_base",
+      "gym_training",
+      "two_day_strength_priority",
+      "stable_recovery"
+    ],
+    "excluded_use_cases": [
+      "reentry_after_break",
+      "running_priority",
+      "minimal_equipment_only"
     ]
   },
   {
@@ -533,6 +577,28 @@
       "completes three weekly sessions consistently for multiple weeks",
       "handles current hinge, squat, push, and pull work with stable recovery",
       "needs a more durable novice home progression path"
+    ],
+    "primary_goals": [
+      "general_strength",
+      "general_health"
+    ],
+    "secondary_goals": [
+      "habit",
+      "fat_loss_support",
+      "hybrid_support"
+    ],
+    "recovery_sensitivity": "moderate",
+    "hybrid_profile": "balanced_mixed_training",
+    "recommended_use_cases": [
+      "beginner_user",
+      "three_day_home_training",
+      "mixed_training",
+      "consistent_weekly_rhythm"
+    ],
+    "excluded_use_cases": [
+      "reentry_after_break",
+      "intermediate_strength_progression",
+      "very_short_sessions"
     ]
   },
   {
@@ -698,6 +764,28 @@
       "completes planned sessions consistently for multiple weeks",
       "shows stable tolerance for gym-based loading and session structure",
       "is ready for a more durable base gym program"
+    ],
+    "primary_goals": [
+      "general_strength",
+      "general_health"
+    ],
+    "secondary_goals": [
+      "gym_foundation",
+      "fat_loss_support",
+      "hybrid_support"
+    ],
+    "recovery_sensitivity": "moderate",
+    "hybrid_profile": "strength_supports_mixed_training",
+    "recommended_use_cases": [
+      "beginner_user",
+      "gym_training",
+      "two_day_strength_foundation",
+      "concurrent_running"
+    ],
+    "excluded_use_cases": [
+      "intermediate_strength_progression",
+      "hypertrophy_priority",
+      "minimal_home_only"
     ]
   },
   {
@@ -818,6 +906,28 @@
       "completes three weekly sessions consistently for multiple weeks",
       "shows stable recovery and low friction across the training week",
       "is ready for a more durable base gym program"
+    ],
+    "primary_goals": [
+      "general_strength",
+      "general_health"
+    ],
+    "secondary_goals": [
+      "gym_foundation",
+      "fat_loss_support",
+      "hybrid_support"
+    ],
+    "recovery_sensitivity": "moderate",
+    "hybrid_profile": "balanced_mixed_training",
+    "recommended_use_cases": [
+      "beginner_user",
+      "gym_training",
+      "three_day_strength_foundation",
+      "stable_weekly_capacity"
+    ],
+    "excluded_use_cases": [
+      "reentry_after_break",
+      "very_low_recovery",
+      "minimal_home_only"
     ]
   },
   {
@@ -919,6 +1029,29 @@
       "completes both weekly sessions consistently for 2 to 3 weeks",
       "reports low friction and stable recovery after sessions",
       "is ready for a more standard beginner or novice loading path"
+    ],
+    "primary_goals": [
+      "reentry",
+      "general_health"
+    ],
+    "secondary_goals": [
+      "habit",
+      "low_fatigue",
+      "hybrid_support"
+    ],
+    "recovery_sensitivity": "high",
+    "hybrid_profile": "recovery_preserving",
+    "recommended_use_cases": [
+      "returning_after_break",
+      "low_readiness",
+      "low_fatigue_need",
+      "short_sessions",
+      "concurrent_running"
+    ],
+    "excluded_use_cases": [
+      "hypertrophy_priority",
+      "aggressive_strength_progression",
+      "high_frequency_training"
     ]
   },
   {
@@ -1031,6 +1164,26 @@
       "novice",
       "3x",
       "strength_priority"
+    ],
+    "primary_goals": [
+      "general_strength"
+    ],
+    "secondary_goals": [
+      "general_health",
+      "barbell_base"
+    ],
+    "recovery_sensitivity": "moderate",
+    "hybrid_profile": "strength_first",
+    "recommended_use_cases": [
+      "novice_strength_base",
+      "gym_training",
+      "three_day_strength_priority",
+      "stable_recovery"
+    ],
+    "excluded_use_cases": [
+      "reentry_after_break",
+      "running_priority",
+      "low_recovery_capacity"
     ]
   },
   {
@@ -1169,6 +1322,28 @@
       "4x",
       "upper_lower",
       "hypertrophy_friendly"
+    ],
+    "primary_goals": [
+      "general_strength",
+      "hypertrophy"
+    ],
+    "secondary_goals": [
+      "upper_lower_structure",
+      "strength_hypertrophy"
+    ],
+    "recovery_sensitivity": "high",
+    "hybrid_profile": "strength_first",
+    "recommended_use_cases": [
+      "novice_user",
+      "gym_training",
+      "four_day_upper_lower",
+      "strength_hypertrophy_goal"
+    ],
+    "excluded_use_cases": [
+      "reentry_after_break",
+      "running_priority",
+      "low_recovery_capacity",
+      "very_short_sessions"
     ]
   },
   {
@@ -1485,6 +1660,27 @@
       "novice",
       "base",
       "mixed_friendly"
+    ],
+    "primary_goals": [
+      "general_strength"
+    ],
+    "secondary_goals": [
+      "general_health",
+      "fat_loss_support",
+      "hybrid_support"
+    ],
+    "recovery_sensitivity": "moderate",
+    "hybrid_profile": "balanced_mixed_training",
+    "recommended_use_cases": [
+      "novice_home_training",
+      "dumbbell_home",
+      "two_day_strength_base",
+      "concurrent_running"
+    ],
+    "excluded_use_cases": [
+      "reentry_after_break",
+      "barbell_strength_priority",
+      "hypertrophy_priority"
     ]
   },
   {
@@ -1594,6 +1790,27 @@
       "novice",
       "3x",
       "mixed_friendly"
+    ],
+    "primary_goals": [
+      "general_strength"
+    ],
+    "secondary_goals": [
+      "general_health",
+      "fat_loss_support",
+      "hybrid_support"
+    ],
+    "recovery_sensitivity": "moderate",
+    "hybrid_profile": "balanced_mixed_training",
+    "recommended_use_cases": [
+      "novice_home_training",
+      "dumbbell_home",
+      "three_day_strength_base",
+      "stable_weekly_capacity"
+    ],
+    "excluded_use_cases": [
+      "reentry_after_break",
+      "barbell_strength_priority",
+      "low_recovery_capacity"
     ]
   },
   {
@@ -1689,6 +1906,30 @@
       "wants more weekly training volume or broader movement coverage",
       "has enough recovery and schedule capacity for a fuller base template",
       "is no longer using minimal dose as the primary adherence strategy"
+    ],
+    "primary_goals": [
+      "minimal_effective_dose",
+      "general_strength"
+    ],
+    "secondary_goals": [
+      "general_health",
+      "habit",
+      "hybrid_support",
+      "maintenance"
+    ],
+    "recovery_sensitivity": "high",
+    "hybrid_profile": "recovery_preserving",
+    "recommended_use_cases": [
+      "short_sessions",
+      "low_fatigue_need",
+      "adherence_priority",
+      "concurrent_running",
+      "maintenance"
+    ],
+    "excluded_use_cases": [
+      "hypertrophy_priority",
+      "high_volume_training",
+      "aggressive_strength_progression"
     ]
   },
   {
@@ -1802,6 +2043,28 @@
       "intermediate",
       "3x",
       "hypertrophy_friendly"
+    ],
+    "primary_goals": [
+      "general_strength",
+      "hypertrophy"
+    ],
+    "secondary_goals": [
+      "dumbbell_home_progression",
+      "strength_hypertrophy"
+    ],
+    "recovery_sensitivity": "moderate",
+    "hybrid_profile": "strength_first",
+    "recommended_use_cases": [
+      "intermediate_user",
+      "dumbbell_home",
+      "three_day_strength_hypertrophy",
+      "stable_recovery"
+    ],
+    "excluded_use_cases": [
+      "beginner_user",
+      "reentry_after_break",
+      "running_priority",
+      "minimal_equipment_only"
     ]
   },
   {
@@ -1941,6 +2204,28 @@
       "4x",
       "upper_lower",
       "strength_hypertrophy"
+    ],
+    "primary_goals": [
+      "general_strength",
+      "hypertrophy"
+    ],
+    "secondary_goals": [
+      "upper_lower_structure",
+      "strength_hypertrophy"
+    ],
+    "recovery_sensitivity": "high",
+    "hybrid_profile": "strength_first",
+    "recommended_use_cases": [
+      "intermediate_user",
+      "gym_training",
+      "four_day_upper_lower",
+      "strength_hypertrophy_goal"
+    ],
+    "excluded_use_cases": [
+      "beginner_user",
+      "reentry_after_break",
+      "running_priority",
+      "low_recovery_capacity"
     ]
   },
   {
@@ -2080,6 +2365,29 @@
       "4x",
       "upper_lower",
       "hypertrophy"
+    ],
+    "primary_goals": [
+      "hypertrophy"
+    ],
+    "secondary_goals": [
+      "fat_loss_support",
+      "upper_lower_structure"
+    ],
+    "recovery_sensitivity": "high",
+    "hybrid_profile": "strength_first",
+    "recommended_use_cases": [
+      "intermediate_user",
+      "gym_training",
+      "hypertrophy_priority",
+      "four_day_upper_lower",
+      "stable_recovery"
+    ],
+    "excluded_use_cases": [
+      "beginner_user",
+      "reentry_after_break",
+      "running_priority",
+      "low_recovery_capacity",
+      "minimalist_training"
     ]
   }
 ]

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -41,6 +41,12 @@ Strength programs may also include compact selector-oriented metadata such as:
 - `program_family`
 - `progression_model`
 - `tags`
+- `primary_goals`
+- `secondary_goals`
+- `recovery_sensitivity`
+- `hybrid_profile`
+- `recommended_use_cases`
+- `excluded_use_cases`
 
 Each `days` entry typically contains:
 
@@ -76,6 +82,15 @@ Practical interpretation:
 - `program_family` groups related templates
 - `progression_model` describes the intended progression pattern at a high level
 - `tags` support lightweight future filtering without making the core schema unreadable
+- `primary_goals` names the main training intent in taxonomy language
+- `secondary_goals` names useful but non-primary outcomes
+- `recovery_sensitivity` describes how conservatively the template should react to poor recovery signals
+- `hybrid_profile` describes how the strength template should coexist with running or mixed training
+- `recommended_use_cases` gives concise machine-readable reasons the template is a good fit
+- `excluded_use_cases` gives concise machine-readable reasons the template should not be recommended
+
+These richer strength metadata fields are intentionally additive.
+They should support matching, explainability, and future UI copy without replacing the existing selector fields.
 
 ---
 

--- a/tests/test_strength_template_metadata_schema_contract.py
+++ b/tests/test_strength_template_metadata_schema_contract.py
@@ -1,0 +1,105 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROGRAMS = ROOT / "app/data/seed/programs.json"
+DATA_MODEL = ROOT / "docs/data-model.md"
+
+REQUIRED_STRENGTH_METADATA = [
+    "primary_goals",
+    "secondary_goals",
+    "recovery_sensitivity",
+    "hybrid_profile",
+    "recommended_use_cases",
+    "excluded_use_cases",
+]
+
+VALID_RECOVERY_SENSITIVITY = {
+    "low",
+    "moderate",
+    "high",
+}
+
+VALID_HYBRID_PROFILES = {
+    "strength_first",
+    "balanced_mixed_training",
+    "strength_supports_mixed_training",
+    "recovery_preserving",
+}
+
+
+def _strength_programs():
+    programs = json.loads(PROGRAMS.read_text())
+    return [
+        item
+        for item in programs
+        if isinstance(item, dict)
+        and str(item.get("kind", "")).strip().lower() == "strength"
+    ]
+
+
+def test_strength_templates_have_richer_identity_metadata():
+    programs = _strength_programs()
+    assert programs, "No strength programs found"
+
+    for program in programs:
+        program_id = str(program.get("id", "")).strip()
+
+        for field in REQUIRED_STRENGTH_METADATA:
+            value = program.get(field)
+            assert value not in (None, "", []), (program_id, field)
+
+        for field in [
+            "primary_goals",
+            "secondary_goals",
+            "recommended_use_cases",
+            "excluded_use_cases",
+        ]:
+            assert isinstance(program[field], list), (program_id, field)
+            assert all(str(x).strip() for x in program[field]), (program_id, field)
+
+        assert program["recovery_sensitivity"] in VALID_RECOVERY_SENSITIVITY, program_id
+        assert program["hybrid_profile"] in VALID_HYBRID_PROFILES, program_id
+
+
+def test_strength_template_metadata_preserves_existing_selector_fields():
+    programs = _strength_programs()
+
+    preserved = [
+        "recommended_levels",
+        "supported_goals",
+        "supported_weekly_sessions",
+        "equipment_profiles",
+        "training_style",
+        "program_family",
+        "progression_model",
+        "fatigue_profile",
+        "complexity",
+        "good_for_reentry",
+        "good_for_concurrent_running",
+        "session_duration_min",
+        "session_duration_max",
+        "tags",
+    ]
+
+    for program in programs:
+        program_id = str(program.get("id", "")).strip()
+        for field in preserved:
+            assert program.get(field) not in (None, "", []), (program_id, field)
+
+
+def test_strength_metadata_schema_is_documented():
+    text = DATA_MODEL.read_text()
+
+    for field in REQUIRED_STRENGTH_METADATA:
+        assert f"`{field}`" in text, field
+
+    assert "intentionally additive" in text
+
+
+if __name__ == "__main__":
+    test_strength_templates_have_richer_identity_metadata()
+    test_strength_template_metadata_preserves_existing_selector_fields()
+    test_strength_metadata_schema_is_documented()
+    print("Strength template metadata schema contract tests passed")


### PR DESCRIPTION
## Summary
Adds richer additive metadata to all strength program templates and documents the schema.

## Problem
Strength templates need clearer identity signals for future matching, explainability, adaptation, and UI copy.

Existing metadata covered core selector fields, but did not explicitly describe primary/secondary intent, recovery sensitivity, hybrid behavior, or when templates should and should not be recommended.

## What changed
Added to all 14 strength templates:
- `primary_goals`
- `secondary_goals`
- `recovery_sensitivity`
- `hybrid_profile`
- `recommended_use_cases`
- `excluded_use_cases`

Updated:
- `docs/data-model.md`

Added:
- `tests/test_strength_template_metadata_schema_contract.py`

## Why
This makes strength templates more explainable and reduces reliance on hard-coded assumptions in future recommendation logic.

## Validation
- `python3 -m json.tool app/data/seed/programs.json`
- `python3 -m py_compile tests/test_strength_template_metadata_schema_contract.py`
- `python3 tests/test_strength_template_metadata_schema_contract.py`
- `git diff --check`

## Scope
- data/schema enrichment only
- docs update
- contract test
- no runtime changes
- no selector logic changes
- no existing field renames