### PR TITLE
Add hybrid profile metadata for cross-domain templates

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -116,7 +116,19 @@
       "intermediate_strength_progression",
       "hypertrophy_priority",
       "high_frequency_training"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "strength",
+    "secondary_domain": "run",
+    "cross_domain_fatigue_sensitivity": "moderate",
+    "key_session_protection_needs": [
+      "protect_strength_progression",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "moderate",
+    "hybrid_progression_model": "strength_primary_run_secondary",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "base_strength_a",
@@ -224,7 +236,19 @@
       "reentry_after_break",
       "running_priority",
       "minimal_equipment_only"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "strength",
+    "secondary_domain": "run",
+    "cross_domain_fatigue_sensitivity": "high",
+    "key_session_protection_needs": [
+      "protect_strength_progression",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "high",
+    "hybrid_progression_model": "strength_primary_run_secondary",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "starter_run_2x",
@@ -315,7 +339,19 @@
       "race_performance_goal",
       "long_run_development",
       "interval_priority"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "run",
+    "secondary_domain": "strength",
+    "cross_domain_fatigue_sensitivity": "moderate",
+    "key_session_protection_needs": [
+      "protect_run_consistency",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "moderate",
+    "hybrid_progression_model": "run_primary_strength_compatible",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "base_run_3x",
@@ -417,7 +453,19 @@
       "return_to_running_after_break",
       "half_marathon_specific_build",
       "low_impact_only"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "run",
+    "secondary_domain": "strength",
+    "cross_domain_fatigue_sensitivity": "moderate",
+    "key_session_protection_needs": [
+      "protect_run_consistency",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "moderate",
+    "hybrid_progression_model": "run_primary_strength_compatible",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "mobility_basic",
@@ -671,7 +719,20 @@
       "reentry_after_break",
       "intermediate_strength_progression",
       "very_short_sessions"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "balanced",
+    "secondary_domain": "balanced",
+    "cross_domain_fatigue_sensitivity": "moderate",
+    "key_session_protection_needs": [
+      "protect_strength_quality",
+      "protect_run_quality",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "moderate",
+    "hybrid_progression_model": "balanced_conservative_progression",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "hybrid_run_strength_3x_beginner",
@@ -783,7 +844,20 @@
       "race_specific_running",
       "hypertrophy_priority",
       "high_frequency_running"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "balanced",
+    "secondary_domain": "balanced",
+    "cross_domain_fatigue_sensitivity": "moderate",
+    "key_session_protection_needs": [
+      "protect_run_quality",
+      "protect_strength_quality",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "moderate",
+    "hybrid_progression_model": "balanced_run_strength_progression",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "starter_strength_gym_2x",
@@ -900,7 +974,19 @@
       "intermediate_strength_progression",
       "hypertrophy_priority",
       "minimal_home_only"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "strength",
+    "secondary_domain": "run",
+    "cross_domain_fatigue_sensitivity": "moderate",
+    "key_session_protection_needs": [
+      "protect_strength_progression",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "moderate",
+    "hybrid_progression_model": "strength_primary_run_secondary",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "starter_strength_gym_3x",
@@ -1042,7 +1128,20 @@
       "reentry_after_break",
       "very_low_recovery",
       "minimal_home_only"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "balanced",
+    "secondary_domain": "balanced",
+    "cross_domain_fatigue_sensitivity": "moderate",
+    "key_session_protection_needs": [
+      "protect_strength_quality",
+      "protect_run_quality",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "moderate",
+    "hybrid_progression_model": "balanced_conservative_progression",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "reentry_strength_2x",
@@ -1166,7 +1265,20 @@
       "hypertrophy_priority",
       "aggressive_strength_progression",
       "high_frequency_training"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "recovery",
+    "secondary_domain": "strength_run",
+    "cross_domain_fatigue_sensitivity": "high",
+    "key_session_protection_needs": [
+      "protect_recovery",
+      "avoid_lower_body_conflict",
+      "preserve_consistency"
+    ],
+    "lower_body_conflict_sensitivity": "high",
+    "hybrid_progression_model": "recovery_first_conservative_progression",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "base_strength_gym_3x",
@@ -1298,7 +1410,19 @@
       "reentry_after_break",
       "running_priority",
       "low_recovery_capacity"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "strength",
+    "secondary_domain": "run",
+    "cross_domain_fatigue_sensitivity": "high",
+    "key_session_protection_needs": [
+      "protect_strength_progression",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "high",
+    "hybrid_progression_model": "strength_primary_run_secondary",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "base_strength_gym_4x",
@@ -1458,7 +1582,19 @@
       "running_priority",
       "low_recovery_capacity",
       "very_short_sessions"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "strength",
+    "secondary_domain": "run",
+    "cross_domain_fatigue_sensitivity": "high",
+    "key_session_protection_needs": [
+      "protect_strength_progression",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "high",
+    "hybrid_progression_model": "strength_primary_run_secondary",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "reentry_run_2x",
@@ -1544,7 +1680,20 @@
       "interval_priority",
       "long_run_development",
       "aggressive_distance_progression"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "recovery",
+    "secondary_domain": "strength_run",
+    "cross_domain_fatigue_sensitivity": "high",
+    "key_session_protection_needs": [
+      "protect_recovery",
+      "avoid_lower_body_conflict",
+      "preserve_consistency"
+    ],
+    "lower_body_conflict_sensitivity": "high",
+    "hybrid_progression_model": "recovery_first_conservative_progression",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "starter_run_3x_beginner",
@@ -1638,7 +1787,19 @@
       "return_to_running_after_break",
       "race_performance_goal",
       "long_run_development"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "run",
+    "secondary_domain": "strength",
+    "cross_domain_fatigue_sensitivity": "moderate",
+    "key_session_protection_needs": [
+      "protect_run_consistency",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "moderate",
+    "hybrid_progression_model": "run_primary_strength_compatible",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "base_run_4x",
@@ -1746,7 +1907,20 @@
       "low_recovery_capacity",
       "strength_priority_hybrid",
       "low_impact_only"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "run",
+    "secondary_domain": "strength",
+    "cross_domain_fatigue_sensitivity": "high",
+    "key_session_protection_needs": [
+      "protect_key_runs",
+      "protect_long_run",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "high",
+    "hybrid_progression_model": "run_primary_strength_secondary",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "hybrid_run_strength_2x_beginner",
@@ -1808,7 +1982,20 @@
       "run_first",
       "home",
       "mixed_friendly"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "balanced",
+    "secondary_domain": "balanced",
+    "cross_domain_fatigue_sensitivity": "moderate",
+    "key_session_protection_needs": [
+      "protect_run_quality",
+      "protect_strength_quality",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "moderate",
+    "hybrid_progression_model": "balanced_hybrid_progression",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "base_strength_home_2x",
@@ -1913,7 +2100,20 @@
       "reentry_after_break",
       "barbell_strength_priority",
       "hypertrophy_priority"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "balanced",
+    "secondary_domain": "balanced",
+    "cross_domain_fatigue_sensitivity": "moderate",
+    "key_session_protection_needs": [
+      "protect_strength_quality",
+      "protect_run_quality",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "moderate",
+    "hybrid_progression_model": "balanced_conservative_progression",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "base_strength_home_3x",
@@ -2043,7 +2243,20 @@
       "reentry_after_break",
       "barbell_strength_priority",
       "low_recovery_capacity"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "balanced",
+    "secondary_domain": "balanced",
+    "cross_domain_fatigue_sensitivity": "moderate",
+    "key_session_protection_needs": [
+      "protect_strength_quality",
+      "protect_run_quality",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "moderate",
+    "hybrid_progression_model": "balanced_conservative_progression",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "minimalist_strength_2x",
@@ -2162,7 +2375,20 @@
       "hypertrophy_priority",
       "high_volume_training",
       "aggressive_strength_progression"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "recovery",
+    "secondary_domain": "strength_run",
+    "cross_domain_fatigue_sensitivity": "high",
+    "key_session_protection_needs": [
+      "protect_recovery",
+      "avoid_lower_body_conflict",
+      "preserve_consistency"
+    ],
+    "lower_body_conflict_sensitivity": "high",
+    "hybrid_progression_model": "recovery_first_conservative_progression",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "intermediate_home_3x",
@@ -2297,7 +2523,19 @@
       "reentry_after_break",
       "running_priority",
       "minimal_equipment_only"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "strength",
+    "secondary_domain": "run",
+    "cross_domain_fatigue_sensitivity": "high",
+    "key_session_protection_needs": [
+      "protect_strength_progression",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "high",
+    "hybrid_progression_model": "strength_primary_run_secondary",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "intermediate_upper_lower_4x",
@@ -2458,7 +2696,19 @@
       "reentry_after_break",
       "running_priority",
       "low_recovery_capacity"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "strength",
+    "secondary_domain": "run",
+    "cross_domain_fatigue_sensitivity": "high",
+    "key_session_protection_needs": [
+      "protect_strength_progression",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "high",
+    "hybrid_progression_model": "strength_primary_run_secondary",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   },
   {
     "id": "intermediate_hypertrophy_4x",
@@ -2620,6 +2870,18 @@
       "running_priority",
       "low_recovery_capacity",
       "minimalist_training"
-    ]
+    ],
+    "hybrid_enabled": true,
+    "primary_domain": "strength",
+    "secondary_domain": "run",
+    "cross_domain_fatigue_sensitivity": "high",
+    "key_session_protection_needs": [
+      "protect_strength_progression",
+      "avoid_lower_body_conflict"
+    ],
+    "lower_body_conflict_sensitivity": "high",
+    "hybrid_progression_model": "strength_primary_run_secondary",
+    "supports_cross_domain_schedule_protection": true,
+    "supports_cross_domain_reduced_day_logic": true
   }
 ]

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -121,6 +121,31 @@ Practical interpretation:
 These richer running metadata fields are intentionally additive.
 They should support matching, explainability, race-aware planning, and hybrid coordination without replacing the existing selector fields.
 
+Hybrid-relevant strength, running, and mixed programs may also include explicit cross-domain coordination metadata such as:
+- `hybrid_enabled`
+- `primary_domain`
+- `secondary_domain`
+- `cross_domain_fatigue_sensitivity`
+- `key_session_protection_needs`
+- `lower_body_conflict_sensitivity`
+- `hybrid_progression_model`
+- `supports_cross_domain_schedule_protection`
+- `supports_cross_domain_reduced_day_logic`
+
+Practical interpretation:
+- `hybrid_enabled` marks that the template can participate in cross-domain planning
+- `primary_domain` describes the domain that should receive priority protection
+- `secondary_domain` describes the supporting or coordinated domain
+- `cross_domain_fatigue_sensitivity` describes how strongly fatigue in one domain should affect the other
+- `key_session_protection_needs` lists the session qualities that future scheduling should protect
+- `lower_body_conflict_sensitivity` describes how carefully lower-body strength and running stress should be coordinated
+- `hybrid_progression_model` describes the template-level progression relationship between domains
+- `supports_cross_domain_schedule_protection` marks templates that can support future scheduling protection logic
+- `supports_cross_domain_reduced_day_logic` marks templates that can support future reduced-day logic across domains
+
+These hybrid metadata fields are intentionally additive.
+They should support future recommendation, scheduling, adaptation, and explanation logic without changing current runtime behavior.
+
 ---
 
 

--- a/tests/test_hybrid_profile_metadata_contract.py
+++ b/tests/test_hybrid_profile_metadata_contract.py
@@ -1,0 +1,111 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROGRAMS = ROOT / "app/data/seed/programs.json"
+DATA_MODEL = ROOT / "docs/data-model.md"
+
+REQUIRED_HYBRID_METADATA = [
+    "hybrid_enabled",
+    "primary_domain",
+    "secondary_domain",
+    "cross_domain_fatigue_sensitivity",
+    "key_session_protection_needs",
+    "lower_body_conflict_sensitivity",
+    "hybrid_progression_model",
+    "supports_cross_domain_schedule_protection",
+    "supports_cross_domain_reduced_day_logic",
+]
+
+VALID_PRIMARY_DOMAINS = {
+    "strength",
+    "run",
+    "balanced",
+    "recovery",
+}
+
+VALID_SECONDARY_DOMAINS = {
+    "strength",
+    "run",
+    "balanced",
+    "strength_run",
+}
+
+VALID_SENSITIVITY = {
+    "low",
+    "moderate",
+    "high",
+}
+
+
+def _programs():
+    return json.loads(PROGRAMS.read_text())
+
+
+def _hybrid_metadata_targets():
+    return [
+        item
+        for item in _programs()
+        if isinstance(item, dict)
+        and str(item.get("kind", "")).strip().lower() not in {"mobility", "recovery"}
+        and (
+            str(item.get("hybrid_profile", "")).strip()
+            or str(item.get("kind", "")).strip().lower() in {"hybrid", "mixed"}
+        )
+    ]
+
+
+def test_hybrid_relevant_templates_have_cross_domain_metadata():
+    programs = _hybrid_metadata_targets()
+    assert programs, "No hybrid metadata targets found"
+
+    for program in programs:
+        program_id = str(program.get("id", "")).strip()
+
+        for field in REQUIRED_HYBRID_METADATA:
+            value = program.get(field)
+            assert value not in (None, "", []), (program_id, field)
+
+        assert program["hybrid_enabled"] is True, program_id
+        assert program["supports_cross_domain_schedule_protection"] is True, program_id
+        assert program["supports_cross_domain_reduced_day_logic"] is True, program_id
+        assert program["primary_domain"] in VALID_PRIMARY_DOMAINS, program_id
+        assert program["secondary_domain"] in VALID_SECONDARY_DOMAINS, program_id
+        assert program["cross_domain_fatigue_sensitivity"] in VALID_SENSITIVITY, program_id
+        assert program["lower_body_conflict_sensitivity"] in VALID_SENSITIVITY, program_id
+        assert isinstance(program["key_session_protection_needs"], list), program_id
+        assert all(str(x).strip() for x in program["key_session_protection_needs"]), program_id
+
+
+def test_mobility_and_recovery_are_not_forced_into_hybrid_schema():
+    support_templates = [
+        item
+        for item in _programs()
+        if isinstance(item, dict)
+        and str(item.get("kind", "")).strip().lower() in {"mobility", "recovery"}
+    ]
+
+    assert support_templates, "No mobility or recovery support templates found"
+
+    for program in support_templates:
+        program_id = str(program.get("id", "")).strip()
+        for field in REQUIRED_HYBRID_METADATA:
+            assert field not in program, (program_id, field)
+
+
+def test_hybrid_metadata_schema_is_documented():
+    text = DATA_MODEL.read_text()
+
+    for field in REQUIRED_HYBRID_METADATA:
+        assert f"`{field}`" in text, field
+
+    assert "intentionally additive" in text
+    assert "without changing current runtime behavior" in text
+
+
+if __name__ == "__main__":
+    test_hybrid_relevant_templates_have_cross_domain_metadata()
+    test_mobility_and_recovery_are_not_forced_into_hybrid_schema()
+    test_hybrid_metadata_schema_is_documented()
+    print("Hybrid profile metadata contract tests passed")


### PR DESCRIPTION
## Summary
Adds explicit cross-domain hybrid metadata to hybrid-relevant strength, running, hybrid, and mixed templates.

## Problem
Hybrid templates and hybrid-compatible templates need explicit coordination metadata so future recommendation, scheduling, adaptation, and explanation logic can distinguish:
- strength-first templates
- run-first templates
- balanced hybrid templates
- recovery-preserving hybrid templates
- mixed run/strength templates

Without this metadata, hybrid templates risk being treated as pure strength or pure running templates with extra sessions attached.

## What changed
Added hybrid coordination metadata to 21 hybrid-relevant templates:
- `hybrid_enabled`
- `primary_domain`
- `secondary_domain`
- `cross_domain_fatigue_sensitivity`
- `key_session_protection_needs`
- `lower_body_conflict_sensitivity`
- `hybrid_progression_model`
- `supports_cross_domain_schedule_protection`
- `supports_cross_domain_reduced_day_logic`

Updated:
- `docs/data-model.md`

Added:
- `tests/test_hybrid_profile_metadata_contract.py`

## Important scope note
Mobility and recovery support templates were intentionally not forced into the hybrid schema, even though they may be usable in hybrid contexts.

## Validation
- `python3 -m json.tool app/data/seed/programs.json`
- `python3 -m py_compile tests/test_hybrid_profile_metadata_contract.py`
- `python3 tests/test_hybrid_profile_metadata_contract.py`
- `git diff --check`
- checked that no programs or existing fields were removed

## Scope
- data/schema enrichment only
- docs update
- contract test
- no runtime changes
- no selector logic changes
- no UI changes