### PR TITLE
Fix account settings navigation from profile page

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2600,8 +2600,7 @@ function renderProfileEquipmentCard(){
   const incrementLineEl = document.getElementById("profileIncrementLine");
   const accountLineEl = document.getElementById("profileAccountLine");
   const accountHelpLineEl = document.getElementById("profileAccountHelpLine");
-  const accountBtn = document.getElementById("openAccountSettingsBtn");
-  const accountBtn2 = document.getElementById("openAccountSettingsSecondaryBtn");
+  const accountButtons = Array.from(document.querySelectorAll('[data-action="open-account-settings"]'));
   const openEquipmentBtn = document.getElementById("openEquipmentSettingsBtn");
   const cancelEquipmentBtn = document.getElementById("cancelEquipmentSettingsBtn");
   const saveEquipmentBtn = document.getElementById("saveEquipmentSettingsBtn");
@@ -3129,12 +3128,12 @@ function renderProfileEquipmentCard(){
 
   const authHref = `${AUTH_BASE}/account?return_to=${encodeURIComponent(AUTH_RETURN_TO)}&lang=${encodeURIComponent(getCurrentLang())}`;
 
-  [accountBtn, accountBtn2].forEach(btn => {
+  accountButtons.forEach(btn => {
     if (!btn) return;
     if (btn.tagName === "A"){
       btn.setAttribute("href", authHref);
-    } else if (!btn.dataset.bound){
-      btn.dataset.bound = "1";
+    } else if (!btn.dataset.boundAccountSettings){
+      btn.dataset.boundAccountSettings = "1";
       btn.addEventListener("click", () => {
         location.href = authHref;
       });
@@ -3643,14 +3642,6 @@ function bindEquipmentEditor(){
     };
   }
 
-  const openAccountProfileBtn = document.getElementById("openAccountSettingsBtnProfile");
-  if (openAccountProfileBtn && !openAccountProfileBtn.dataset.bound){
-    openAccountProfileBtn.dataset.bound = "1";
-    openAccountProfileBtn.onclick = (ev) => {
-      ev.preventDefault();
-      accountBtn2?.click();
-    };
-  }
 
   if (cancelBtn){
     cancelBtn.onclick = (ev) => {

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -413,7 +413,7 @@
         </div>
         <div class="btn-row profile-summary-buttons">
           <button type="button" id="openEquipmentSettingsBtn" data-i18n="button.edit_profile_equipment">Redigér profil og udstyr</button>
-          <button type="button" id="openAccountSettingsSecondaryBtn" data-i18n="button.account_password">Konto og adgangskode</button>
+          <button type="button" id="openAccountSettingsSecondaryBtn" data-action="open-account-settings" data-i18n="button.account_password">Konto og adgangskode</button>
         </div>
       </section>
 
@@ -767,7 +767,7 @@
 
 <div class="btn-row" style="margin-top:12px">
         <button type="button" id="openEquipmentSettingsBtnProfile" data-i18n="button.edit_profile_equipment">Redigér profil og udstyr</button>
-        <button type="button" id="openAccountSettingsBtnProfile" data-i18n="button.account_password">Konto og adgangskode</button>
+        <button type="button" data-action="open-account-settings" data-i18n="button.account_password">Konto og adgangskode</button>
       </div>
     </section>
 
@@ -821,7 +821,7 @@
 
       <div class="btn-row" style="margin-top:12px">
         <button type="button" id="openEquipmentSettingsBtnProfile" data-i18n="button.edit_profile_equipment">Redigér profil og udstyr</button>
-        <button type="button" id="openAccountSettingsBtnProfile" data-i18n="button.account_password">Konto og adgangskode</button>
+        <button type="button" data-action="open-account-settings" data-i18n="button.account_password">Konto og adgangskode</button>
       </div>
     </section>
 

--- a/tests/test_account_settings_navigation_contract.py
+++ b/tests/test_account_settings_navigation_contract.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app/frontend/app.js"
+INDEX_HTML = ROOT / "app/frontend/index.html"
+
+
+def test_account_settings_buttons_use_shared_action():
+    html = INDEX_HTML.read_text()
+
+    assert html.count('data-action="open-account-settings"') >= 3
+    assert 'id="openAccountSettingsBtnProfile"' not in html
+
+
+def test_account_settings_buttons_are_bound_by_shared_selector():
+    js = APP_JS.read_text()
+
+    assert 'document.querySelectorAll(\'[data-action="open-account-settings"]\')' in js
+    assert "accountButtons.forEach" in js
+    assert "boundAccountSettings" in js
+    assert "location.href = authHref;" in js


### PR DESCRIPTION
## Summary

Fixes #735.

The `Konto og adgangskode` button worked from Overview, but did nothing from the Profile and equipment page.

The root cause was inconsistent DOM wiring:

- the working Overview button had a bound id
- profile buttons used `openAccountSettingsBtnProfile`
- that id appeared more than once
- the profile buttons were not included in the account settings listener binding

This PR replaces the profile-specific account button wiring with one shared action selector for all account/password buttons.

## Changes

- Adds `data-action="open-account-settings"` to all account/password buttons.
- Removes duplicate `openAccountSettingsBtnProfile` ids from profile buttons.
- Binds account/password navigation using `querySelectorAll('[data-action="open-account-settings"]')`.
- Removes obsolete profile-specific click forwarding logic.
- Adds a regression contract test for account settings navigation wiring.

## Validation

- `node --check app/frontend/app.js`
- `python -m pytest tests/test_account_settings_navigation_contract.py -q`
- `python -m pytest -q`

Result:

- `154 passed in 33.49s`

## Notes

This is a frontend-only navigation fix. No backend changes.