### PR TITLE
Fix manual override session source

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -8547,6 +8547,19 @@ async function handleRecoverySubmit(ev){
 }
 
 
+function getSessionResultSourceForPlan(plan){
+  const raw = String(plan?.source || "").trim();
+  if (raw === "manual_override") return "manual_override";
+  if (raw === "manual") return "manual";
+  if (raw === "autoplan") return "autoplan";
+
+  const variant = String(plan?.plan_variant || "").trim();
+  if (variant === "manual_override") return "manual_override";
+
+  return "autoplan";
+}
+
+
 async function handleSessionResultSubmit(ev){
   ev.preventDefault();
 
@@ -8576,6 +8589,8 @@ session_type:
 
     timing_state: plan.timing_state || "",
     readiness_score: plan.readiness_score ?? null,
+    source: getSessionResultSourceForPlan(plan),
+    manual_override_workout_id: String(plan.manual_override_workout_id || "").trim(),
     completed: String(form.session_completed.value) === "true",
     notes: form.session_notes.value.trim(),
     cardio_kind: form.cardio_kind?.value?.trim() || "",

--- a/tests/test_today_plan_e2e_flow.py
+++ b/tests/test_today_plan_e2e_flow.py
@@ -49,3 +49,40 @@ def test_today_plan_flow_basic():
 
 if __name__ == "__main__":
     test_today_plan_flow_basic()
+
+
+def test_session_result_preserves_manual_override_source():
+    client = backend_app.app.test_client()
+
+    original_require_auth_user = backend_app.require_auth_user
+    try:
+        backend_app.require_auth_user = lambda: ({"user_id": "1"}, None)
+
+        response = client.post("/api/session-result", json={
+            "date": "2026-04-25",
+            "session_type": "styrke",
+            "source": "manual_override",
+            "completed": True,
+            "results": [
+                {
+                    "exercise_id": "bench_press",
+                    "completed": True,
+                    "target_reps": "6-8",
+                    "achieved_reps": "8",
+                    "load": "40 kg",
+                    "sets": [
+                        {"reps": "8", "load": "40 kg"}
+                    ],
+                    "hit_failure": False,
+                }
+            ],
+        })
+
+        assert response.status_code == 201, response.data
+        payload = response.get_json()
+        item = payload.get("item", {})
+        assert item.get("source") == "manual_override", item
+        assert item.get("session_type") == "styrke", item
+        assert item.get("completed") is True, item
+    finally:
+        backend_app.require_auth_user = original_require_auth_user


### PR DESCRIPTION
Fixes #729.

Manual override workouts were saved through the session-result flow without preserving their plan source. Because the backend defaults missing `source` to `autoplan`, manual override sessions were saved as planned/autoplan sessions in history and weekly rhythm.

This change preserves the source from the current Today Plan when saving a session result.

## Changes

- Adds a frontend helper to resolve session-result source from the current plan.
- Sends `source` in the session-result payload.
- Sends `manual_override_workout_id` when present.
- Adds a regression test confirming that `source = manual_override` is preserved by `/api/session-result`.

## Validation

- `node --check app/frontend/app.js`
- `python -m pytest tests/test_today_plan_e2e_flow.py -q`
- `python -m pytest -q`

Result:

- `151 passed in 35.71s`

## Notes

This fixes the observed data contract issue where manual override sessions could appear as `autoplan` in saved session history.

Follow-up work may still be needed to clarify how purely extra/manual sessions should count toward weekly rhythm, but this fix preserves the existing manual override source correctly.