### PR TITLE
Upgrade running template metadata schema

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -274,6 +274,47 @@
     "equipment_profiles": [
       "run_only",
       "hybrid_home"
+    ],
+    "training_style": "run_walk_foundation",
+    "program_family": "starter_run",
+    "progression_model": "duration_first",
+    "fatigue_profile": "low",
+    "complexity": "low",
+    "tags": [
+      "run",
+      "starter",
+      "2x",
+      "low_barrier",
+      "habit"
+    ],
+    "primary_goals": [
+      "habit",
+      "general_health"
+    ],
+    "secondary_goals": [
+      "fat_loss_support",
+      "base_building"
+    ],
+    "run_structure_type": "run_walk",
+    "impact_profile": "low",
+    "hybrid_profile": "hybrid_compatible",
+    "race_distance_support": [
+      "none"
+    ],
+    "event_capability": "none",
+    "taper_support": "none",
+    "long_run_support": "none",
+    "recommended_use_cases": [
+      "beginner_runner",
+      "low_barrier_start",
+      "two_runs_per_week",
+      "habit_building",
+      "hybrid_training"
+    ],
+    "excluded_use_cases": [
+      "race_performance_goal",
+      "long_run_development",
+      "interval_priority"
     ]
   },
   {
@@ -345,6 +386,37 @@
       "3x",
       "aerobic",
       "interval_progression"
+    ],
+    "fatigue_profile": "moderate",
+    "complexity": "moderate",
+    "primary_goals": [
+      "base_running",
+      "general_health"
+    ],
+    "secondary_goals": [
+      "fat_loss_support",
+      "performance_base"
+    ],
+    "run_structure_type": "easy_base_with_quality",
+    "impact_profile": "moderate",
+    "hybrid_profile": "hybrid_compatible",
+    "race_distance_support": [
+      "general_base",
+      "5k_base"
+    ],
+    "event_capability": "base_support",
+    "taper_support": "none",
+    "long_run_support": "optional",
+    "recommended_use_cases": [
+      "beginner_or_novice_runner",
+      "three_runs_per_week",
+      "aerobic_base",
+      "controlled_quality_work"
+    ],
+    "excluded_use_cases": [
+      "return_to_running_after_break",
+      "half_marathon_specific_build",
+      "low_impact_only"
     ]
   },
   {
@@ -669,6 +741,48 @@
           }
         ]
       }
