### PR TITLE
Persist session plan identity

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -808,6 +808,12 @@ def create_session_result(user_id, payload):
     completed = bool(payload.get("completed", False))
     readiness_score = payload.get("readiness_score", None)
     source = str(payload.get("source", "autoplan")).strip() or "autoplan"
+    program_id = str(payload.get("program_id", "")).strip()
+    program_day_label = str(payload.get("program_day_label", "")).strip()
+    template_id = str(payload.get("template_id", "")).strip()
+    plan_variant = str(payload.get("plan_variant", "")).strip()
+    selected_strength_program_id = str(payload.get("selected_strength_program_id", "")).strip()
+    selected_endurance_program_id = str(payload.get("selected_endurance_program_id", "")).strip()
     results = payload.get("results", [])
 
     if not date:
@@ -954,6 +960,12 @@ def create_session_result(user_id, payload):
         "readiness_score": readiness_score,
         "completed": completed,
         "source": source,
+        "program_id": program_id or None,
+        "program_day_label": program_day_label or None,
+        "template_id": template_id or None,
+        "plan_variant": plan_variant or None,
+        "selected_strength_program_id": selected_strength_program_id or None,
+        "selected_endurance_program_id": selected_endurance_program_id or None,
         "counts_toward_weekly_goal": counts_toward_weekly_goal,
         "notes": notes,
         "cardio_kind": cardio_kind if session_type in ("løb", "cardio", "run") else "",
@@ -994,6 +1006,12 @@ def build_session_result_item(user_id, payload, existing_item=None):
     timing_state = str(payload.get("timing_state", "")).strip() or str(existing_item.get("timing_state", "")).strip() or "on_time"
     notes = str(payload.get("notes", "")).strip()
     source = str(payload.get("source", "")).strip() or str(existing_item.get("source", "")).strip() or "manual"
+    program_id = str(payload.get("program_id", "")).strip() or str(existing_item.get("program_id", "")).strip()
+    program_day_label = str(payload.get("program_day_label", "")).strip() or str(existing_item.get("program_day_label", "")).strip()
+    template_id = str(payload.get("template_id", "")).strip() or str(existing_item.get("template_id", "")).strip()
+    plan_variant = str(payload.get("plan_variant", "")).strip() or str(existing_item.get("plan_variant", "")).strip()
+    selected_strength_program_id = str(payload.get("selected_strength_program_id", "")).strip() or str(existing_item.get("selected_strength_program_id", "")).strip()
+    selected_endurance_program_id = str(payload.get("selected_endurance_program_id", "")).strip() or str(existing_item.get("selected_endurance_program_id", "")).strip()
     completed = bool(payload.get("completed", False))
     readiness_score = payload.get("readiness_score", existing_item.get("readiness_score"))
     cardio_kind = str(payload.get("cardio_kind", "")).strip()
@@ -1094,6 +1112,12 @@ def build_session_result_item(user_id, payload, existing_item=None):
         "readiness_score": readiness_score,
         "completed": completed,
         "source": source,
+        "program_id": program_id or None,
+        "program_day_label": program_day_label or None,
+        "template_id": template_id or None,
+        "plan_variant": plan_variant or None,
+        "selected_strength_program_id": selected_strength_program_id or None,
+        "selected_endurance_program_id": selected_endurance_program_id or None,
         "counts_toward_weekly_goal": counts_toward_weekly_goal,
         "notes": notes,
         "cardio_kind": cardio_kind if session_type in ("løb", "cardio", "run") else "",

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -8574,6 +8574,23 @@ function getSessionResultSourceForPlan(plan){
 }
 
 
