### PR TITLE
Clarify adjusted Today Plan wording

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -7482,7 +7482,8 @@ function deriveTodayPlanDisplayState(item){
     trainingAllowedSummary = tr("plan.weekplan_rest_today");
   } else if (todayWeekKind && todayWeekKind !== actualKind){
     const plannedLabel = formatSessionType(todayWeekPlanItem?.kind || todayWeekPlanItem?.kindLabel || "");
-    trainingAllowedSummary = tr("plan.weekplan_adjusted_today", { value: plannedLabel });
+    const actualLabel = formatSessionType(item?.session_type || "");
+    trainingAllowedSummary = tr("plan.weekplan_adjusted_to_today", { planned: plannedLabel, actual: actualLabel });
   } else if (todayWeekKind){
     const plannedLabel = formatSessionType(todayWeekPlanItem?.kind || todayWeekPlanItem?.kindLabel || "");
     trainingAllowedSummary = tr("plan.weekplan_planned_label", { value: plannedLabel });

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -942,5 +942,6 @@
   "local_protection.region.shoulder": "Skulder",
   "local_protection.region.elbow": "Albue",
   "local_protection.region.wrist": "Håndled",
-  "today_plan.local_adjustment_scope_help": "Justerer kun denne øvelse i dag. Programskift og loaded alternativer håndteres via programanbefalinger."
+  "today_plan.local_adjustment_scope_help": "Justerer kun denne øvelse i dag. Programskift og loaded alternativer håndteres via programanbefalinger.",
+  "plan.weekplan_adjusted_to_today": "Ugeplanen foreslog {planned}, men dagens plan er justeret til {actual}."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -926,5 +926,6 @@
   "local_protection.region.shoulder": "Shoulder",
   "local_protection.region.elbow": "Elbow",
   "local_protection.region.wrist": "Wrist",
-  "today_plan.local_adjustment_scope_help": "Adjusts only this exercise today. Program switches and loaded alternatives are handled through program recommendations."
+  "today_plan.local_adjustment_scope_help": "Adjusts only this exercise today. Program switches and loaded alternatives are handled through program recommendations.",
+  "plan.weekplan_adjusted_to_today": "The weekly plan suggested {planned}, but today's plan was adjusted to {actual}."
 }


### PR DESCRIPTION
Fixes #757.

Summary:
- Clarifies the Today Plan summary when the weekly planned modality differs from the actual adjusted recommendation.
- Shows both the planned weekly modality and the actual adjusted session type.
- Adds Danish and English i18n strings for the clearer wording.

Before:
- `Planlagt i ugeplanen: Mobilitet · justeret i dag.`

After:
- `Ugeplanen foreslog Mobilitet, men dagens plan er justeret til Styrke.`

Scope:
- Frontend display logic only
- i18n only
- No backend changes
- No data changes
- No proxy changes
- Does not change planner behavior or workout/review flow

Validation:
- `node --check app/frontend/app.js`
- `python3 -m json.tool app/frontend/i18n/da.json >/dev/null`
- `python3 -m json.tool app/frontend/i18n/en.json >/dev/null`
- Result: all passed with no output

Risk:
- Low. This only changes user-facing summary text for adjusted Today Plan display.