+    ],
+    "training_style": "hybrid_run_strength_foundation",
+    "program_family": "hybrid_run_strength",
+    "progression_model": "hybrid_beginner_balanced",
+    "fatigue_profile": "moderate",
+    "complexity": "moderate",
+    "tags": [
+      "hybrid",
+      "beginner",
+      "run",
+      "strength",
+      "mixed_friendly"
+    ],
+    "primary_goals": [
+      "hybrid_base",
+      "general_health"
+    ],
+    "secondary_goals": [
+      "fat_loss_support",
+      "habit",
+      "strength_support"
+    ],
+    "run_structure_type": "hybrid_support",
+    "impact_profile": "moderate",
+    "hybrid_profile": "balanced_run_strength",
+    "race_distance_support": [
+      "none",
+      "general_base"
+    ],
+    "event_capability": "none",
+    "taper_support": "none",
+    "long_run_support": "none",
+    "recommended_use_cases": [
+      "beginner_user",
+      "mixed_training",
+      "run_and_strength_same_week",
+      "three_sessions_total"
+    ],
+    "excluded_use_cases": [
+      "race_specific_running",
+      "hypertrophy_priority",
+      "high_frequency_running"
     ]
   },
   {
@@ -1387,6 +1501,49 @@
     "equipment_profiles": [
       "run_only",
       "hybrid_home"
+    ],
+    "training_style": "run_walk_reentry",
+    "program_family": "reentry_run",
+    "progression_model": "reentry_conservative",
+    "fatigue_profile": "low",
+    "complexity": "low",
+    "tags": [
+      "run",
+      "reentry",
+      "2x",
+      "low_impact",
+      "recovery_friendly"
+    ],
+    "primary_goals": [
+      "reentry",
+      "general_health"
+    ],
+    "secondary_goals": [
+      "habit",
+      "fat_loss_support",
+      "hybrid_support"
+    ],
+    "run_structure_type": "run_walk",
+    "impact_profile": "reentry_protective",
+    "hybrid_profile": "recovery_preserving",
+    "race_distance_support": [
+      "none"
+    ],
+    "event_capability": "none",
+    "taper_support": "none",
+    "long_run_support": "none",
+    "recommended_use_cases": [
+      "returning_after_break",
+      "low_running_tolerance",
+      "two_runs_per_week",
+      "low_impact_need",
+      "hybrid_training"
+    ],
+    "excluded_use_cases": [
+      "race_performance_goal",
+      "interval_priority",
+      "long_run_development",
+      "aggressive_distance_progression"
     ]
   },
   {
@@ -1440,6 +1597,47 @@
     "equipment_profiles": [
       "run_only",
       "hybrid_home"
+    ],
+    "training_style": "easy_base_foundation",
+    "program_family": "starter_run",
+    "progression_model": "duration_first",
+    "fatigue_profile": "moderate",
+    "complexity": "low",
+    "tags": [
+      "run",
+      "starter",
+      "3x",
+      "habit",
+      "base"
+    ],
+    "primary_goals": [
+      "habit",
+      "base_running"
+    ],
+    "secondary_goals": [
+      "general_health",
+      "fat_loss_support"
+    ],
+    "run_structure_type": "easy_base",
+    "impact_profile": "moderate",
+    "hybrid_profile": "hybrid_compatible",
+    "race_distance_support": [
+      "general_base",
+      "5k_base"
+    ],
+    "event_capability": "base_support",
+    "taper_support": "none",
+    "long_run_support": "none",
+    "recommended_use_cases": [
+      "beginner_runner",
+      "three_runs_per_week",
+      "habit_building",
+      "base_running"
+    ],
+    "excluded_use_cases": [
+      "return_to_running_after_break",
+      "race_performance_goal",
+      "long_run_development"
     ]
   },
   {
@@ -1514,6 +1712,40 @@
       "aerobic",
       "interval_progression",
       "long_run"
+    ],
+    "fatigue_profile": "moderate_to_high",
+    "complexity": "moderate",
+    "primary_goals": [
+      "base_running",
+      "performance_base"
+    ],
+    "secondary_goals": [
+      "general_health",
+      "fat_loss_support"
+    ],
+    "run_structure_type": "base_with_long_run",
+    "impact_profile": "moderate_high",
+    "hybrid_profile": "run_first",
+    "race_distance_support": [
+      "general_base",
+      "5k_base",
+      "10k_base"
+    ],
+    "event_capability": "base_support",
+    "taper_support": "none",
+    "long_run_support": "supportive",
+    "recommended_use_cases": [
+      "novice_runner",
+      "four_runs_per_week",
+      "aerobic_base",
+      "long_run_development",
+      "running_priority"
+    ],
+    "excluded_use_cases": [
+      "return_to_running_after_break",
+      "low_recovery_capacity",
+      "strength_priority_hybrid",
+      "low_impact_only"
     ]
   },
   {

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -92,6 +92,35 @@ Practical interpretation:
 These richer strength metadata fields are intentionally additive.
 They should support matching, explainability, and future UI copy without replacing the existing selector fields.
 
+Running and hybrid programs may also include running-specific metadata such as:
+- `run_structure_type`
+- `impact_profile`
+- `hybrid_profile`
+- `race_distance_support`
+- `event_capability`
+- `taper_support`
+- `long_run_support`
+- `primary_goals`
+- `secondary_goals`
+- `recommended_use_cases`
+- `excluded_use_cases`
+
+Practical interpretation:
+- `run_structure_type` describes the weekly/session shape of the running work
+- `impact_profile` describes expected mechanical impact and tissue-load cost
+- `hybrid_profile` describes how running should coexist with strength or mixed training
+- `race_distance_support` lists distance contexts the template can support
+- `event_capability` describes whether the template is generic, base-supporting, or event-oriented
+- `taper_support` describes whether the template can support tapering toward an event
+- `long_run_support` describes whether long-run development is absent, optional, supportive, or central
+- `primary_goals` names the main running or hybrid training intent
+- `secondary_goals` names useful but non-primary outcomes
+- `recommended_use_cases` gives concise machine-readable reasons the template is a good fit
+- `excluded_use_cases` gives concise machine-readable reasons the template should not be recommended
+
+These richer running metadata fields are intentionally additive.
+They should support matching, explainability, race-aware planning, and hybrid coordination without replacing the existing selector fields.
+
 ---
 
 

--- a/tests/test_running_template_metadata_schema_contract.py
+++ b/tests/test_running_template_metadata_schema_contract.py
@@ -1,0 +1,134 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROGRAMS = ROOT / "app/data/seed/programs.json"
+DATA_MODEL = ROOT / "docs/data-model.md"
+
+REQUIRED_CORE_METADATA = [
+    "training_style",
+    "program_family",
+    "progression_model",
+    "fatigue_profile",
+    "complexity",
+    "tags",
+]
+
+REQUIRED_RUNNING_METADATA = [
+    "primary_goals",
+    "secondary_goals",
+    "run_structure_type",
+    "impact_profile",
+    "hybrid_profile",
+    "race_distance_support",
+    "event_capability",
+    "taper_support",
+    "long_run_support",
+    "recommended_use_cases",
+    "excluded_use_cases",
+]
+
+VALID_IMPACT_PROFILES = {
+    "low",
+    "moderate",
+    "moderate_high",
+    "high",
+    "reentry_protective",
+}
+
+VALID_EVENT_CAPABILITY = {
+    "none",
+    "base_support",
+    "race_preparation",
+    "event_week_only",
+}
+
+VALID_TAPER_SUPPORT = {
+    "none",
+    "basic",
+    "structured",
+}
+
+VALID_LONG_RUN_SUPPORT = {
+    "none",
+    "optional",
+    "supportive",
+    "central",
+}
+
+VALID_HYBRID_PROFILES = {
+    "hybrid_compatible",
+    "balanced_run_strength",
+    "recovery_preserving",
+    "run_first",
+}
+
+
+def _run_or_hybrid_programs():
+    programs = json.loads(PROGRAMS.read_text())
+    return [
+        item
+        for item in programs
+        if isinstance(item, dict)
+        and str(item.get("kind", "")).strip().lower() in {"run", "hybrid"}
+    ]
+
+
+def test_run_and_hybrid_templates_have_core_metadata():
+    programs = _run_or_hybrid_programs()
+    assert programs, "No run or hybrid programs found"
+
+    for program in programs:
+        program_id = str(program.get("id", "")).strip()
+
+        for field in REQUIRED_CORE_METADATA:
+            value = program.get(field)
+            assert value not in (None, "", []), (program_id, field)
+
+        assert isinstance(program["tags"], list), program_id
+        assert all(str(x).strip() for x in program["tags"]), program_id
+
+
+def test_run_and_hybrid_templates_have_running_identity_metadata():
+    programs = _run_or_hybrid_programs()
+
+    for program in programs:
+        program_id = str(program.get("id", "")).strip()
+
+        for field in REQUIRED_RUNNING_METADATA:
+            value = program.get(field)
+            assert value not in (None, "", []), (program_id, field)
+
+        for field in [
+            "primary_goals",
+            "secondary_goals",
+            "race_distance_support",
+            "recommended_use_cases",
+            "excluded_use_cases",
+        ]:
+            assert isinstance(program[field], list), (program_id, field)
+            assert all(str(x).strip() for x in program[field]), (program_id, field)
+
+        assert program["impact_profile"] in VALID_IMPACT_PROFILES, program_id
+        assert program["event_capability"] in VALID_EVENT_CAPABILITY, program_id
+        assert program["taper_support"] in VALID_TAPER_SUPPORT, program_id
+        assert program["long_run_support"] in VALID_LONG_RUN_SUPPORT, program_id
+        assert program["hybrid_profile"] in VALID_HYBRID_PROFILES, program_id
+
+
+def test_running_metadata_schema_is_documented():
+    text = DATA_MODEL.read_text()
+
+    for field in REQUIRED_RUNNING_METADATA:
+        assert f"`{field}`" in text, field
+
+    assert "intentionally additive" in text
+    assert "race-aware planning" in text
+
+
+if __name__ == "__main__":
+    test_run_and_hybrid_templates_have_core_metadata()
+    test_run_and_hybrid_templates_have_running_identity_metadata()
+    test_running_metadata_schema_is_documented()
+    print("Running template metadata schema contract tests passed")


### PR DESCRIPTION
## Summary
Adds richer additive metadata to all run and hybrid program templates and documents the schema.

## Problem
Running templates need clearer identity signals for future matching, adaptation, race-aware planning, and hybrid coordination.

Existing run/hybrid templates had uneven metadata coverage and lacked explicit fields for impact, race support, taper support, long-run support, hybrid behavior, and recommendation/exclusion use cases.

## What changed
Added or completed core metadata for run/hybrid templates:
- `training_style`
- `program_family`
- `progression_model`
- `fatigue_profile`
- `complexity`
- `tags`

Added running-specific metadata:
- `primary_goals`
- `secondary_goals`
- `run_structure_type`
- `impact_profile`
- `hybrid_profile`
- `race_distance_support`
- `event_capability`
- `taper_support`
- `long_run_support`
- `recommended_use_cases`
- `excluded_use_cases`

Updated:
- `docs/data-model.md`

Added:
- `tests/test_running_template_metadata_schema_contract.py`

## Why
This makes running and hybrid templates more explainable and gives future recommendation, scheduling, race-aware, and hybrid-aware logic structured metadata to inspect instead of relying on fragile assumptions.

## Validation
- `python3 -m json.tool app/data/seed/programs.json`
- `python3 -m py_compile tests/test_running_template_metadata_schema_contract.py`
- `python3 tests/test_running_template_metadata_schema_contract.py`
- `git diff --check`

## Scope
- data/schema enrichment only
- docs update
- contract test
- no runtime changes
- no selector logic changes
- no UI changes