### PR TITLE
Sort latest strength session result by date

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -1593,15 +1593,28 @@ def find_latest_session_by_type(session_results, session_type):
 
 
 def find_latest_completed_strength_session_result(session_results):
-    for session in reversed(session_results or []):
+    candidates = []
+    for session in session_results or []:
         if not isinstance(session, dict):
             continue
         if str(session.get("session_type", "")).strip() != "styrke":
             continue
         if not bool(session.get("completed", False)):
             continue
-        return session
-    return None
+        candidates.append(session)
+
+    if not candidates:
+        return None
+
+    return sorted(
+        candidates,
+        key=lambda item: (
+            str(item.get("date", "")).strip(),
+            str(item.get("created_at", "")).strip(),
+            str(item.get("id", "")).strip(),
+        ),
+        reverse=True,
+    )[0]
 
 
 def get_starter_capacity_calibration_sessions(session_results, limit=3):

--- a/tests/test_today_plan_strength_rotation_source_contract.py
+++ b/tests/test_today_plan_strength_rotation_source_contract.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import importlib.util
+import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 APP = ROOT / "app/backend/app.py"
@@ -19,3 +21,35 @@ def test_today_plan_no_longer_sets_latest_strength_from_workouts_before_session_
     block = py[start:end]
 
     assert "latest_strength = find_latest_strength_workout(workouts)\\n    days_since_last_strength" not in block
+
+
+def test_latest_completed_strength_session_result_sorts_by_date_not_list_order():
+    backend_dir = ROOT / "app/backend"
+    if str(backend_dir) not in sys.path:
+        sys.path.insert(0, str(backend_dir))
+
+    spec = importlib.util.spec_from_file_location("sovereign_app", APP)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    sessions = [
+        {
+            "id": "newer",
+            "date": "2026-04-29",
+            "session_type": "styrke",
+            "completed": True,
+            "program_day_label": "Day A",
+        },
+        {
+            "id": "older",
+            "date": "2026-04-20",
+            "session_type": "styrke",
+            "completed": True,
+            "program_day_label": "Old Day",
+        },
+    ]
+
+    latest = module.find_latest_completed_strength_session_result(sessions)
+
+    assert latest["id"] == "newer"
+    assert latest["program_day_label"] == "Day A"


### PR DESCRIPTION
Part of #750.

Changes:
- Sort completed strength session result candidates by date, created_at, and id before selecting latest context.
- Prevent session_results JSON list order from deciding strength rotation.
- Extend backend contract test to prove newer dated sessions win even when list order is misleading.

Validation:
- python -m py_compile app/backend/app.py
- pytest tests/test_today_plan_strength_rotation_source_contract.py -q
- Result: 3 passed

Scope: backend latest-strength context selection only.