### PR TITLE
Fix time-based strength summary seconds

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -5882,6 +5882,19 @@ def _parse_time_under_tension_seconds(value):
         return float(num)
     return 0.0
 
+
+def _parse_result_time_under_tension_seconds(value, *, assume_seconds=False):
+    parsed = _parse_time_under_tension_seconds(value)
+    if parsed > 0:
+        return parsed
+
+    if assume_seconds:
+        num = _parse_numeric_token(str(value or "").strip())
+        if num > 0:
+            return float(num)
+
+    return 0.0
+
 def build_weekly_training_status(user_id, checkin_date, training_day_prefs, weekly_target_sessions):
     status = {
         "week_start": None,
@@ -6406,7 +6419,7 @@ def build_session_summary(session_item):
 
         sets = r.get("sets", [])
         achieved_reps = _safe_int(r.get("achieved_reps", "0"))
-        achieved_tut = _parse_time_under_tension_seconds(r.get("achieved_reps", ""))
+        achieved_tut = _parse_result_time_under_tension_seconds(r.get("achieved_reps", ""), assume_seconds=is_time_based)
         base_load = _safe_float(r.get("load", "0"))
         effective_load = _estimate_effective_load_for_result(r, exercise_meta, bodyweight_kg, base_load)
 
@@ -6417,7 +6430,7 @@ def build_session_summary(session_item):
                     continue
 
                 reps_val = _safe_int(s.get("reps", "0"))
-                tut_val = _parse_time_under_tension_seconds(s.get("reps", ""))
+                tut_val = _parse_result_time_under_tension_seconds(s.get("reps", ""), assume_seconds=is_time_based)
                 load_val = _safe_float(s.get("load", "0"))
                 effective_set_load = _estimate_effective_load_for_result(r, exercise_meta, bodyweight_kg, load_val)
 

--- a/tests/test_time_based_strength_summary.py
+++ b/tests/test_time_based_strength_summary.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND = ROOT / "app" / "backend"
+
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+from app import build_session_summary
+
+
+def test_time_based_strength_numeric_achieved_reps_count_as_seconds():
+    session = {
+        "session_type": "styrke",
+        "results": [
+            {
+                "exercise_id": "plank",
+                "target_reps": "20 sec",
+                "achieved_reps": "20",
+                "completed": True,
+                "sets": [],
+            }
+        ],
+    }
+
+    summary = build_session_summary(session)
+
+    assert summary["total_reps"] == 0
+    assert summary["total_time_under_tension_sec"] == 20
+
+
+def test_rep_based_strength_numeric_achieved_reps_still_count_as_reps():
+    session = {
+        "session_type": "styrke",
+        "results": [
+            {
+                "exercise_id": "squat",
+                "target_reps": "8-10",
+                "achieved_reps": "8",
+                "completed": True,
+                "sets": [],
+            }
+        ],
+    }
+
+    summary = build_session_summary(session)
+
+    assert summary["total_reps"] == 8
+    assert summary["total_time_under_tension_sec"] == 0


### PR DESCRIPTION
Fixes #731.

Summary:
- Count numeric achieved values as seconds for time-based strength results.
- Keep normal rep-based strength summaries unchanged.
- Add regression tests for plank/time-hold and squat/rep-based behavior.

Validation:
- .venv/bin/python -m pytest tests/test_time_based_strength_summary.py tests/test_mixed_session_summary_contract.py -q
- Result: 5 passed
- .venv/bin/python -m py_compile app/backend/app.py

Scope: backend summary logic only. No frontend or catalog data changes.