### PR TITLE
Fix manual override navigation after save

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -8215,6 +8215,7 @@ async function handleWorkoutSubmit(ev){
   const form = ev.currentTarget;
   const statusEl = document.getElementById("formStatus");
   const selectedDay = getSelectedProgramDay();
+  const wasManualOverride = STATE.manualWorkoutActsAsTodayOverride === true;
 
   const payload = {
     date: form.date.value,
@@ -8243,7 +8244,7 @@ async function handleWorkoutSubmit(ev){
     renderPendingEntries();
     setText("programLoadStatus", tr("workout.no_program_loaded"));
     await refreshAll();
-    advanceWizardAfterCheckin();
+    showWizardStep(wasManualOverride ? "manual" : "plan");
   }catch(err){
     const rawMessage = String(err?.message || err || "").trim();
     const normalizedMessage = rawMessage === "empty_workout"

--- a/tests/test_manual_override_navigation_contract.py
+++ b/tests/test_manual_override_navigation_contract.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app/frontend/app.js"
+
+
+def test_manual_override_submit_preserves_manual_navigation_after_save():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert "const wasManualOverride = STATE.manualWorkoutActsAsTodayOverride === true;" in js
+    assert 'showWizardStep(wasManualOverride ? "manual" : "plan");' in js
+
+
+def test_manual_override_submit_no_longer_uses_checkin_advance_after_save():
+    js = APP_JS.read_text(encoding="utf-8")
+    submit_start = js.index("async function handleWorkoutSubmit")
+    submit_end = js.index("function updateCheckinEditMenstruationVisibility", submit_start)
+    submit_block = js[submit_start:submit_end]
+
+    assert "advanceWizardAfterCheckin();" not in submit_block


### PR DESCRIPTION
Fixes #744.

Summary:
- Preserve manual override navigation intent during workout submit.
- After saving a manual override workout, return to the manual flow instead of forcing Today Plan navigation.
- Keep normal non-manual workout submit behavior going back to the plan step.
- Add a frontend contract test for this navigation behavior.

Validation:
- node --check app/frontend/app.js
- .venv/bin/python -m pytest tests/test_manual_override_navigation_contract.py -q
- Result: 2 passed

Scope: frontend navigation only. No backend, catalog, or runtime data changes.