### PR TITLE
Localize Today overview next-guidance fallback

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2152,7 +2152,7 @@ function renderForecastHero(planItem, latestCheckin){
     }
 
     let nextGuidanceMessage = getNextPlannedSessionOverviewText(planItem || null) || "";
-    if (!nextGuidanceMessage){
+    if (!nextGuidanceMessage && getCurrentLang() === "en"){
       const rawNextGuidanceMessage = String(planItem?.next_guidance?.message || "").trim();
       const loweredNextGuidance = rawNextGuidanceMessage.toLowerCase();
       if (
@@ -2192,7 +2192,10 @@ function renderForecastHero(planItem, latestCheckin){
   if (planVariantLabel && !plannedRestToday) bits.push(tr("forecast.plan_label", { value: formatPlanMotor(planVariantLabel) }));
   if (planItem.recovery_state && typeof planItem.recovery_state === "object") bits.push(tr("forecast.recovery_label", { value: `${formatRecoveryState(planItem.recovery_state.recovery_state || "")}${planItem.recovery_state.recovery_score != null ? ` (${planItem.recovery_state.recovery_score})` : ""}` }));
 
-  let nextGuidanceMessage = String(planItem?.next_guidance?.message || "").trim();
+  let nextGuidanceMessage = getNextPlannedSessionOverviewText(planItem || null) || "";
+  if (!nextGuidanceMessage && getCurrentLang() === "en"){
+    nextGuidanceMessage = String(planItem?.next_guidance?.message || "").trim();
+  }
   if (plannedRestToday){
     const lowered = nextGuidanceMessage.toLowerCase();
     if (
@@ -7489,7 +7492,10 @@ function deriveTodayPlanDisplayState(item){
     trainingAllowedSummary = tr("plan.weekplan_planned_label", { value: plannedLabel });
   }
 
-  let nextGuidanceMessage = String(item?.next_guidance?.message || "").trim();
+  let nextGuidanceMessage = getNextPlannedSessionOverviewText(item || null) || "";
+  if (!nextGuidanceMessage && getCurrentLang() === "en"){
+    nextGuidanceMessage = String(item?.next_guidance?.message || "").trim();
+  }
   if (isPlannedRestDay && nextGuidanceMessage){
     const lowered = nextGuidanceMessage.toLowerCase();
     if (


### PR DESCRIPTION
Fixes #739.

Summary:
- Prevents raw backend `next_guidance.message` from leaking into the Danish Today/Overview UI.
- Keeps using structured frontend formatting via `getNextPlannedSessionOverviewText(...)` when available.
- Allows raw backend fallback only when the active UI language is English.
- Applies the same fallback rule across forecast hero and Today Plan display-state logic.

Why:
The Danish UI could show English guidance such as:

`Today's focus is strength. The next expected training after today is strength 2026-04-27.`

That made an otherwise Danish card feel unfinished.

Scope:
- Frontend display logic only
- No backend changes
- No data changes
- No i18n file changes
- No planner behavior changes
- Does not affect workout/review flow

Validation:
- `node --check app/frontend/app.js`
- Result: passed with no output

Risk:
- Low. The change only suppresses raw backend English fallback in non-English UI and keeps English fallback behavior for English UI.