### PR TITLE
Respect planned running days in Today Plan

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -271,6 +271,150 @@ def get_iso_weekday_key(date_str):
     return mapping.get(dt.isoweekday())
 
 
+def choose_week_index_combinations(indices, target_count):
+    values = list(indices or [])
+    try:
+        target = int(target_count or 0)
+    except Exception:
+        target = 0
+
+    out = []
+    n = len(values)
+    if not n or target <= 0 or target > n:
+        return out
+
+    def walk(start_idx, acc):
+        if len(acc) == target:
+            out.append(list(acc))
+            return
+        for idx in range(start_idx, n):
+            acc.append(values[idx])
+            walk(idx + 1, acc)
+            acc.pop()
+
+    walk(0, [])
+    return out
+
+
+def score_training_slot_combo(indices, total_days=7):
+    try:
+        days = max(1, int(total_days or 7))
+    except Exception:
+        days = 7
+
+    sorted_indices = sorted(int(x) for x in (indices or []))
+    if not sorted_indices:
+        return float("-inf")
+    if len(sorted_indices) == 1:
+        return 1000
+
+    gaps = []
+    for idx, current in enumerate(sorted_indices):
+        next_value = sorted_indices[(idx + 1) % len(sorted_indices)]
+        gap = (next_value + days) - current if idx == len(sorted_indices) - 1 else next_value - current
+        gaps.append(gap)
+
+    min_gap = min(gaps)
+    max_gap = max(gaps)
+    adjacent_count = sum(1 for gap in gaps if gap <= 1)
+    tight_count = sum(1 for gap in gaps if gap <= 2)
+    spread_penalty = max_gap - min_gap
+
+    return (min_gap * 100) - (adjacent_count * 1000) - (tight_count * 25) - (spread_penalty * 10)
+
+
+def pick_distributed_week_indices(available_indices, target_count, total_days=7):
+    indices = [
+        int(x)
+        for x in (available_indices or [])
+        if isinstance(x, int) or str(x).strip().isdigit()
+    ]
+
+    try:
+        target = max(0, min(int(target_count or 0), len(indices)))
+    except Exception:
+        target = 0
+
+    if not indices or not target:
+        return []
+    if target >= len(indices):
+        return sorted(indices)
+
+    combos = choose_week_index_combinations(indices, target)
+    if not combos:
+        return []
+
+    best = combos[0]
+    best_score = score_training_slot_combo(best, total_days)
+
+    for combo in combos[1:]:
+        score = score_training_slot_combo(combo, total_days)
+        if score > best_score:
+            best = combo
+            best_score = score
+
+    return sorted(best)
+
+
+def get_week_plan_type_sequence_from_preferences(preferences):
+    prefs = preferences if isinstance(preferences, dict) else {}
+    training_types = prefs.get("training_types", {})
+    if not isinstance(training_types, dict):
+        training_types = {}
+
+    wants_strength = training_types.get("strength_weights") is not False or training_types.get("bodyweight") is not False
+    wants_running = training_types.get("running") is True
+    wants_mobility = training_types.get("mobility") is True
+
+    if wants_strength and wants_running:
+        return ["strength", "running"]
+    if wants_strength:
+        return ["strength"]
+    if wants_running:
+        return ["running"]
+    if wants_mobility:
+        return ["mobility"]
+    return ["recovery"]
+
+
+def infer_week_plan_kind_for_day(preferences, weekday_key, training_days, preferred_sessions):
+    day_order = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+    key = str(weekday_key or "").strip().lower()
+    if key not in day_order:
+        return "rest"
+
+    enabled_days = {str(x).strip().lower() for x in (training_days or []) if str(x).strip()}
+    available_indices = [
+        idx
+        for idx, day_key in enumerate(day_order)
+        if day_key in enabled_days
+    ]
+
+    training_slots = set(pick_distributed_week_indices(available_indices, preferred_sessions, len(day_order)))
+    idx = day_order.index(key)
+
+    if idx in training_slots:
+        sequence = get_week_plan_type_sequence_from_preferences(preferences)
+        sorted_slots = sorted(training_slots)
+        seq_idx = sorted_slots.index(idx)
+        return sequence[seq_idx % len(sequence)] if sequence else "recovery"
+
+    prev_was_training = (idx - 1) in training_slots
+    next_is_training = (idx + 1) in training_slots
+    allowed_day = key in enabled_days
+
+    training_types = preferences.get("training_types", {}) if isinstance(preferences, dict) else {}
+    if not isinstance(training_types, dict):
+        training_types = {}
+
+    if prev_was_training and allowed_day:
+        return "mobility" if training_types.get("mobility") is True else "recovery"
+    if next_is_training and allowed_day and training_types.get("mobility") is True:
+        return "mobility"
+
+    return "rest"
+
+
 def get_training_day_context(user_settings, date_str):
     if not isinstance(user_settings, dict):
         user_settings = {}
