### PR TITLE
Improve latest workouts summary detail

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1009,6 +1009,7 @@ function renderWorkouts(items){
     const rawEntries = Array.isArray(item.entries) ? item.entries : [];
     const isCardio = String(item?.session_type || "").trim().toLowerCase() === "løb";
     const cardioMeta = buildCardioHistoryMeta(item);
+    const compactSummary = buildLatestWorkoutSummary(item);
     const totalSets = rawEntries.reduce((sum, entry) => sum + (Number(entry?.sets || 0) || 0), 0);
 
     const entriesHtml = isCardio
@@ -1043,9 +1044,7 @@ function renderWorkouts(items){
           <span class="small">${esc(item.date || "")}</span>
         </div>
         <div class="small">
-          ${isCardio
-            ? esc(cardioMeta || "")
-            : `${totalSets ? tr("exercise.sets_count", { count: esc(String(totalSets)) }) : ""}`}
+          ${esc(compactSummary || (isCardio ? cardioMeta : ""))}
         </div>
         ${item.notes ? `<div style="margin-top:8px">${esc(item.notes)}</div>` : ""}
         ${entriesHtml}
@@ -1092,6 +1091,45 @@ function buildCardioHistoryMeta(item){
   const rpe = item?.avg_rpe != null && item?.avg_rpe !== "" ? `RPE ${item.avg_rpe}` : "";
 
   return [cardioKind, distance, duration, pace, rpe].filter(Boolean).join(" · ");
+}
+
+function buildLatestWorkoutSummary(item){
+  if (!item || typeof item !== "object") return "";
+
+  const summary = item.summary && typeof item.summary === "object" ? item.summary : {};
+  const sessionType = String(item.session_type || summary.session_type || "").trim().toLowerCase();
+
+  if (sessionType === "løb" || sessionType === "cardio" || sessionType === "run"){
+    return buildCardioHistoryMeta({
+      ...item,
+      cardio_kind: item.cardio_kind || summary.cardio_kind,
+      distance_km: item.distance_km ?? summary.distance_km,
+      duration_total_sec: item.duration_total_sec ?? summary.duration_total_sec,
+      pace_sec_per_km: item.pace_sec_per_km ?? summary.pace_sec_per_km,
+    });
+  }
+
+  const results = Array.isArray(item.results) ? item.results : [];
+  const completedExercises = Number(summary.completed_exercises || summary.total_exercises || 0) || results.length;
+  const totalSets = Number(summary.total_sets || 0) || results.reduce((acc, result) => {
+    const sets = Array.isArray(result?.sets) ? result.sets : [];
+    return acc + sets.length;
+  }, 0);
+  const totalReps = Number(summary.total_reps || 0) || results.reduce((acc, result) => {
+    const sets = Array.isArray(result?.sets) ? result.sets : [];
+    return acc + sets.reduce((inner, set) => inner + (Number(set?.reps || 0) || 0), 0);
+  }, 0);
+  const totalTUT = Number(summary.total_time_under_tension_sec || 0) || 0;
+  const estimatedVolume = Number(summary.estimated_volume || 0) || 0;
+
+  const bits = [];
+  if (completedExercises) bits.push(tr("history.exercise_count_compact", { count: String(completedExercises) }));
+  if (totalSets) bits.push(tr("exercise.sets_count", { count: String(totalSets) }));
+  if (totalReps) bits.push(tr("exercise.reps_count", { count: String(totalReps) }));
+  if (totalTUT) bits.push(`${Math.round(totalTUT)} ${tr("unit.seconds")}`);
+  if (estimatedVolume) bits.push(tr("exercise.volume_label", { value: String(Math.round(estimatedVolume)) }));
+
+  return bits.join(" · ");
 }
 
 function getUserBodyweightKg(){

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -944,5 +944,6 @@
   "local_protection.region.wrist": "Håndled",
   "today_plan.local_adjustment_scope_help": "Justerer kun denne øvelse i dag. Programskift og loaded alternativer håndteres via programanbefalinger.",
   "plan.weekplan_adjusted_to_today": "Ugeplanen foreslog {planned}, men dagens plan er justeret til {actual}.",
-  "today_plan.local_protection_adjusted": "Dagens plan er justeret for at beskytte {regions}."
+  "today_plan.local_protection_adjusted": "Dagens plan er justeret for at beskytte {regions}.",
+  "history.exercise_count_compact": "{count} øvelse(r)"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -928,5 +928,6 @@
   "local_protection.region.wrist": "Wrist",
   "today_plan.local_adjustment_scope_help": "Adjusts only this exercise today. Program switches and loaded alternatives are handled through program recommendations.",
   "plan.weekplan_adjusted_to_today": "The weekly plan suggested {planned}, but today's plan was adjusted to {actual}.",
-  "today_plan.local_protection_adjusted": "Today's plan was adjusted to protect {regions}."
+  "today_plan.local_protection_adjusted": "Today's plan was adjusted to protect {regions}.",
+  "history.exercise_count_compact": "{count} exercise(s)"
 }

--- a/tests/test_latest_workouts_summary_contract.py
+++ b/tests/test_latest_workouts_summary_contract.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "frontend" / "app.js"
+DA_JSON = ROOT / "app" / "frontend" / "i18n" / "da.json"
+EN_JSON = ROOT / "app" / "frontend" / "i18n" / "en.json"
+
+
+def test_latest_workouts_uses_compact_summary_helper():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert "function buildLatestWorkoutSummary(item){" in js
+    assert "const compactSummary = buildLatestWorkoutSummary(item);" in js
+    assert "${esc(compactSummary || (isCardio ? cardioMeta : \"\"))}" in js
+
+
+def test_latest_workouts_summary_uses_session_result_summary_fields():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert "summary.completed_exercises" in js
+    assert "summary.total_sets" in js
+    assert "summary.total_reps" in js
+    assert "summary.total_time_under_tension_sec" in js
+    assert "summary.estimated_volume" in js
+
+
+def test_latest_workouts_compact_i18n_keys_exist():
+    da = DA_JSON.read_text(encoding="utf-8")
+    en = EN_JSON.read_text(encoding="utf-8")
+
+    assert '"history.exercise_count_compact": "{count} øvelse(r)"' in da
+    assert '"history.exercise_count_compact": "{count} exercise(s)"' in en


### PR DESCRIPTION
Fixes #728.

Summary:
- Adds a compact latest-workout summary helper for the `Seneste workouts` card.
- Uses existing session-result `summary` fields first, including exercise count, sets, reps, time-under-tension, and estimated volume.
- Keeps cardio summaries based on existing cardio history metadata.
- Adds Danish and English compact exercise-count i18n keys.
- Adds a frontend contract test so the latest-workouts card keeps using useful summary data.

Why:
The latest workouts card was too minimal and could show little more than session type and date. It now gives users enough compact information to distinguish recent sessions without expanding the card into a full history view.

Scope:
- Frontend history overview only
- i18n only
- Test coverage only
- No backend changes
- No data changes
- No workout execution changes
- Existing detailed session history remains unchanged

Validation:
- `node --check app/frontend/app.js`
- `python3 -m json.tool app/frontend/i18n/da.json >/dev/null`
- `python3 -m json.tool app/frontend/i18n/en.json >/dev/null`
- `.venv/bin/python -m pytest tests/test_latest_workouts_summary_contract.py -q`
- Result: `3 passed in 0.06s`

Risk:
- Low. This only changes compact rendering in the latest workouts card and relies on existing stored session summary fields.