### PR TITLE
Remove duplicate finish workout button

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -7130,7 +7130,7 @@ function renderActiveWorkoutCard(item){
         <div style="margin-bottom:18px">${loggingHtml}</div>
         <div style="margin-top:auto; display:flex; gap:10px; flex-wrap:wrap">
           <button type="button" id="nextWorkoutEntryBtn" style="padding:18px 18px; font-size:1.1rem; font-weight:800; width:100%">${esc(nextActionLabel)}</button>
-          <button type="button" id="finishWorkoutEarlyBtn" class="secondary" style="width:100%; padding:14px 16px; font-size:0.98rem">${esc(tr("button.finish_workout"))}</button>
+          ${!isLast ? `<button type="button" id="finishWorkoutEarlyBtn" class="secondary" style="width:100%; padding:14px 16px; font-size:0.98rem">${esc(tr("button.finish_workout"))}</button>` : ""}
           <button type="button" class="secondary" data-exercise-viewer="${esc(entry.exercise_id || "")}" style="width:100%; padding:14px 16px; font-size:0.98rem">${esc(tr("button.view_exercise"))}</button>
         </div>
       </li>

--- a/tests/test_workout_player_finish_button_contract.py
+++ b/tests/test_workout_player_finish_button_contract.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app/frontend/app.js"
+
+
+def test_finish_workout_early_button_is_hidden_on_last_exercise():
+    js = APP_JS.read_text()
+
+    assert 'id="nextWorkoutEntryBtn"' in js
+    assert 'id="finishWorkoutEarlyBtn"' in js
+    assert '${!isLast ? `<button type="button" id="finishWorkoutEarlyBtn"' in js
+
+
+def test_finish_workout_primary_label_still_exists_for_last_exercise():
+    js = APP_JS.read_text()
+
+    assert 'return tr(isLast ? "button.finish_workout" : "button.next_exercise");' in js
+    assert 'advanceActiveWorkoutAfterCompletedSet(item, idx, currentSetIndex, hasMoreSetsRemaining && !isCardioEntry);' in js


### PR DESCRIPTION
## Summary

Fixes #724.

The mobile workout player could show two `Afslut træning` buttons on the final exercise:

- the primary `nextWorkoutEntryBtn`, which correctly becomes `Afslut træning` on the last exercise
- the secondary `finishWorkoutEarlyBtn`, which was always rendered

This PR keeps the primary final action and only shows the secondary early-finish button before the last exercise.

## Changes

- Render `finishWorkoutEarlyBtn` only when `!isLast`.
- Keep the primary final workout action unchanged.
- Add a regression contract test ensuring the early-finish button is not rendered unconditionally on the final exercise.

## Validation

- `node --check app/frontend/app.js`
- `python -m pytest tests/test_workout_player_finish_button_contract.py -q`
- `python -m pytest -q`

Result:

- `156 passed in 35.70s`

## Notes

Frontend-only UI fix. No backend or data changes.