### PR TITLE
Fix recovery pressure override in progression decisions

### DIFF
--- a/app/backend/progression_engine.py
+++ b/app/backend/progression_engine.py
@@ -716,6 +716,14 @@ def decide_progression_from_context(exercise_id, ctx):
                     progression_reason = "gentagen succes i kalibrering"
                 else:
                     progression_reason = "gentagen succes i stabil trend"
+
+                if recent_recovery_ctx.get("multi_session_fatigue_pressure") == "high":
+                    next_load = int(first_set_load)
+                    decision = "hold"
+                    progression_reason = (
+                        "gentagen dårlig recovery over seneste check-ins "
+                        "overrulede ellers positivt progressionssignal"
+                    )
         else:
             next_load = int(first_set_load)
             decision = "hold"

--- a/tests/test_progression_phase_scenarios.py
+++ b/tests/test_progression_phase_scenarios.py
@@ -27,7 +27,7 @@ def make_strength_session(date, created_at, exercise_id, reps, load, *, hit_fail
     }
 
 
-def run_strength_progression_scenario(*, session_results, reps=8, load=100.0, fatigue_score=0):
+def run_strength_progression_scenario(*, session_results, reps=8, load=100.0, fatigue_score=0, recent_recovery_ctx=None):
     latest_result, latest_session = backend_app.find_latest_session_result_for_exercise(session_results, "bench_press")
     analysis = backend_app.analyze_session_result_for_progression(latest_result)
 
@@ -49,6 +49,7 @@ def run_strength_progression_scenario(*, session_results, reps=8, load=100.0, fa
         "fatigue_score": fatigue_score,
         "last_load": int(load),
         "last_entry": {"reps": "6-8", "achieved_reps": str(reps)},
+        "recent_recovery_ctx": recent_recovery_ctx or {},
     }
 
     out = backend_app.decide_progression_from_context("bench_press", ctx)
