### PR TITLE
Fix manual override payload for Today Plan

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -8224,7 +8224,7 @@ async function handleWorkoutSubmit(ev){
     notes: form.notes.value.trim(),
     program_id: form.program_id.value.trim(),
     program_day_label: selectedDay?.label || "",
-    is_manual_override: STATE.manualWorkoutActsAsTodayOverride === true,
+    is_manual_override: wasManualFlow,
     entries: [...STATE.pendingEntries]
   };
 

--- a/tests/test_manual_override_navigation_contract.py
+++ b/tests/test_manual_override_navigation_contract.py
@@ -18,3 +18,12 @@ def test_manual_override_submit_no_longer_uses_checkin_advance_after_save():
     submit_block = js[submit_start:submit_end]
 
     assert "advanceWizardAfterCheckin();" not in submit_block
+
+
+def test_manual_workout_submit_saves_manual_step_as_today_override():
+    js = APP_JS.read_text(encoding="utf-8")
+    submit_start = js.index("async function handleWorkoutSubmit")
+    submit_end = js.index("function updateCheckinEditMenstruationVisibility", submit_start)
+    submit_block = js[submit_start:submit_end]
+
+    assert "is_manual_override: wasManualFlow," in submit_block


### PR DESCRIPTION
Fixes #744.

Manual workout saves now mark the saved workout as a manual override when the user is in the manual flow.

Validation:
- node --check app/frontend/app.js
- pytest manual override navigation contract: 3 passed