### PR TITLE
Show rest guidance when weekly goal is complete

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -9933,6 +9933,21 @@ function formatIsoDateForUi(dateStr){
   return `${weekdayNames[weekdayIndex]} ${day}. ${monthNames[month - 1]}`;
 }
 
+function isWeeklyGoalComplete(planItem){
+  const weeklyStatus = planItem?.weekly_status && typeof planItem.weekly_status === "object"
+    ? planItem.weekly_status
+    : {};
+  const completed = Number(weeklyStatus.completed_sessions || 0) || 0;
+  const target = Number(weeklyStatus.weekly_target_sessions || weeklyStatus.target_sessions || 0) || 0;
+  return target > 0 && completed >= target;
+}
+
+function getWeeklyGoalCompleteGuidanceText(planItem){
+  return isWeeklyGoalComplete(planItem)
+    ? tr("weekplan.weekly_goal_complete_guidance")
+    : "";
+}
+
 function getNextPlannedSessionInfo(planItem){
   const items = buildWeekPlanItems(planItem);
   if (!Array.isArray(items) || !items.length) return null;
@@ -9981,6 +9996,16 @@ function getNextPlannedSessionInfo(planItem){
 }
 
 function buildNextPlannedSessionHtml(planItem){
+  const weeklyGoalCompleteText = getWeeklyGoalCompleteGuidanceText(planItem);
+  if (weeklyGoalCompleteText){
+    return `
+      <div class="small" style="margin-top:10px; padding-top:10px; border-top:1px solid rgba(255,255,255,0.08)">
+        <div style="font-weight:700; margin-bottom:6px">${esc(tr("review.saved_next_label"))}</div>
+        <div style="font-weight:600">${esc(weeklyGoalCompleteText)}</div>
+      </div>
+    `;
+  }
+
   const info = getNextPlannedSessionInfo(planItem);
   if (!info || !info.nextTraining) return "";
 
@@ -10008,6 +10033,9 @@ function buildNextPlannedSessionHtml(planItem){
 }
 
 function getNextPlannedSessionOverviewText(planItem){
+  const weeklyGoalCompleteText = getWeeklyGoalCompleteGuidanceText(planItem);
+  if (weeklyGoalCompleteText) return weeklyGoalCompleteText;
+
   const info = getNextPlannedSessionInfo(planItem);
   if (!info || !info.nextTraining) return "";
 

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -945,5 +945,6 @@
   "today_plan.local_adjustment_scope_help": "Justerer kun denne øvelse i dag. Programskift og loaded alternativer håndteres via programanbefalinger.",
   "plan.weekplan_adjusted_to_today": "Ugeplanen foreslog {planned}, men dagens plan er justeret til {actual}.",
   "today_plan.local_protection_adjusted": "Dagens plan er justeret for at beskytte {regions}.",
-  "history.exercise_count_compact": "{count} øvelse(r)"
+  "history.exercise_count_compact": "{count} øvelse(r)",
+  "weekplan.weekly_goal_complete_guidance": "Ugemålet er nået. Restituer frem til næste planlagte træningsdag."
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -929,5 +929,6 @@
   "today_plan.local_adjustment_scope_help": "Adjusts only this exercise today. Program switches and loaded alternatives are handled through program recommendations.",
   "plan.weekplan_adjusted_to_today": "The weekly plan suggested {planned}, but today's plan was adjusted to {actual}.",
   "today_plan.local_protection_adjusted": "Today's plan was adjusted to protect {regions}.",
-  "history.exercise_count_compact": "{count} exercise(s)"
+  "history.exercise_count_compact": "{count} exercise(s)",
+  "weekplan.weekly_goal_complete_guidance": "Weekly goal reached. Recover until your next planned training day."
 }

--- a/tests/test_weekly_goal_complete_guidance_contract.py
+++ b/tests/test_weekly_goal_complete_guidance_contract.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "frontend" / "app.js"
+DA_JSON = ROOT / "app" / "frontend" / "i18n" / "da.json"
+EN_JSON = ROOT / "app" / "frontend" / "i18n" / "en.json"
+
+
+def test_weekly_goal_complete_guidance_i18n_keys_exist():
+    da = json.loads(DA_JSON.read_text(encoding="utf-8"))
+    en = json.loads(EN_JSON.read_text(encoding="utf-8"))
+
+    assert da["weekplan.weekly_goal_complete_guidance"] == (
+        "Ugemålet er nået. Restituer frem til næste planlagte træningsdag."
+    )
+    assert en["weekplan.weekly_goal_complete_guidance"] == (
+        "Weekly goal reached. Recover until your next planned training day."
+    )
+
+
+def test_frontend_has_weekly_goal_complete_guard_before_next_session_lookup():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert "function isWeeklyGoalComplete(planItem)" in js
+    assert "completed >= target" in js
+    assert "function getWeeklyGoalCompleteGuidanceText(planItem)" in js
+
+    overview_start = js.index("function getNextPlannedSessionOverviewText(planItem)")
+    overview_block = js[overview_start: overview_start + 500]
+    assert "getWeeklyGoalCompleteGuidanceText(planItem)" in overview_block
+    assert "if (weeklyGoalCompleteText) return weeklyGoalCompleteText;" in overview_block
+    assert overview_block.index("getWeeklyGoalCompleteGuidanceText(planItem)") < overview_block.index("getNextPlannedSessionInfo(planItem)")
+
+
+def test_after_session_html_uses_weekly_goal_complete_guidance():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    html_start = js.index("function buildNextPlannedSessionHtml(planItem)")
+    html_block = js[html_start: html_start + 900]
+    assert "getWeeklyGoalCompleteGuidanceText(planItem)" in html_block
+    assert "weeklyGoalCompleteText" in html_block
+    assert "review.saved_next_label" in html_block
+    assert html_block.index("getWeeklyGoalCompleteGuidanceText(planItem)") < html_block.index("getNextPlannedSessionInfo(planItem)")


### PR DESCRIPTION
Summary:
- Adds a frontend weekly-goal-complete guard for next guidance.
- When `completed_sessions >= weekly_target_sessions`, the overview and after-session next guidance now show:

`Ugemålet er nået. Restituer frem til næste planlagte træningsdag.`

- Adds English fallback copy.
- Prevents the UI from showing another same-week likely session, such as Sunday mobility, as the primary next recommendation when the weekly goal is already complete.
- Adds a lightweight contract test for the frontend guard and i18n keys.

Why:
When user 3 had completed 4/4 weekly sessions, the UI still showed `Næste sandsynlige pas: Mobilitet · søndag 3. maj`. That is technically derived from the rhythm preview, but it is not useful guidance after the weekly target is complete. The app should stop nudging and recommend recovery instead. Humanity has suffered enough from apps pretending every free slot is a productivity opportunity.

Scope:
- Frontend next guidance display
- i18n copy
- No workout logging changes
- No Today Plan selection changes
- No backend decision logic changes

Flow affected:
- forecast → check-in → plan → workout → review/overview
- Specifically post-session overview and weekly rhythm guidance.

Validation:
- `node --check app/frontend/app.js`
- `python3 -m json.tool app/frontend/i18n/da.json >/dev/null`
- `python3 -m json.tool app/frontend/i18n/en.json >/dev/null`
- `.venv/bin/python -m pytest tests/test_weekly_goal_complete_guidance_contract.py -q`
- Result: `3 passed in 0.06s`

Expected behavior:
- If weekly target is complete, frontend shows: `Ugemålet er nået. Restituer frem til næste planlagte træningsdag.`
- It does not show `Næste sandsynlige pas: Mobilitet · søndag ...` as primary guidance in that state.