### PR TITLE
Fix manual form override payload detection

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -8215,7 +8215,8 @@ async function handleWorkoutSubmit(ev){
   const form = ev.currentTarget;
   const statusEl = document.getElementById("formStatus");
   const selectedDay = getSelectedProgramDay();
-  const wasManualFlow = CURRENT_STEP === "manual" || STATE.manualWorkoutActsAsTodayOverride === true;
+  const formIsManualWorkout = form.closest("#manualWorkoutSection") !== null;
+  const wasManualFlow = formIsManualWorkout || STATE.manualWorkoutActsAsTodayOverride === true;
 
   const payload = {
     date: form.date.value,

--- a/tests/test_manual_override_navigation_contract.py
+++ b/tests/test_manual_override_navigation_contract.py
@@ -7,7 +7,8 @@ APP_JS = ROOT / "app/frontend/app.js"
 def test_manual_workout_submit_preserves_manual_navigation_after_save():
     js = APP_JS.read_text(encoding="utf-8")
 
-    assert 'const wasManualFlow = CURRENT_STEP === "manual" || STATE.manualWorkoutActsAsTodayOverride === true;' in js
+    assert 'const formIsManualWorkout = form.closest("#manualWorkoutSection") !== null;' in js
+    assert "const wasManualFlow = formIsManualWorkout || STATE.manualWorkoutActsAsTodayOverride === true;" in js
     assert 'showWizardStep(wasManualFlow ? "manual" : "plan");' in js
 
 


### PR DESCRIPTION
Fixes #744.

Manual workout submit now detects manual flow from the workout form location inside `#manualWorkoutSection`, not only from global step state.

This ensures manual form saves are sent with `is_manual_override: true`, so Today Plan can update to the manual workout.

Validation:
- node --check app/frontend/app.js
- pytest manual override navigation contract: 3 passed