+function getProgramDayLabelFromPlanTemplate(templateId){
+  const raw = String(templateId || "").trim().toLowerCase();
+  const match = raw.match(/^strength_day_([a-z0-9]+)$/);
+  return match ? `Day ${match[1].toUpperCase()}` : "";
+}
+
+function getSessionResultProgramIdForPlan(plan){
+  const sessionType = String(plan?.session_type || "").trim().toLowerCase();
+  if (sessionType === "styrke" || sessionType === "strength"){
+    return String(plan?.selected_strength_program_id || "").trim();
+  }
+  if (sessionType === "løb" || sessionType === "run" || sessionType === "cardio"){
+    return String(plan?.selected_endurance_program_id || "").trim();
+  }
+  return "";
+}
+
 async function handleSessionResultSubmit(ev){
   ev.preventDefault();
 
@@ -8593,9 +8610,16 @@ async function handleSessionResultSubmit(ev){
   const cardioDistanceKm = (cardioKmWhole + (cardioKmPartMeters / 1000)).toFixed(1).replace(/\.0$/, "");
   const cardioDurationMin = form.cardio_duration_min?.value?.trim() || "";
   const cardioDurationSec = form.cardio_duration_sec?.value?.trim() || "";
+  const planTemplateId = String(plan.template_id || "").trim();
 
   const payload = {
     date: plan.date || new Date().toISOString().slice(0,10),
+    program_id: getSessionResultProgramIdForPlan(plan),
+    program_day_label: String(plan.program_day_label || "").trim() || getProgramDayLabelFromPlanTemplate(planTemplateId),
+    template_id: planTemplateId,
+    plan_variant: String(plan.plan_variant || "").trim(),
+    selected_strength_program_id: String(plan.selected_strength_program_id || "").trim(),
+    selected_endurance_program_id: String(plan.selected_endurance_program_id || "").trim(),
     
 session_type:
   plan.session_type

--- a/tests/test_session_result_plan_identity_contract.py
+++ b/tests/test_session_result_plan_identity_contract.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app/frontend/app.js"
+BACKEND_APP = ROOT / "app/backend/app.py"
+
+
+def test_session_result_submit_sends_today_plan_identity():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert "function getProgramDayLabelFromPlanTemplate(templateId)" in js
+    assert "function getSessionResultProgramIdForPlan(plan)" in js
+    assert "program_id: getSessionResultProgramIdForPlan(plan)," in js
+    assert 'program_day_label: String(plan.program_day_label || "").trim() || getProgramDayLabelFromPlanTemplate(planTemplateId),' in js
+    assert "template_id: planTemplateId," in js
+    assert 'plan_variant: String(plan.plan_variant || "").trim(),' in js
+    assert 'selected_strength_program_id: String(plan.selected_strength_program_id || "").trim(),' in js
+    assert 'selected_endurance_program_id: String(plan.selected_endurance_program_id || "").trim(),' in js
+
+
+def test_backend_persists_session_result_plan_identity():
+    py = BACKEND_APP.read_text(encoding="utf-8")
+
+    for field in [
+        '"program_id": program_id or None',
+        '"program_day_label": program_day_label or None',
+        '"template_id": template_id or None',
+        '"plan_variant": plan_variant or None',
+        '"selected_strength_program_id": selected_strength_program_id or None',
+        '"selected_endurance_program_id": selected_endurance_program_id or None',
+    ]:
+        assert py.count(field) >= 2


### PR DESCRIPTION
Part of #750.

Summary:
- Send Today Plan identity when saving session results.
- Persist plan identity on session result create and update.
- Store `program_id`, `program_day_label`, `template_id`, `plan_variant`, `selected_strength_program_id`, and `selected_endurance_program_id`.
- Add a contract test so future saves do not drop plan identity again.

Why:
Strength rotation needs completed program context. Without persisted program/day identity, later planning cannot reliably know which program day was completed and may restart/repeat similar strength sessions.

Validation:
- node --check app/frontend/app.js
- python -m py_compile app/backend/app.py
- pytest tests/test_session_result_plan_identity_contract.py -q
- Result: 2 passed

Scope: session-result persistence contract only. This does not yet change planner selection behavior for existing historical results without plan identity.