### PR TITLE
Preserve run plan variants in Today Plan

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -5026,6 +5026,10 @@ def normalize_session_type(raw):
     return x or "unknown"
 
 
+def should_preserve_plan_variant(session_type):
+    return normalize_session_type(session_type) in ("strength", "cardio", "restitution")
+
+
 def build_decision_trace(
     readiness_score,
     fatigue_score,
@@ -5657,7 +5661,7 @@ def get_today_plan():
         "local_protection_explanation": local_protection_explanation,
         "days_since_last_strength": days_since_last_strength,
         "decision_trace": decision_trace,
-        "plan_variant": plan_variant if session_type in ("styrke", "restitution", "cardio") else "default",
+        "plan_variant": plan_variant if should_preserve_plan_variant(session_type) else "default",
         "entries": plan_entries
     }
 
@@ -5953,7 +5957,7 @@ def get_today_plan_debug():
         "training_day_context": training_day_ctx if isinstance(training_day_ctx, dict) else {},
         "reason": reason,
         "days_since_last_strength": fatigue_ctx["days_since_last_strength"],
-        "plan_variant": plan_variant if session_type in ("styrke", "restitution", "cardio") else "default",
+        "plan_variant": plan_variant if should_preserve_plan_variant(session_type) else "default",
         "entries": plan_entries,
     }
 

--- a/tests/test_run_plan_variant_preserved_contract.py
+++ b/tests/test_run_plan_variant_preserved_contract.py
@@ -1,0 +1,24 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND_DIR = ROOT / "app" / "backend"
+APP_PATH = BACKEND_DIR / "app.py"
+
+sys.path.insert(0, str(BACKEND_DIR))
+
+spec = importlib.util.spec_from_file_location("backend_app", APP_PATH)
+backend_app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(backend_app)
+
+
+def test_run_session_type_preserves_plan_variant():
+    assert backend_app.normalize_session_type("løb") == "cardio"
+    assert backend_app.should_preserve_plan_variant("løb") is True
+    assert backend_app.should_preserve_plan_variant("run") is True
+    assert backend_app.should_preserve_plan_variant("cardio") is True
+
+
+def test_unknown_session_type_does_not_preserve_plan_variant():
+    assert backend_app.should_preserve_plan_variant("weird") is False


### PR DESCRIPTION
Summary:
- Adds `should_preserve_plan_variant(session_type)` using existing `normalize_session_type(...)`.
- Preserves `plan_variant` for Danish run session type `løb`, plus `run` and `cardio`.
- Applies the same normalization in both normal Today Plan and Today Plan debug item builders.
- Adds a contract test for run plan variant preservation.

Why:
After fixing planned running days, live traces showed `session_type = løb` and `template_id = autoplan_cardio`, but `plan_variant = default`. The existing preservation check only accepted `styrke`, `restitution`, and `cardio`, so Danish `løb` was normalized down to `default`. Tiny metadata bug, maximum annoyance, as tradition demands.

Scope:
- Backend metadata normalization only
- No Today Plan selection behavior changes
- No frontend changes
- No data changes

Validation:
- `python3 -m py_compile app/backend/app.py`
- `.venv/bin/python -m pytest tests/test_run_plan_variant_preserved_contract.py -q`
- Result: `2 passed in 0.69s`

Expected behavior:
- `løb`, `run`, and `cardio` preserve variants such as `autoplan_cardio`.
- Unknown session types still fall back to `default`.