@@ -59,8 +60,8 @@ def run_strength_progression_scenario(*, session_results, reps=8, load=100.0, fa
 def test_calibration_requires_repeated_success():
     session_results = [
         make_strength_session(
-            "2026-03-17",
-            "2026-03-17T06:41:23+00:00",
+            "2026-04-24",
+            "2026-04-24T06:41:23+00:00",
             "bench_press",
             8,
             100,
@@ -78,9 +79,9 @@ def test_calibration_requires_repeated_success():
 
 def test_trend_allows_progression_after_repeated_success():
     session_results = [
-        make_strength_session("2026-03-10", "2026-03-10T06:00:00+00:00", "bench_press", 8, 96),
-        make_strength_session("2026-03-13", "2026-03-13T06:00:00+00:00", "bench_press", 8, 98),
-        make_strength_session("2026-03-17", "2026-03-17T06:00:00+00:00", "bench_press", 8, 100),
+        make_strength_session("2026-04-18", "2026-04-18T06:00:00+00:00", "bench_press", 8, 96),
+        make_strength_session("2026-04-21", "2026-04-21T06:00:00+00:00", "bench_press", 8, 98),
+        make_strength_session("2026-04-24", "2026-04-24T06:00:00+00:00", "bench_press", 8, 100),
     ]
 
     out = run_strength_progression_scenario(session_results=session_results)
@@ -92,11 +93,42 @@ def test_trend_allows_progression_after_repeated_success():
     assert out["next_load"] == 102, out
 
 
+
+
+def test_high_multi_session_fatigue_pressure_downgrades_increase_to_hold():
+    session_results = [
+        make_strength_session("2026-04-18", "2026-04-18T06:00:00+00:00", "bench_press", 8, 96),
+        make_strength_session("2026-04-21", "2026-04-21T06:00:00+00:00", "bench_press", 8, 98),
+        make_strength_session("2026-04-24", "2026-04-24T06:00:00+00:00", "bench_press", 8, 100),
+    ]
+
+    out = run_strength_progression_scenario(
+        session_results=session_results,
+        recent_recovery_ctx={
+            "multi_session_fatigue_pressure": "high",
+            "multi_session_fatigue_reason": "gentagne lave recovery-scores",
+            "recent_checkin_count": 3,
+            "poor_recovery_count": 2,
+            "latest_readiness_score": 3,
+        },
+    )
+
+    assert out["progression_phase"] == "trend", out
+    assert out["trend_repeated_success"] is True, out
+    assert out["progression_decision"] == "hold", out
+    assert out["next_load"] == 100, out
+    assert out["multi_session_fatigue_pressure"] == "high", out
+    assert out["multi_session_fatigue_reason"] == "gentagne lave recovery-scores", out
+    assert (
+        out["progression_reason"]
+        == "gentagen dårlig recovery over seneste check-ins overrulede ellers positivt progressionssignal"
+    ), out
+
 def test_trend_blocks_progression_when_failure_exists_in_window():
     session_results = [
-        make_strength_session("2026-03-10", "2026-03-10T06:00:00+00:00", "bench_press", 8, 96),
-        make_strength_session("2026-03-13", "2026-03-13T06:00:00+00:00", "bench_press", 8, 98, hit_failure=True),
-        make_strength_session("2026-03-17", "2026-03-17T06:00:00+00:00", "bench_press", 8, 100),
+        make_strength_session("2026-04-18", "2026-04-18T06:00:00+00:00", "bench_press", 8, 96),
+        make_strength_session("2026-04-21", "2026-04-21T06:00:00+00:00", "bench_press", 8, 98, hit_failure=True),
+        make_strength_session("2026-04-24", "2026-04-24T06:00:00+00:00", "bench_press", 8, 100),
     ]
 
     out = run_strength_progression_scenario(session_results=session_results)
@@ -124,9 +156,9 @@ def test_recalibration_blocks_progression_after_long_pause():
 
 def test_trend_at_minimum_threshold_without_repeated_success_holds():
     session_results = [
-        make_strength_session("2026-03-10", "2026-03-10T06:00:00+00:00", "bench_press", 7, 96),
-        make_strength_session("2026-03-13", "2026-03-13T06:00:00+00:00", "bench_press", 8, 98),
-        make_strength_session("2026-03-17", "2026-03-17T06:00:00+00:00", "bench_press", 8, 100),
+        make_strength_session("2026-04-18", "2026-04-18T06:00:00+00:00", "bench_press", 7, 96),
+        make_strength_session("2026-04-21", "2026-04-21T06:00:00+00:00", "bench_press", 8, 98),
+        make_strength_session("2026-04-24", "2026-04-24T06:00:00+00:00", "bench_press", 8, 100),
     ]
 
     out = run_strength_progression_scenario(session_results=session_results)
@@ -140,9 +172,9 @@ def test_trend_at_minimum_threshold_without_repeated_success_holds():
 
 def test_trend_blocks_progression_when_load_drop_exists_in_window():
     session_results = [
-        make_strength_session("2026-03-10", "2026-03-10T06:00:00+00:00", "bench_press", 8, 96),
-        make_strength_session("2026-03-13", "2026-03-13T06:00:00+00:00", "bench_press", 8, 98, load_drop=True),
-        make_strength_session("2026-03-17", "2026-03-17T06:00:00+00:00", "bench_press", 8, 100),
+        make_strength_session("2026-04-18", "2026-04-18T06:00:00+00:00", "bench_press", 8, 96),
+        make_strength_session("2026-04-21", "2026-04-21T06:00:00+00:00", "bench_press", 8, 98, load_drop=True),
+        make_strength_session("2026-04-24", "2026-04-24T06:00:00+00:00", "bench_press", 8, 100),
     ]
 
     out = run_strength_progression_scenario(session_results=session_results)
@@ -156,9 +188,9 @@ def test_trend_blocks_progression_when_load_drop_exists_in_window():
 
 def test_trend_recommends_deload_after_repeated_failures():
     session_results = [
-        make_strength_session("2026-03-10", "2026-03-10T06:00:00+00:00", "bench_press", 8, 96, hit_failure=True),
-        make_strength_session("2026-03-13", "2026-03-13T06:00:00+00:00", "bench_press", 8, 98, hit_failure=True),
-        make_strength_session("2026-03-17", "2026-03-17T06:00:00+00:00", "bench_press", 8, 100),
+        make_strength_session("2026-04-18", "2026-04-18T06:00:00+00:00", "bench_press", 8, 96, hit_failure=True),
+        make_strength_session("2026-04-21", "2026-04-21T06:00:00+00:00", "bench_press", 8, 98, hit_failure=True),
+        make_strength_session("2026-04-24", "2026-04-24T06:00:00+00:00", "bench_press", 8, 100),
     ]
 
     out = run_strength_progression_scenario(session_results=session_results)


### PR DESCRIPTION
## Summary

Fixes #89.

This PR makes the progression engine use existing recent recovery context when deciding whether to increase load.

Previously, `recent_recovery_ctx.multi_session_fatigue_pressure` was returned in progression metadata, but did not affect the progression decision itself. That meant an exercise could still progress even when recent check-ins showed repeated poor recovery. Elegant, in the same way ignoring a smoke alarm is “minimalist interior design”.

Now, when the normal trend logic would allow `increase`, but recent recovery context reports `multi_session_fatigue_pressure == "high"`, the decision is downgraded to `hold`, and the next load stays at the current load.

## Changed

- Updated `decide_progression_from_context(...)`.
- Added a high recovery-pressure override after an otherwise valid `increase` decision.
- Kept existing guards intact:
  - failure
  - load-drop
  - acute fatigue score
  - recalibration
  - equipment constraint
  - jump guard
- Added regression coverage for the high-pressure override case.
- Extended the progression phase test helper so tests can pass `recent_recovery_ctx`.
- Updated time-sensitive test dates in `test_progression_phase_scenarios.py` from March to April 2026 so relevant scenarios remain in `calibration` / `trend` instead of drifting into `recalibration`.

## Behavior

If repeated success would normally increase load, but recent recovery pressure is high, the final result becomes:

- `progression_decision = "hold"`
- `next_load = current load`

The returned `progression_reason` now explains that repeated poor recovery over recent check-ins overruled the otherwise positive progression signal.

## Validation

Passed:

- `python -m py_compile app/backend/progression_engine.py tests/test_progression_phase_scenarios.py`
- `python -m pytest tests/test_progression_phase_scenarios.py::test_high_multi_session_fatigue_pressure_downgrades_increase_to_hold -q`

Result:

- `1 passed`

## Known existing test debt

A broader related test run still has existing failures outside the scope of this PR:

- `python -m pytest tests/test_progression_phase_scenarios.py tests/test_progression_equipment_constraints.py -q`
- observed result: `4 failed, 7 passed`

Those failures appear to reflect older test expectations that no longer match the current phase/trend-gated progression behavior:

- one historical failure or load-drop no longer blocks progression unless it is the latest blocking signal or part of repeated negative signals;
- equipment constraint tests do not provide enough session history to reach the current `trend` progression path.

This PR does not change that broader behavior.