### PR TITLE
Add event capability metadata for race-aware templates

### DIFF
--- a/app/data/seed/programs.json
+++ b/app/data/seed/programs.json
@@ -351,7 +351,16 @@
     "lower_body_conflict_sensitivity": "moderate",
     "hybrid_progression_model": "run_primary_strength_compatible",
     "supports_cross_domain_schedule_protection": true,
-    "supports_cross_domain_reduced_day_logic": true
+    "supports_cross_domain_reduced_day_logic": true,
+    "supports_event_target": false,
+    "supported_event_types": [],
+    "event_date_required_for_full_behavior": false,
+    "supports_phase_shift": false,
+    "supports_taper": false,
+    "supports_strength_adjustment_around_event": false,
+    "supports_hybrid_event_coordination": false,
+    "event_priority_behavior": "ignore_event",
+    "race_specificity_level": "none"
   },
   {
     "id": "base_run_3x",
@@ -465,7 +474,18 @@
     "lower_body_conflict_sensitivity": "moderate",
     "hybrid_progression_model": "run_primary_strength_compatible",
     "supports_cross_domain_schedule_protection": true,
-    "supports_cross_domain_reduced_day_logic": true
+    "supports_cross_domain_reduced_day_logic": true,
+    "supports_event_target": true,
+    "supported_event_types": [
+      "5k"
+    ],
+    "event_date_required_for_full_behavior": false,
+    "supports_phase_shift": false,
+    "supports_taper": false,
+    "supports_strength_adjustment_around_event": false,
+    "supports_hybrid_event_coordination": false,
+    "event_priority_behavior": "base_support_optional",
+    "race_specificity_level": "optional"
   },
   {
     "id": "mobility_basic",
@@ -857,7 +877,16 @@
     "lower_body_conflict_sensitivity": "moderate",
     "hybrid_progression_model": "balanced_run_strength_progression",
     "supports_cross_domain_schedule_protection": true,
-    "supports_cross_domain_reduced_day_logic": true
+    "supports_cross_domain_reduced_day_logic": true,
+    "supports_event_target": false,
+    "supported_event_types": [],
+    "event_date_required_for_full_behavior": false,
+    "supports_phase_shift": false,
+    "supports_taper": false,
+    "supports_strength_adjustment_around_event": false,
+    "supports_hybrid_event_coordination": false,
+    "event_priority_behavior": "ignore_event",
+    "race_specificity_level": "none"
   },
   {
     "id": "starter_strength_gym_2x",
@@ -1693,7 +1722,16 @@
     "lower_body_conflict_sensitivity": "high",
     "hybrid_progression_model": "recovery_first_conservative_progression",
     "supports_cross_domain_schedule_protection": true,
-    "supports_cross_domain_reduced_day_logic": true
+    "supports_cross_domain_reduced_day_logic": true,
+    "supports_event_target": false,
+    "supported_event_types": [],
+    "event_date_required_for_full_behavior": false,
+    "supports_phase_shift": false,
+    "supports_taper": false,
+    "supports_strength_adjustment_around_event": false,
+    "supports_hybrid_event_coordination": false,
+    "event_priority_behavior": "ignore_event",
+    "race_specificity_level": "none"
   },
   {
     "id": "starter_run_3x_beginner",
@@ -1799,7 +1837,18 @@
     "lower_body_conflict_sensitivity": "moderate",
     "hybrid_progression_model": "run_primary_strength_compatible",
     "supports_cross_domain_schedule_protection": true,
-    "supports_cross_domain_reduced_day_logic": true
+    "supports_cross_domain_reduced_day_logic": true,
+    "supports_event_target": true,
+    "supported_event_types": [
+      "5k"
+    ],
+    "event_date_required_for_full_behavior": false,
+    "supports_phase_shift": false,
+    "supports_taper": false,
+    "supports_strength_adjustment_around_event": false,
+    "supports_hybrid_event_coordination": false,
+    "event_priority_behavior": "base_support_optional",
+    "race_specificity_level": "optional"
   },
   {
     "id": "base_run_4x",
@@ -1920,7 +1969,19 @@
     "lower_body_conflict_sensitivity": "high",
     "hybrid_progression_model": "run_primary_strength_secondary",
     "supports_cross_domain_schedule_protection": true,
-    "supports_cross_domain_reduced_day_logic": true
+    "supports_cross_domain_reduced_day_logic": true,
+    "supports_event_target": true,
+    "supported_event_types": [
+      "5k",
+      "10k"
+    ],
+    "event_date_required_for_full_behavior": false,
+    "supports_phase_shift": false,
+    "supports_taper": false,
+    "supports_strength_adjustment_around_event": false,
+    "supports_hybrid_event_coordination": false,
+    "event_priority_behavior": "base_support_optional",
+    "race_specificity_level": "optional"
   },
   {
     "id": "hybrid_run_strength_2x_beginner",
@@ -1995,7 +2056,16 @@
     "lower_body_conflict_sensitivity": "moderate",
     "hybrid_progression_model": "balanced_hybrid_progression",
     "supports_cross_domain_schedule_protection": true,
-    "supports_cross_domain_reduced_day_logic": true
+    "supports_cross_domain_reduced_day_logic": true,
+    "supports_event_target": false,
+    "supported_event_types": [],
+    "event_date_required_for_full_behavior": false,
+    "supports_phase_shift": false,
+    "supports_taper": false,
+    "supports_strength_adjustment_around_event": false,
+    "supports_hybrid_event_coordination": false,
+    "event_priority_behavior": "ignore_event",
+    "race_specificity_level": "none"
   },
   {
     "id": "base_strength_home_2x",

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -146,6 +146,31 @@ Practical interpretation:
 These hybrid metadata fields are intentionally additive.
 They should support future recommendation, scheduling, adaptation, and explanation logic without changing current runtime behavior.
 
+Running, hybrid, and mixed programs may also include explicit event-capability metadata such as:
+- `supports_event_target`
+- `supported_event_types`
+- `event_date_required_for_full_behavior`
+- `supports_phase_shift`
+- `supports_taper`
+- `supports_strength_adjustment_around_event`
+- `supports_hybrid_event_coordination`
+- `event_priority_behavior`
+- `race_specificity_level`
+
+Practical interpretation:
+- `supports_event_target` marks whether the template should react to a user-specified race or event target
+- `supported_event_types` lists supported event distances such as `5k`, `10k`, or `half_marathon`
+- `event_date_required_for_full_behavior` marks whether full behavior depends on a known event date
+- `supports_phase_shift` marks whether the template can support future build/peak/taper phase logic
+- `supports_taper` marks whether taper behavior can be applied safely
+- `supports_strength_adjustment_around_event` marks whether strength work can be adjusted around a running event
+- `supports_hybrid_event_coordination` marks whether cross-domain coordination can react to event proximity
+- `event_priority_behavior` describes how strongly event context should influence selection or adaptation
+- `race_specificity_level` describes whether race-awareness is `none`, `optional`, or `strong`
+
+These event-capability fields are intentionally additive.
+They should allow future race-aware behavior to apply selectively without leaking taper or event logic into general-purpose templates.
+
 ---
 
 

--- a/tests/test_event_capability_metadata_contract.py
+++ b/tests/test_event_capability_metadata_contract.py
@@ -1,0 +1,120 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROGRAMS = ROOT / "app/data/seed/programs.json"
+DATA_MODEL = ROOT / "docs/data-model.md"
+
+REQUIRED_EVENT_METADATA = [
+    "supports_event_target",
+    "supported_event_types",
+    "event_date_required_for_full_behavior",
+    "supports_phase_shift",
+    "supports_taper",
+    "supports_strength_adjustment_around_event",
+    "supports_hybrid_event_coordination",
+    "event_priority_behavior",
+    "race_specificity_level",
+]
+
+VALID_EVENT_TYPES = {
+    "5k",
+    "10k",
+    "half_marathon",
+}
+
+VALID_EVENT_PRIORITY_BEHAVIOR = {
+    "ignore_event",
+    "base_support_optional",
+    "event_target_optional",
+    "event_target_required",
+}
+
+VALID_RACE_SPECIFICITY_LEVEL = {
+    "none",
+    "optional",
+    "strong",
+}
+
+
+def _programs():
+    return json.loads(PROGRAMS.read_text())
+
+
+def _event_capability_targets():
+    return [
+        item
+        for item in _programs()
+        if isinstance(item, dict)
+        and str(item.get("kind", "")).strip().lower() in {"run", "hybrid", "mixed"}
+    ]
+
+
+def test_run_hybrid_and_mixed_templates_declare_event_capability():
+    programs = _event_capability_targets()
+    assert programs, "No event-capability templates found"
+
+    for program in programs:
+        program_id = str(program.get("id", "")).strip()
+
+        for field in REQUIRED_EVENT_METADATA:
+            assert field in program, (program_id, field)
+
+        assert isinstance(program["supports_event_target"], bool), program_id
+        assert isinstance(program["supported_event_types"], list), program_id
+        assert isinstance(program["event_date_required_for_full_behavior"], bool), program_id
+        assert isinstance(program["supports_phase_shift"], bool), program_id
+        assert isinstance(program["supports_taper"], bool), program_id
+        assert isinstance(program["supports_strength_adjustment_around_event"], bool), program_id
+        assert isinstance(program["supports_hybrid_event_coordination"], bool), program_id
+
+        for event_type in program["supported_event_types"]:
+            assert event_type in VALID_EVENT_TYPES, (program_id, event_type)
+
+        assert program["event_priority_behavior"] in VALID_EVENT_PRIORITY_BEHAVIOR, program_id
+        assert program["race_specificity_level"] in VALID_RACE_SPECIFICITY_LEVEL, program_id
+
+
+def test_non_event_templates_do_not_claim_taper_or_phase_behavior():
+    programs = _event_capability_targets()
+
+    for program in programs:
+        program_id = str(program.get("id", "")).strip()
+        if program["race_specificity_level"] == "none":
+            assert program["supports_event_target"] is False, program_id
+            assert program["supported_event_types"] == [], program_id
+            assert program["supports_phase_shift"] is False, program_id
+            assert program["supports_taper"] is False, program_id
+            assert program["event_priority_behavior"] == "ignore_event", program_id
+
+
+def test_base_support_templates_are_event_optional_and_non_tapering():
+    programs = _event_capability_targets()
+
+    for program in programs:
+        program_id = str(program.get("id", "")).strip()
+        if program["race_specificity_level"] == "optional":
+            assert program["supports_event_target"] is True, program_id
+            assert program["supported_event_types"], program_id
+            assert program["event_date_required_for_full_behavior"] is False, program_id
+            assert program["supports_taper"] is False, program_id
+            assert program["event_priority_behavior"] == "base_support_optional", program_id
+
+
+def test_event_capability_schema_is_documented():
+    text = DATA_MODEL.read_text()
+
+    for field in REQUIRED_EVENT_METADATA:
+        assert f"`{field}`" in text, field
+
+    assert "These event-capability fields are intentionally additive." in text
+    assert "without leaking taper or event logic into general-purpose templates" in text
+
+
+if __name__ == "__main__":
+    test_run_hybrid_and_mixed_templates_declare_event_capability()
+    test_non_event_templates_do_not_claim_taper_or_phase_behavior()
+    test_base_support_templates_are_event_optional_and_non_tapering()
+    test_event_capability_schema_is_documented()
+    print("Event capability metadata contract tests passed")


### PR DESCRIPTION
## Summary
Adds explicit event-capability metadata to all run, hybrid, and mixed templates.

## Problem
Race-aware behavior should only apply where templates explicitly support it. Without event-capability metadata, future taper, phase-shift, and race-specific logic could leak into general-purpose starter, base, re-entry, or hybrid templates.

## What changed
Added event-capability metadata:
- `supports_event_target`
- `supported_event_types`
- `event_date_required_for_full_behavior`
- `supports_phase_shift`
- `supports_taper`
- `supports_strength_adjustment_around_event`
- `supports_hybrid_event_coordination`
- `event_priority_behavior`
- `race_specificity_level`

Updated:
- `docs/data-model.md`

Added:
- `tests/test_event_capability_metadata_contract.py`

## Validation
- `python3 -m json.tool app/data/seed/programs.json`
- `python3 -m py_compile tests/test_event_capability_metadata_contract.py`
- `python3 tests/test_event_capability_metadata_contract.py`
- `git diff --check`
- checked that no programs or existing fields were removed

## Scope
- data/schema enrichment only
- docs update
- contract test
- no runtime changes
- no planner changes
- no selector logic changes
- no UI changes