### PR TITLE
Explain local protection adjustments in Today Plan

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -3919,6 +3919,46 @@ function formatPlanReason(value){
   return tr("plan.reason.generic_today_choice");
 }
 
+function formatLocalProtectionRegion(region){
+  const key = String(region || "").trim().toLowerCase();
+  if (!key) return "";
+  const label = tr(`local_protection.region.${key}`);
+  return label === `local_protection.region.${key}` ? key : label;
+}
+
+function formatLocalProtectionExplanation(item){
+  if (!item || typeof item !== "object") return "";
+
+  const rawExplanation = String(item.local_protection_explanation || "").trim();
+  const rawReason = String(item.reason || "").trim();
+  const planVariant = String(item.plan_variant || "").trim().toLowerCase();
+
+  const knownRegions = ["ankle_calf", "knee", "hip", "low_back", "shoulder", "elbow", "wrist"];
+  const usedRegions = knownRegions.filter(region =>
+    rawExplanation.includes(region) || rawReason.includes(region)
+  );
+
+  if (rawExplanation){
+    let text = rawExplanation;
+    usedRegions.forEach(region => {
+      text = text.replaceAll(region, formatLocalProtectionRegion(region));
+    });
+    return text;
+  }
+
+  const hasLocalProtectionSignal =
+    planVariant === "local_light_strength" ||
+    planVariant === "local_protection_override" ||
+    planVariant === "local_protection_restitution" ||
+    rawReason.toLowerCase().includes("lokal beskyttelse") ||
+    rawReason.toLowerCase().includes("local protection");
+
+  if (!hasLocalProtectionSignal || !usedRegions.length) return "";
+
+  const regionText = usedRegions.map(formatLocalProtectionRegion).filter(Boolean).join(", ");
+  return regionText ? tr("today_plan.local_protection_adjusted", { regions: regionText }) : "";
+}
+
 function formatFatigueText(value){
   const v = String(value || "").trim().toLowerCase();
   if (!v) return tr("common.unknown_lower");
@@ -7654,7 +7694,7 @@ function renderStandardTodayPlan(item, root, displayState){
     variantLabel,
     timeBudgetMin: item.time_budget_min,
     planContextBits,
-    localProtectionExplanation: item?.local_protection_explanation || "",
+    localProtectionExplanation: formatLocalProtectionExplanation(item),
   });
 
   const recoveryCard = "";

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -943,5 +943,6 @@
   "local_protection.region.elbow": "Albue",
   "local_protection.region.wrist": "Håndled",
   "today_plan.local_adjustment_scope_help": "Justerer kun denne øvelse i dag. Programskift og loaded alternativer håndteres via programanbefalinger.",
-  "plan.weekplan_adjusted_to_today": "Ugeplanen foreslog {planned}, men dagens plan er justeret til {actual}."
+  "plan.weekplan_adjusted_to_today": "Ugeplanen foreslog {planned}, men dagens plan er justeret til {actual}.",
+  "today_plan.local_protection_adjusted": "Dagens plan er justeret for at beskytte {regions}."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -927,5 +927,6 @@
   "local_protection.region.elbow": "Elbow",
   "local_protection.region.wrist": "Wrist",
   "today_plan.local_adjustment_scope_help": "Adjusts only this exercise today. Program switches and loaded alternatives are handled through program recommendations.",
-  "plan.weekplan_adjusted_to_today": "The weekly plan suggested {planned}, but today's plan was adjusted to {actual}."
+  "plan.weekplan_adjusted_to_today": "The weekly plan suggested {planned}, but today's plan was adjusted to {actual}.",
+  "today_plan.local_protection_adjusted": "Today's plan was adjusted to protect {regions}."
 }


### PR DESCRIPTION
Fixes #725.

Summary:
- Adds a centralized frontend helper for local protection display text.
- Maps internal region keys such as `low_back` through existing i18n region labels.
- Builds a fallback explanation when `local_protection_explanation` is missing but the plan variant/reason indicates local protection.
- Uses the formatted explanation in the Today Plan hero card.
- Adds Danish and English i18n strings for local protection adjustment fallback text.

Why:
The Today Plan could functionally adjust for local protection while still failing to explain the adjustment clearly to the user. In some cases, internal region keys such as `low_back` could leak into user-facing text.

Scope:
- Frontend explainability only
- i18n only
- No backend changes
- No planner behavior changes
- No data changes
- Does not affect workout/review flow

Validation:
- `node --check app/frontend/app.js`
- `python3 -m json.tool app/frontend/i18n/da.json >/dev/null`
- `python3 -m json.tool app/frontend/i18n/en.json >/dev/null`
- `.venv/bin/python -m pytest tests/test_local_protection_scenarios.py tests/test_manual_local_protection_ui_contract.py tests/test_longitudinal_scenarios.py -q`
- Result: `18 passed in 34.25s`

Risk:
- Low to moderate. This changes user-facing explanation text only and keeps existing local protection behavior intact.