### PR TITLE
Fix manual step save navigation

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -8215,7 +8215,7 @@ async function handleWorkoutSubmit(ev){
   const form = ev.currentTarget;
   const statusEl = document.getElementById("formStatus");
   const selectedDay = getSelectedProgramDay();
-  const wasManualOverride = STATE.manualWorkoutActsAsTodayOverride === true;
+  const wasManualFlow = CURRENT_STEP === "manual" || STATE.manualWorkoutActsAsTodayOverride === true;
 
   const payload = {
     date: form.date.value,
@@ -8244,7 +8244,7 @@ async function handleWorkoutSubmit(ev){
     renderPendingEntries();
     setText("programLoadStatus", tr("workout.no_program_loaded"));
     await refreshAll();
-    showWizardStep(wasManualOverride ? "manual" : "plan");
+    showWizardStep(wasManualFlow ? "manual" : "plan");
   }catch(err){
     const rawMessage = String(err?.message || err || "").trim();
     const normalizedMessage = rawMessage === "empty_workout"

--- a/tests/test_manual_override_navigation_contract.py
+++ b/tests/test_manual_override_navigation_contract.py
@@ -4,11 +4,11 @@ ROOT = Path(__file__).resolve().parents[1]
 APP_JS = ROOT / "app/frontend/app.js"
 
 
-def test_manual_override_submit_preserves_manual_navigation_after_save():
+def test_manual_workout_submit_preserves_manual_navigation_after_save():
     js = APP_JS.read_text(encoding="utf-8")
 
-    assert "const wasManualOverride = STATE.manualWorkoutActsAsTodayOverride === true;" in js
-    assert 'showWizardStep(wasManualOverride ? "manual" : "plan");' in js
+    assert 'const wasManualFlow = CURRENT_STEP === "manual" || STATE.manualWorkoutActsAsTodayOverride === true;' in js
+    assert 'showWizardStep(wasManualFlow ? "manual" : "plan");' in js
 
 
 def test_manual_override_submit_no_longer_uses_checkin_advance_after_save():


### PR DESCRIPTION
Follow-up to #744.

The first #744 fix preserved navigation only when `manualWorkoutActsAsTodayOverride` was true. Live testing showed that the manual workout section can also be opened directly via navigation/utility nav, where that flag is false.

Summary:
- Preserve manual navigation after saving whenever the user is currently in the manual step.
- Keep `is_manual_override` semantics unchanged.
- Do not treat all manual workout saves as Today Plan overrides.
- Update the frontend contract test to cover manual step navigation rather than only override flag navigation.

Validation:
- node --check app/frontend/app.js
- .venv/bin/python -m pytest tests/test_manual_override_navigation_contract.py -q
- Result: 2 passed

Scope: frontend navigation only. No backend, catalog, or runtime data changes.