### PR TITLE
Fix edited session source preservation

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1284,6 +1284,8 @@ function buildSessionPlanFromHistoryItem(item){
     session_type: item?.session_type || "strength",
     timing_state: item?.timing_state || "",
     readiness_score: item?.readiness_score ?? null,
+    source: String(item?.source || "").trim(),
+    manual_override_workout_id: String(item?.manual_override_workout_id || "").trim(),
     entries: results.map(result => {
       const sets = Array.isArray(result?.sets) ? result.sets : [];
       return {

--- a/tests/test_manual_workout_review_identity_contract.py
+++ b/tests/test_manual_workout_review_identity_contract.py
@@ -32,3 +32,12 @@ if __name__ == "__main__":
     test_session_review_does_not_close_day_for_unsaved_workout_handoff()
     test_successful_session_save_clears_unsaved_review_handoff()
     print("Manual workout review identity contract tests passed")
+
+
+def test_session_edit_plan_preserves_source_identity():
+    js = APP_JS.read_text()
+
+    assert "function buildSessionPlanFromHistoryItem(item)" in js
+    assert 'source: String(item?.source || "").trim(),' in js
+    assert 'manual_override_workout_id: String(item?.manual_override_workout_id || "").trim(),' in js
+    assert "source: getSessionResultSourceForPlan(plan)," in js


### PR DESCRIPTION
## Summary

Fixes #733.

Editing a saved manual override session could change its source from `manual_override` back to `autoplan` because the edit flow rebuilt the review plan from history without preserving the original session source.

This change preserves session origin metadata when loading a saved session into the edit/review flow.

## Changes

- Preserve `source` in `buildSessionPlanFromHistoryItem()`.
- Preserve `manual_override_workout_id` in `buildSessionPlanFromHistoryItem()`.
- Add a regression contract test to ensure session edit plans preserve source identity and continue sending source in the session result payload.

## Validation

- `node --check app/frontend/app.js`
- `python -m pytest tests/test_manual_workout_review_identity_contract.py -q`
- `python -m pytest tests/test_manual_workout_review_identity_contract.py tests/test_today_plan_e2e_flow.py -q`
- `python -m pytest -q`

Result:

- `152 passed in 37.15s`

## Notes

This is a follow-up to #729. #729 fixed first-time manual override save. This PR fixes source preservation when editing an already saved session.