### PR TITLE
Use session results for strength rotation

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -1592,6 +1592,18 @@ def find_latest_session_by_type(session_results, session_type):
     return None
 
 
+def find_latest_completed_strength_session_result(session_results):
+    for session in reversed(session_results or []):
+        if not isinstance(session, dict):
+            continue
+        if str(session.get("session_type", "")).strip() != "styrke":
+            continue
+        if not bool(session.get("completed", False)):
+            continue
+        return session
+    return None
+
+
 def get_starter_capacity_calibration_sessions(session_results, limit=3):
     completed = []
     for session in session_results or []:
@@ -4080,16 +4092,16 @@ def build_today_plan_timing_state(previous_recommendation, checkin_date):
 
 
 def build_today_plan_fatigue_context(auth_user, latest_checkin, workouts, checkin_date):
-    latest_strength = find_latest_strength_workout(workouts)
+    session_results = list_session_results_for_user(auth_user.get("user_id"))
+    latest_strength_session = find_latest_completed_strength_session_result(session_results)
+    latest_strength = latest_strength_session or find_latest_strength_workout(workouts)
+
     days_since_last_strength = None
     if latest_strength:
         days_since_last_strength = days_between_iso_dates(checkin_date, latest_strength.get("date", ""))
 
-    session_results = list_session_results_for_user(auth_user.get("user_id"))
     recommendations = read_json_file(FILES["recommendations"])
     previous_recommendation = recommendations[-1] if recommendations else None
-
-    latest_strength_session = find_latest_session_by_type(session_results, "styrke")
     latest_strength_failed = session_has_failure(latest_strength_session)
     latest_strength_load_drop_count = count_load_drop_exercises(latest_strength_session)
     latest_strength_completed = None if latest_strength_session is None else bool(latest_strength_session.get("completed", False))

--- a/tests/test_today_plan_strength_rotation_source_contract.py
+++ b/tests/test_today_plan_strength_rotation_source_contract.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "app/backend/app.py"
+
+
+def test_today_plan_uses_completed_session_results_for_latest_strength_rotation():
+    py = APP.read_text(encoding="utf-8")
+
+    assert "def find_latest_completed_strength_session_result(session_results):" in py
+    assert "latest_strength_session = find_latest_completed_strength_session_result(session_results)" in py
+    assert "latest_strength = latest_strength_session or find_latest_strength_workout(workouts)" in py
+
+
+def test_today_plan_no_longer_sets_latest_strength_from_workouts_before_session_results():
+    py = APP.read_text(encoding="utf-8")
+    start = py.index("def build_today_plan_fatigue_context")
+    end = py.index("def log_today_plan_decision", start)
+    block = py[start:end]
+
+    assert "latest_strength = find_latest_strength_workout(workouts)\\n    days_since_last_strength" not in block


### PR DESCRIPTION
Part of #750.

Changes:
- Add latest completed strength session result helper.
- Prefer completed session results for latest strength context.
- Keep workouts as fallback.
- Add backend contract test.

Validation:
- python -m py_compile app/backend/app.py
- pytest tests/test_today_plan_strength_rotation_source_contract.py -q
- Result: 2 passed