### PR TITLE
Fix exercise contract review rep choices

### DIFF
--- a/docs/exercise-model-contract.md
+++ b/docs/exercise-model-contract.md
@@ -97,14 +97,18 @@ These fields are valid but not required for every exercise:
 - `rep_options`
 - `time_options`
 - `load_options`
+- `workout_rep_choices`
 
 These fields are typically tied to input and review behavior.
 
 ### Guidance
 
-- `rep_options` is most relevant for rep-based exercises
+- `rep_options` is most relevant for rep-based exercise ranges and manual plan entry
 - `time_options` is most relevant for time-based exercises
 - `load_options` is most relevant when `supports_load = true`
+- `workout_rep_choices` is optional review/UI metadata for concrete achieved-rep choices during workout review
+
+`workout_rep_choices` must remain optional because not every rep-based exercise needs discrete review buttons, and older records may rely only on `rep_options`.
 
 ---
 

--- a/scripts/audit_exercise_model.py
+++ b/scripts/audit_exercise_model.py
@@ -38,6 +38,7 @@ OPTIONAL_FIELDS = {
     "rep_options",
     "time_options",
     "load_options",
+    "workout_rep_choices",
     "image_folder",
     "external_images",
     "progression_channels",
@@ -133,6 +134,9 @@ def main() -> None:
 
         if "load_options" in item and not isinstance(item["load_options"], list):
             fail(f"{item_id}: load_options must be a list when present")
+
+        if "workout_rep_choices" in item and not isinstance(item["workout_rep_choices"], list):
+            fail(f"{item_id}: workout_rep_choices must be a list when present")
 
         if "progression_channels" in item and not isinstance(item["progression_channels"], list):
             fail(f"{item_id}: progression_channels must be a list when present")


### PR DESCRIPTION
## Summary

- Documents `workout_rep_choices` as optional review/UI metadata in the exercise model contract.
- Allows `workout_rep_choices` in the exercise contract audit script.
- Adds type validation so `workout_rep_choices` must be a list when present.

## Why

The seed exercise catalog already uses `workout_rep_choices` for concrete achieved-rep choices during workout review, and the frontend reads it. The validator failed because the contract did not recognize the field, so the contract and actual model usage had drifted.

## Validation

- `python3 scripts/audit_exercise_model.py`
- `python3 -m py_compile scripts/audit_exercise_model.py`
- `git status --short` clean locally after sync