### PR TITLE
Add safe catalog deploy workflow

### DIFF
--- a/scripts/deploy_catalog_safe.sh
+++ b/scripts/deploy_catalog_safe.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SRC_ROOT="app/data/seed"
+TARGET_ROOT="/var/www/sovereign-strength/data"
+BACKUP_TS="$(date +%Y%m%d-%H%M%S)"
+
+FILES=(
+  "programs.json"
+  "exercises.json"
+)
+
+echo "Safe catalog deploy"
+echo "Source: ${SRC_ROOT}"
+echo "Target: ${TARGET_ROOT}"
+echo
+
+if [[ ! -d "${SRC_ROOT}" ]]; then
+  echo "ERROR: Source root not found: ${SRC_ROOT}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${TARGET_ROOT}" ]]; then
+  echo "ERROR: Target data root not found: ${TARGET_ROOT}" >&2
+  exit 1
+fi
+
+for rel in "${FILES[@]}"; do
+  if [[ ! -f "${SRC_ROOT}/${rel}" ]]; then
+    echo "ERROR: Missing source catalog file: ${SRC_ROOT}/${rel}" >&2
+    exit 1
+  fi
+done
+
+echo "Validating local catalog JSON..."
+python3 -m json.tool "${SRC_ROOT}/programs.json" >/dev/null
+python3 -m json.tool "${SRC_ROOT}/exercises.json" >/dev/null
+
+echo "Validating catalog integrity..."
+python3 scripts/validate_catalog_integrity.py
+
+echo
+echo "Creating live catalog backups..."
+for rel in "${FILES[@]}"; do
+  if [[ ! -f "${TARGET_ROOT}/${rel}" ]]; then
+    echo "ERROR: Missing live catalog file: ${TARGET_ROOT}/${rel}" >&2
+    exit 1
+  fi
+  backup_path="${TARGET_ROOT}/${rel}.bak.${BACKUP_TS}"
+  echo "-> ${backup_path}"
+  sudo cp "${TARGET_ROOT}/${rel}" "${backup_path}"
+done
+
+echo
+echo "Deploying managed catalog files only..."
+for rel in "${FILES[@]}"; do
+  echo "-> ${rel}"
+  sudo cp "${SRC_ROOT}/${rel}" "${TARGET_ROOT}/${rel}"
+  sudo chown root:root "${TARGET_ROOT}/${rel}"
+  sudo chmod 644 "${TARGET_ROOT}/${rel}"
+done
+
+echo
+echo "Post-deploy safety checks..."
+for rel in "${FILES[@]}"; do
+  if [[ ! -s "${TARGET_ROOT}/${rel}" ]]; then
+    echo "ERROR: Deployed catalog file missing or empty: ${TARGET_ROOT}/${rel}" >&2
+    exit 1
+  fi
+  python3 -m json.tool "${TARGET_ROOT}/${rel}" >/dev/null
+  echo "OK: ${TARGET_ROOT}/${rel}"
+done
+
+echo "Catalog deploy completed safely."

--- a/tests/test_safe_catalog_deploy_script_contract.py
+++ b/tests/test_safe_catalog_deploy_script_contract.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "deploy_catalog_safe.sh"
+
+
+def test_safe_catalog_deploy_script_exists_and_is_catalog_only():
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'SRC_ROOT="app/data/seed"' in text
+    assert 'TARGET_ROOT="/var/www/sovereign-strength/data"' in text
+    assert '"programs.json"' in text
+    assert '"exercises.json"' in text
+
+    assert "rsync" not in text
+    assert "rm -rf" not in text
+    assert "workouts.json" not in text
+    assert "user_settings.json" not in text
+    assert "checkins.json" not in text
+
+
+def test_safe_catalog_deploy_script_validates_and_backs_up_before_copy():
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'python3 -m json.tool "${SRC_ROOT}/programs.json" >/dev/null' in text
+    assert 'python3 -m json.tool "${SRC_ROOT}/exercises.json" >/dev/null' in text
+    assert "python3 scripts/validate_catalog_integrity.py" in text
+    assert 'backup_path="${TARGET_ROOT}/${rel}.bak.${BACKUP_TS}"' in text
+    assert 'sudo cp "${TARGET_ROOT}/${rel}" "${backup_path}"' in text
+    assert 'sudo cp "${SRC_ROOT}/${rel}" "${TARGET_ROOT}/${rel}"' in text
+    assert 'sudo chmod 644 "${TARGET_ROOT}/${rel}"' in text


### PR DESCRIPTION
Fixes #511.

Summary:
- Adds `scripts/deploy_catalog_safe.sh` as an explicit safe deploy workflow for frontend-visible catalog data.
- Deploys only:
  - `app/data/seed/programs.json` → `/var/www/sovereign-strength/data/programs.json`
  - `app/data/seed/exercises.json` → `/var/www/sovereign-strength/data/exercises.json`
- Validates local JSON before deploy.
- Runs catalog integrity validation before deploy.
- Creates timestamped live backups before copying.
- Sets deployed catalog file ownership/permissions.
- Runs post-deploy existence and JSON checks.
- Adds a contract test to prevent the script from expanding into runtime/user data or broad rsync behavior.

Why:
The normal safe frontend deploy intentionally deploys only managed frontend files. That left a deployment gap for Library/catalog changes, proven during #726 where merged seed/catalog changes still required manual live data copy.

Scope:
- Deploy workflow only
- Catalog files only
- No backend changes
- No frontend app behavior changes
- No runtime user data changes
- Does not alter `scripts/deploy_frontend_safe.sh`

Validation:
- `bash -n scripts/deploy_catalog_safe.sh`
- `python3 scripts/validate_catalog_integrity.py`
- `.venv/bin/python -m pytest tests/test_safe_catalog_deploy_script_contract.py -q`
- Result: catalog integrity OK, `2 passed in 0.05s`

Live workflow test:
- Ran `./scripts/deploy_catalog_safe.sh`
- Script created timestamped backups:
  - `/var/www/sovereign-strength/data/programs.json.bak.20260502-000933`
  - `/var/www/sovereign-strength/data/exercises.json.bak.20260502-000933`
- Script deployed only `programs.json` and `exercises.json`
- Post-deploy checks passed

Risk:
- Low. The script is explicit, catalog-only, validates before deploy, backs up before copy, and avoids broad data sync behavior.