### PR TITLE
Expose Today Plan program context

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -3744,6 +3744,15 @@ function getProgramDisplayName(program){
   ).trim();
 }
 
+function getProgramDisplayNameById(programId){
+  const id = String(programId || "").trim();
+  if (!id) return "";
+  const found = Array.isArray(STATE.programs)
+    ? STATE.programs.find(program => String(program?.id || "").trim() === id)
+    : null;
+  return found ? getProgramDisplayName(found) : id;
+}
+
 function getProgramKindDisplayLabel(value){
   const x = String(value || "").trim().toLowerCase();
   if (!x) return "";
@@ -7456,6 +7465,14 @@ function deriveTodayPlanDisplayState(item){
   const todayWeekPlanItem = getTodayWeekPlanItem(item);
   const todayWeekKind = String(todayWeekPlanItem?.kind || "").trim().toLowerCase();
   const actualKind = String(item?.session_type || "").trim().toLowerCase();
+  const selectedStrengthProgramName = getProgramDisplayNameById(item?.selected_strength_program_id);
+  const selectedRunProgramName = getProgramDisplayNameById(item?.selected_endurance_program_id);
+  const selectedPlanProgramSummary =
+    actualKind === "styrke" && selectedStrengthProgramName
+      ? tr("today_plan.selected_strength_program", { value: selectedStrengthProgramName })
+      : (actualKind === "løb" || actualKind === "run" || actualKind === "cardio") && selectedRunProgramName
+        ? tr("today_plan.selected_run_program", { value: selectedRunProgramName })
+        : "";
   const isManualOverridePlan = String(item?.plan_variant || "").trim() === "manual_override"
     || String(item?.source || "").trim() === "manual_override";
   const isPlannedRestDay = todayWeekKind === "rest" && !isManualOverridePlan;
@@ -7521,6 +7538,7 @@ function deriveTodayPlanDisplayState(item){
   const rawReason = String(item?.reason || "").trim();
   const overrideReasonText = rawReason ? formatPlanReason(rawReason) : "";
   const planContextBits = [
+    selectedPlanProgramSummary,
     recoverySummaryText,
     recoveryExplanationText,
     ...(hasHighImpactOverride

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -130,6 +130,8 @@
   "session_type.strength": "Styrke",
   "settings.strength_weights": "Styrke med vægte",
   "today_plan.title": "Dagens plan",
+  "today_plan.selected_strength_program": "Styrkeprogram: {value}",
+  "today_plan.selected_run_program": "Løbeprogram: {value}",
   "weekday.fri": "Fredag",
   "weekday.mon": "Mandag",
   "weekday.sat": "Lørdag",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -117,6 +117,8 @@
   "session_type.strength": "Strength",
   "settings.strength_weights": "Strength with weights",
   "today_plan.title": "Today's plan",
+  "today_plan.selected_strength_program": "Strength program: {value}",
+  "today_plan.selected_run_program": "Run program: {value}",
   "weekday.fri": "Friday",
   "weekday.mon": "Monday",
   "weekday.sat": "Saturday",

--- a/tests/test_today_plan_program_context_contract.py
+++ b/tests/test_today_plan_program_context_contract.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app/frontend/app.js"
+DA_JSON = ROOT / "app/frontend/i18n/da.json"
+EN_JSON = ROOT / "app/frontend/i18n/en.json"
+
+
+def test_today_plan_can_display_selected_program_context():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert "function getProgramDisplayNameById(programId)" in js
+    assert "selected_strength_program_id" in js
+    assert "selected_endurance_program_id" in js
+    assert "selectedPlanProgramSummary" in js
+    assert "selectedPlanProgramSummary," in js
+
+
+def test_today_plan_program_context_has_danish_and_english_labels():
+    da = DA_JSON.read_text(encoding="utf-8")
+    en = EN_JSON.read_text(encoding="utf-8")
+
+    assert '"today_plan.selected_strength_program": "Styrkeprogram: {value}"' in da
+    assert '"today_plan.selected_run_program": "Løbeprogram: {value}"' in da
+    assert '"today_plan.selected_strength_program": "Strength program: {value}"' in en
+    assert '"today_plan.selected_run_program": "Run program: {value}"' in en


### PR DESCRIPTION
Part of #750.

Summary:
- Show the selected strength/run program context in Today Plan.
- Use existing `selected_strength_program_id` and `selected_endurance_program_id` fields already returned by the backend.
- Add Danish and English labels.
- Add a frontend contract test for the program context display.

Validation:
- node --check app/frontend/app.js
- python3 -m json.tool app/frontend/i18n/da.json
- python3 -m json.tool app/frontend/i18n/en.json
- .venv/bin/python -m pytest tests/test_today_plan_program_context_contract.py -q
- Result: 2 passed

Scope: frontend explainability only. No planner behavior changes yet.