### PR TITLE
Fix cardio tempo display label

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -3820,7 +3820,8 @@ function formatExerciseName(exerciseId){
     cardio_easy: tr("exercise.cardio_easy"),
     cardio_intervals: tr("exercise.cardio_intervals"),
     cardio_session: tr("session_type.cardio"),
-    cardio_base: tr("exercise.cardio_base")
+    cardio_base: tr("exercise.cardio_base"),
+    cardio_tempo: tr("exercise.cardio_tempo")
   };
   if (mapped[id]) return mapped[id];
 

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -522,6 +522,7 @@
   "exercise.cardio_easy": "Rolig cardio",
   "exercise.cardio_intervals": "Intervaller",
   "exercise.cardio_base": "Rolig løbetur",
+  "exercise.cardio_tempo": "Tempoløb",
   "exercise.planned_session": "Planlagt session",
   "decision.autoplan_cardio_initial": "Valgt som rolig cardio i dag",
   "decision.generic": "Tilpasset dagens plan",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -509,6 +509,7 @@
   "exercise.cardio_easy": "Easy cardio",
   "exercise.cardio_intervals": "Intervals",
   "exercise.cardio_base": "Easy run",
+  "exercise.cardio_tempo": "Tempo run",
   "exercise.planned_session": "Planned session",
   "decision.autoplan_cardio_initial": "Selected as easy cardio today",
   "decision.generic": "Adjusted for today's plan",

--- a/tests/test_cardio_tempo_display_contract.py
+++ b/tests/test_cardio_tempo_display_contract.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app/frontend/app.js"
+DA_JSON = ROOT / "app/frontend/i18n/da.json"
+EN_JSON = ROOT / "app/frontend/i18n/en.json"
+
+
+def test_cardio_tempo_has_frontend_display_mapping():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert 'cardio_tempo: tr("exercise.cardio_tempo")' in js
+
+
+def test_cardio_tempo_has_danish_and_english_labels():
+    da = DA_JSON.read_text(encoding="utf-8")
+    en = EN_JSON.read_text(encoding="utf-8")
+
+    assert '"exercise.cardio_tempo": "Tempoløb"' in da
+    assert '"exercise.cardio_tempo": "Tempo run"' in en


### PR DESCRIPTION
Fixes #723.

Summary:
- Add a frontend display mapping for `cardio_tempo`.
- Add Danish and English i18n labels.
- Prevent Today Plan cards from showing `ukendt: cardio_tempo`.
- Add a small contract test for the display mapping and labels.

Validation:
- node --check app/frontend/app.js
- python3 -m json.tool app/frontend/i18n/da.json
- python3 -m json.tool app/frontend/i18n/en.json
- .venv/bin/python -m pytest tests/test_cardio_tempo_display_contract.py -q
- Result: 2 passed

Scope: frontend display/i18n only. No backend, catalog, or runtime data changes.