### PR TITLE
Add safe backend deploy script

### DIFF
--- a/scripts/deploy_backend_safe.sh
+++ b/scripts/deploy_backend_safe.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SRC_FILE="app/backend/app.py"
+TARGET_FILE="/opt/sovereign-strength-api/app/backend/app.py"
+SERVICE_NAME="sovereign-strength-api.service"
+BACKUP_TS="$(date +%Y%m%d-%H%M%S)"
+BACKUP_FILE="${TARGET_FILE}.bak.${BACKUP_TS}"
+
+echo "Safe backend deploy"
+echo "Source: ${SRC_FILE}"
+echo "Target: ${TARGET_FILE}"
+echo "Service: ${SERVICE_NAME}"
+echo
+
+if [[ ! -f "${SRC_FILE}" ]]; then
+  echo "ERROR: Source backend file not found: ${SRC_FILE}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${TARGET_FILE}" ]]; then
+  echo "ERROR: Target backend file not found: ${TARGET_FILE}" >&2
+  exit 1
+fi
+
+echo "Validating Python syntax..."
+python3 -m py_compile "${SRC_FILE}"
+
+echo
+echo "Verifying active systemd backend path..."
+if ! systemctl cat "${SERVICE_NAME}" --no-pager -l | grep -q "WorkingDirectory=/opt/sovereign-strength-api/app/backend"; then
+  echo "ERROR: Service WorkingDirectory does not match expected active backend path." >&2
+  systemctl cat "${SERVICE_NAME}" --no-pager -l >&2
+  exit 1
+fi
+
+if ! systemctl cat "${SERVICE_NAME}" --no-pager -l | grep -q "app:app"; then
+  echo "ERROR: Service does not appear to run gunicorn app:app." >&2
+  systemctl cat "${SERVICE_NAME}" --no-pager -l >&2
+  exit 1
+fi
+
+echo
+echo "Creating backup..."
+echo "-> ${BACKUP_FILE}"
+sudo cp "${TARGET_FILE}" "${BACKUP_FILE}"
+
+echo
+echo "Deploying backend..."
+sudo cp "${SRC_FILE}" "${TARGET_FILE}"
+sudo chown jakob:jakob "${TARGET_FILE}"
+sudo chmod 644 "${TARGET_FILE}"
+
+echo
+echo "Restarting service..."
+sudo systemctl restart "${SERVICE_NAME}"
+
+echo
+echo "Checking service status..."
+sudo systemctl status "${SERVICE_NAME}" --no-pager -l
+
+echo
+echo "Post-deploy verification..."
+if ! grep -q "def get_today_plan" "${TARGET_FILE}"; then
+  echo "ERROR: Deployed backend file does not look like the expected Flask app." >&2
+  exit 1
+fi
+
+python3 -m py_compile "${TARGET_FILE}"
+
+echo
+echo "Backend deploy completed safely."
+echo "Backup: ${BACKUP_FILE}"

--- a/tests/test_safe_backend_deploy_script_contract.py
+++ b/tests/test_safe_backend_deploy_script_contract.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "deploy_backend_safe.sh"
+
+
+def test_safe_backend_deploy_script_targets_active_backend_path():
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'SRC_FILE="app/backend/app.py"' in text
+    assert 'TARGET_FILE="/opt/sovereign-strength-api/app/backend/app.py"' in text
+    assert 'SERVICE_NAME="sovereign-strength-api.service"' in text
+
+
+def test_safe_backend_deploy_script_validates_before_deploy_and_restarts_service():
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'python3 -m py_compile "${SRC_FILE}"' in text
+    assert 'WorkingDirectory=/opt/sovereign-strength-api/app/backend' in text
+    assert 'sudo cp "${TARGET_FILE}" "${BACKUP_FILE}"' in text
+    assert 'sudo cp "${SRC_FILE}" "${TARGET_FILE}"' in text
+    assert 'sudo systemctl restart "${SERVICE_NAME}"' in text
+    assert 'sudo systemctl status "${SERVICE_NAME}" --no-pager -l' in text
+
+
+def test_safe_backend_deploy_script_verifies_deployed_file():
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'grep -q "def get_today_plan" "${TARGET_FILE}"' in text
+    assert 'python3 -m py_compile "${TARGET_FILE}"' in text


### PR DESCRIPTION
Summary:
- Adds `scripts/deploy_backend_safe.sh` for controlled backend-only deploys.
- Targets the active systemd/Gunicorn backend path: `/opt/sovereign-strength-api/app/backend/app.py`.
- Validates Python syntax before deploy.
- Verifies the systemd service uses the expected backend working directory and `app:app` target.
- Creates a timestamped backup of the live backend file before replacing it.
- Restarts `sovereign-strength-api.service` and prints service status.
- Re-validates the deployed backend file after copy.
- Adds a contract test for the deploy script.

Why:
During the user 3 Today Plan fix, we initially copied backend code to `/opt/sovereign-strength-api/app.py`, but systemd actually serves Gunicorn from `/opt/sovereign-strength-api/app/backend` with `app:app`. That meant deploy appeared successful while live kept running the old code. A thrilling little trap for anyone who enjoys debugging reality itself.

Scope:
- Deploy/ops script only
- No application behavior changes
- No frontend changes
- No data changes

Validation:
- `bash -n scripts/deploy_backend_safe.sh`
- `.venv/bin/python -m pytest tests/test_safe_backend_deploy_script_contract.py -q`
- Result: `3 passed in 0.04s`
- Smoke-tested locally: script created backup, copied backend to active path, restarted service, and service remained active/running.

Risk:
- Low. Script is additive and explicitly validates target path before deploying.