### PR TITLE
Localize saved session history progression text

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1409,7 +1409,7 @@ function renderSessionHistory(items){
     const totalReps = Number(summary.total_reps || 0);
     const totalTUT = Number(summary.total_time_under_tension_sec || 0);
     const estimatedVolume = Number(summary.estimated_volume || 0);
-    const nextStepHint = String(summary.next_step_hint || "").trim();
+    const nextStepHint = formatSavedSummaryNextStep(String(summary.progression_summary || summary.next_step_hint || "").trim());
     const progressFlags = Array.isArray(summary.progress_flags) ? summary.progress_flags : [];
     const notes = String(item && item.notes || "").trim();
     const typeLabel = formatSessionType(item && item.session_type || "");

--- a/tests/test_saved_summary_localization_contract.py
+++ b/tests/test_saved_summary_localization_contract.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "frontend" / "app.js"
+DA_JSON = ROOT / "app" / "frontend" / "i18n" / "da.json"
+
+
+def test_session_history_formats_saved_next_step_hint():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert (
+        'const nextStepHint = formatSavedSummaryNextStep(String(summary.progression_summary || summary.next_step_hint || "").trim());'
+        in js
+    )
+    assert 'const nextStepHint = String(summary.next_step_hint || "").trim();' not in js
+
+
+def test_danish_saved_summary_progression_text_exists():
+    da = DA_JSON.read_text(encoding="utf-8")
+
+    assert '"review.saved_summary.progress_next_time": "Du kan sandsynligvis progrediere næste gang."' in da
+    assert '"review.saved_summary.light_load_recorded": "Lav samlet belastning registreret."' in da
+    assert '"review.saved_summary.session_saved": "Dagens session er gemt."' in da


### PR DESCRIPTION
Fixes #727.

Summary:
- Updates Session History rendering so saved progression guidance is passed through the existing localization formatter.
- Uses `progression_summary` first, then falls back to `next_step_hint`.
- Adds a contract test to prevent raw backend English next-step text from reappearing in Danish history UI.

Why:
History could show mixed-language text such as:

`Progression næste gang: You can probably progress next time.`

The review summary path already localized these strings, but Session History rendered `summary.next_step_hint` directly.

Scope:
- Frontend history rendering only
- Test coverage only
- No backend changes
- No data migration
- No session save behavior changes
- Does not affect Today Plan or workout execution

Validation:
- `node --check app/frontend/app.js`
- `.venv/bin/python -m pytest tests/test_saved_summary_localization_contract.py -q`
- Result: `2 passed in 0.05s`

Risk:
- Low. Existing saved strings remain unchanged; only user-facing rendering is localized.