@@ -299,12 +443,19 @@ def get_training_day_context(user_settings, date_str):
 
     weekday_key = get_iso_weekday_key(date_str)
     is_training_day = bool(weekday_key and weekday_key in training_days)
+    planned_kind = infer_week_plan_kind_for_day(
+        preferences=preferences,
+        weekday_key=weekday_key,
+        training_days=training_days,
+        preferred_sessions=preferred_sessions,
+    )
 
     return {
         "weekday_key": weekday_key,
         "training_days": training_days,
         "preferred_sessions_per_week": preferred_sessions,
         "is_training_day": is_training_day,
+        "planned_kind": planned_kind,
     }
 def get_user_settings_for(user_id):
     return get_storage().get_user_settings_for(user_id)
@@ -4514,6 +4665,8 @@ def build_today_plan_training_decision(
     starter_capacity_profile = get_starter_capacity_profile(user_settings)
 
     autoplan_meta = None
+    planned_kind = str(training_day_ctx.get("planned_kind", "") if isinstance(training_day_ctx, dict) else "").strip().lower()
+    planned_running_day = planned_kind in ("running", "run", "cardio", "løb")
 
     if not has_any_primary_training_type:
         return {
@@ -4619,7 +4772,44 @@ def build_today_plan_training_decision(
             autoplan_meta = None
 
     elif planning_mode == "autoplan":
-        if prefs.get("strength_weights", True) or prefs.get("bodyweight", True):
+        if planned_running_day and prefs.get("running", True):
+            cardio_plan = build_autoplan_cardio(
+                user_id=auth_user.get("user_id"),
+                readiness=readiness_score,
+                time_budget_min=time_budget_min,
+                recovery_state=recovery_state,
+                training_day_context=training_day_ctx,
+            )
+            session_type = "løb"
+            template_id = "autoplan_cardio"
+            plan_entries = cardio_plan.get("entries", []) if isinstance(cardio_plan, dict) else []
+            plan_variant = "autoplan_cardio"
+            reason = "ugeplanen foreslog løb · cardio-autoplan aktiv"
+            autoplan_meta = {
+                "template_mode": cardio_plan.get("template_mode") if isinstance(cardio_plan, dict) else None,
+                "families_selected": [],
+                "selected_endurance_program_id": selected_endurance_program_id,
+                "local_protection_override": bool(cardio_plan.get("local_protection_override")) if isinstance(cardio_plan, dict) else False,
+                "protected_regions": cardio_plan.get("protected_regions", []) if isinstance(cardio_plan, dict) else [],
+            }
+
+            if not plan_entries:
+                if prefs.get("strength_weights", True) or prefs.get("bodyweight", True):
+                    session_type = "styrke"
+                    template_id = strength_ctx.get("template_id")
+                    plan_entries = strength_ctx.get("plan_entries", [])
+                    plan_variant = strength_ctx.get("plan_variant", "default")
+                    reason = "ugeplanen foreslog løb · cardio tom, fallback til styrkeplan"
+                    autoplan_meta = None
+                else:
+                    session_type = "restitution"
+                    template_id = "restitution_easy"
+                    plan_entries = build_restitution_plan(time_budget_min, starter_capacity_profile=starter_capacity_profile)
+                    plan_variant = "default"
+                    reason = "ugeplanen foreslog løb · cardio tom og ingen styrkevalg · restitution vælges"
+                    autoplan_meta = None
+
+        elif prefs.get("strength_weights", True) or prefs.get("bodyweight", True):
             autoplan = build_autoplan_strength(
                 user_id=auth_user.get("user_id"),
                 readiness=readiness_score,
@@ -4675,7 +4865,44 @@ def build_today_plan_training_decision(
             reason = "løb og styrke fravalgt · restitution vælges"
             autoplan_meta = None
     else:
-        if prefs.get("strength_weights", True) or prefs.get("bodyweight", True):
+        if planned_running_day and prefs.get("running", True):
+            cardio_plan = build_autoplan_cardio(
+                user_id=auth_user.get("user_id"),
+                readiness=readiness_score,
+                time_budget_min=time_budget_min,
+                recovery_state=recovery_state,
+                training_day_context=training_day_ctx,
+            )
+            session_type = "løb"
+            template_id = "autoplan_cardio"
+            plan_entries = cardio_plan.get("entries", []) if isinstance(cardio_plan, dict) else []
+            plan_variant = "autoplan_cardio"
+            reason = "ugeplanen foreslog løb · cardio vælges"
+            autoplan_meta = {
+                "template_mode": cardio_plan.get("template_mode") if isinstance(cardio_plan, dict) else None,
+                "families_selected": [],
+                "selected_endurance_program_id": selected_endurance_program_id,
+                "local_protection_override": bool(cardio_plan.get("local_protection_override")) if isinstance(cardio_plan, dict) else False,
+                "protected_regions": cardio_plan.get("protected_regions", []) if isinstance(cardio_plan, dict) else [],
+            }
+
+            if not plan_entries:
+                if prefs.get("strength_weights", True) or prefs.get("bodyweight", True):
+                    session_type = "styrke"
+                    template_id = strength_ctx.get("template_id")
+                    plan_entries = strength_ctx.get("plan_entries", [])
+                    plan_variant = strength_ctx.get("plan_variant", "default")
+                    reason = "ugeplanen foreslog løb · cardio tom, fallback til styrkeplan"
+                    autoplan_meta = None
+                else:
+                    session_type = "restitution"
+                    template_id = "restitution_easy"
+                    plan_entries = build_restitution_plan(time_budget_min, starter_capacity_profile=starter_capacity_profile)
+                    plan_variant = "default"
+                    reason = "ugeplanen foreslog løb · cardio tom og ingen styrkevalg · restitution vælges"
+                    autoplan_meta = None
+
+        elif prefs.get("strength_weights", True) or prefs.get("bodyweight", True):
             session_type = "styrke"
             template_id = strength_ctx.get("template_id")
             plan_entries = strength_ctx.get("plan_entries", [])
@@ -5450,6 +5677,12 @@ def get_today_plan():
             "reason": item.get("reason"),
             "readiness_score": item.get("readiness_score"),
             "fatigue_score": item.get("fatigue_score"),
+            "weekly_status": item.get("weekly_status"),
+            "recovery_state": item.get("recovery_state"),
+            "training_day_context": item.get("training_day_context"),
+            "selected_strength_program_id": item.get("selected_strength_program_id"),
+            "selected_endurance_program_id": item.get("selected_endurance_program_id"),
+            "decision_trace": item.get("decision_trace"),
         }
     )
 

--- a/tests/test_today_plan_planned_running_day_contract.py
+++ b/tests/test_today_plan_planned_running_day_contract.py
@@ -1,0 +1,165 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND_DIR = ROOT / "app" / "backend"
+APP_PATH = BACKEND_DIR / "app.py"
+
+sys.path.insert(0, str(BACKEND_DIR))
+
+spec = importlib.util.spec_from_file_location("backend_app", APP_PATH)
+backend_app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(backend_app)
+
+
+def user_settings_for_strength_and_running():
+    return {
+        "preferences": {
+            "training_types": {
+                "running": True,
+                "strength_weights": True,
+                "bodyweight": True,
+                "mobility": True,
+            },
+            "training_days": {
+                "mon": True,
+                "tue": False,
+                "wed": True,
+                "thu": True,
+                "fri": True,
+                "sat": True,
+                "sun": True,
+            },
+            "weekly_target_sessions": 4,
+        }
+    }
+
+
+def test_training_day_context_marks_planned_running_day_like_frontend_weekplan():
+    settings = user_settings_for_strength_and_running()
+
+    ctx = backend_app.get_training_day_context(settings, "2026-05-02")
+
+    assert ctx["weekday_key"] == "sat"
+    assert ctx["is_training_day"] is True
+    assert ctx["planned_kind"] == "running"
+
+
+def test_planned_running_day_prefers_cardio_over_generic_strength(monkeypatch):
+    settings = user_settings_for_strength_and_running()
+    ctx = backend_app.get_training_day_context(settings, "2026-05-02")
+
+    monkeypatch.setattr(
+        backend_app,
+        "select_today_strength_program",
+        lambda **kwargs: "base_strength_gym_4x",
+    )
+    monkeypatch.setattr(
+        backend_app,
+        "select_endurance_program",
+        lambda **kwargs: "hybrid_run_strength_3x_beginner",
+    )
+    monkeypatch.setattr(
+        backend_app,
+        "build_strength_plan",
+        lambda **kwargs: {
+            "template_id": "strength_day_a",
+            "plan_entries": [{"exercise_id": "squat"}],
+            "plan_variant": "full",
+            "reason": "styrke prioriteres",
+        },
+    )
+    monkeypatch.setattr(
+        backend_app,
+        "shape_strength_ctx_for_local_protection",
+        lambda strength_ctx, **kwargs: strength_ctx,
+    )
+    monkeypatch.setattr(
+        backend_app,
+        "build_weekly_training_status",
+        lambda **kwargs: {"completed_sessions": 0, "weekly_target_sessions": 4},
+    )
+    monkeypatch.setattr(
+        backend_app,
+        "build_autoplan_cardio",
+        lambda **kwargs: {
+            "entries": [{"exercise_id": "run_easy"}],
+            "template_mode": "autoplan_cardio_v0_1",
+            "local_protection_override": False,
+            "protected_regions": [],
+        },
+    )
+
+    decision = backend_app.build_today_plan_training_decision(
+        auth_user={"user_id": 3},
+        checkin_date="2026-05-02",
+        readiness_score=4,
+        fatigue_score=1,
+        recovery_state={"recovery_state": "ready", "load_status": "normal"},
+        time_budget_min=45,
+        user_settings=settings,
+        training_day_ctx=ctx,
+        programs=[],
+        exercises=[],
+        latest_strength=None,
+    )
+
+    assert decision["session_type"] == "løb"
+    assert decision["template_id"] == "autoplan_cardio"
+    assert decision["plan_variant"] == "autoplan_cardio"
+    assert decision["reason"] == "ugeplanen foreslog løb · cardio vælges"
+    assert len(decision["plan_entries"]) == 1
+
+
+def test_low_readiness_still_overrides_planned_running_day(monkeypatch):
+    settings = user_settings_for_strength_and_running()
+    ctx = backend_app.get_training_day_context(settings, "2026-05-02")
+
+    monkeypatch.setattr(
+        backend_app,
+        "build_local_risk_planning_override",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        backend_app,
+        "should_use_reentry_strength",
+        lambda **kwargs: False,
+    )
+    monkeypatch.setattr(
+        backend_app,
+        "build_restitution_plan",
+        lambda *args, **kwargs: [{"exercise_id": "easy_walk"}],
+    )
+
+    decision = backend_app.resolve_today_plan_decision_context(
+        auth_user={"user_id": 3},
+        checkin_date="2026-05-02",
+        readiness_score=3,
+        fatigue_score=1,
+        timing_state="on_time",
+        recovery_state={"recovery_state": "recover", "load_status": "normal"},
+        days_since_last_strength=2,
+        time_budget_min=45,
+        training_day_ctx=ctx,
+        weekly_status={"completed_sessions": 0, "weekly_target_sessions": 4},
+        latest_checkin={"date": "2026-05-02", "readiness_score": 3},
+        user_settings=settings,
+        programs=[],
+        exercises=[],
+        latest_strength=None,
+    )
+
+    assert decision["session_type"] == "restitution"
+    assert decision["template_id"] == "restitution_easy"
+    assert decision["reason"] == "low readiness"
+
+def test_today_plan_trace_payload_includes_planning_context():
+    js = APP_PATH.read_text(encoding="utf-8")
+
+    assert '"training_day_context": item.get("training_day_context")' in js
+    assert '"weekly_status": item.get("weekly_status")' in js
+    assert '"selected_strength_program_id": item.get("selected_strength_program_id")' in js
+    assert '"selected_endurance_program_id": item.get("selected_endurance_program_id")' in js
+    assert '"decision_trace": item.get("decision_trace")' in js
+


### PR DESCRIPTION
Summary:
- Adds backend planned-week kind inference to `training_day_context` so backend Today Plan sees the same planned day type that the frontend weekplan shows.
- Mirrors the frontend weekplan slot distribution logic in backend helpers.
- Lets planned running days choose cardio/run before generic strength fallback when running is enabled.
- Keeps priority overrides intact: low readiness/recovery can still choose restitution before training decision.
- Expands `today_plan_traces` with useful diagnostic context: weekly status, recovery state, training day context, selected program ids, and decision trace.
- Adds a contract test covering the user 3 case where a planned running day was being turned into strength.

Why:
User 3 saw the weekplan/forecast indicating running, but Today Plan still selected strength or restitution regardless of check-in. Investigation showed backend `training_day_context` only knew whether the date was a training day, not whether it was planned as strength/running/mobility. As a result, generic strength fallback won whenever strength was enabled. Truly majestic, if the goal was to make a plan ignore itself.

Scope:
- Backend Today Plan decision logic
- Backend diagnostic trace payload
- Test coverage
- No frontend changes
- No data changes
- No deployment script changes

Validation:
- `python3 -m py_compile app/backend/app.py`
- `.venv/bin/python -m pytest tests/test_today_plan_planned_running_day_contract.py -q`
- Result: `4 passed in 0.36s`

Behavior verified locally:
- User 3 on 2026-05-02 now gets `training_day_context.planned_kind = running`.
- With readiness 4/fatigue 1, decision becomes `session_type = løb`, `template_id = autoplan_cardio`.
- With readiness 3/recovery state recover, decision remains `session_type = restitution`, preserving safety override.

Risk:
- Moderate-low. This changes Today Plan selection priority for days explicitly inferred as running days, but keeps restitution/priority overrides before the training decision. The added test guards the intended behavior.