### PR TITLE
Complete weekly goal guidance across all next-session paths

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -5258,6 +5258,29 @@ def _session_type_label_en(value):
         return "cardio"
     return x
 
+def is_weekly_goal_complete_from_item(item):
+    obj = item if isinstance(item, dict) else {}
+    weekly_status = obj.get("weekly_status", {})
+    if not isinstance(weekly_status, dict):
+        return False
+    try:
+        completed = int(weekly_status.get("completed_sessions", 0) or 0)
+        target = int(weekly_status.get("weekly_target_sessions", weekly_status.get("target_sessions", 0)) or 0)
+    except Exception:
+        return False
+    return target > 0 and completed >= target
+
+
+def build_weekly_goal_complete_guidance():
+    return {
+        "kind": "weekly_goal_complete",
+        "next_session_type": None,
+        "next_date": None,
+        "source": "weekly_goal_complete",
+        "message": "Ugemålet er nået. Restituer frem til næste planlagte træningsdag.",
+    }
+
+
 def build_next_guidance(today_plan_item, completed_today=False):
     item = today_plan_item if isinstance(today_plan_item, dict) else {}
     if not item:
@@ -5310,6 +5333,9 @@ def build_next_guidance(today_plan_item, completed_today=False):
     next_label = _session_type_label_en(next_session_type)
 
     if completed_today:
+        if is_weekly_goal_complete_from_item(item):
+            return build_weekly_goal_complete_guidance()
+
         if next_date:
             return {
                 "kind": "completed_today",

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1597,9 +1597,12 @@ function renderWeeklyRhythmCard(sessionResults, planItem){
   const latestLine = latest
     ? `${String(latest.date || "")} · ${formatSessionType(latest.session_type || "")}`
     : tr("history.weekly_rhythm_none_completed");
-  const nextLine = summary.nextTraining
-    ? `${summary.nextTraining.kindLabel || ""} · ${summary.nextTraining.dateLabel || summary.nextTraining.date || ""}`
-    : tr("common.no_recommendation");
+  const weeklyGoalComplete = Number(summary.completedCount || 0) >= Number(summary.weeklyTargetSessions || 0);
+  const nextLine = weeklyGoalComplete
+    ? tr("weekplan.weekly_goal_complete_guidance")
+    : summary.nextTraining
+      ? `${summary.nextTraining.kindLabel || ""} · ${summary.nextTraining.dateLabel || summary.nextTraining.date || ""}`
+      : tr("common.no_recommendation");
   const rhythmSummaryLine = `${String(summary.completedCount)} / ${String(summary.weeklyTargetSessions)}`;
 
   body.innerHTML = `

--- a/tests/test_weekly_goal_complete_guidance_contract.py
+++ b/tests/test_weekly_goal_complete_guidance_contract.py
@@ -42,3 +42,31 @@ def test_after_session_html_uses_weekly_goal_complete_guidance():
     assert "weeklyGoalCompleteText" in html_block
     assert "review.saved_next_label" in html_block
     assert html_block.index("getWeeklyGoalCompleteGuidanceText(planItem)") < html_block.index("getNextPlannedSessionInfo(planItem)")
+
+
+def test_weekly_rhythm_card_uses_goal_complete_guidance_before_next_training():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    render_start = js.index("function renderWeeklyRhythmCard(sessionResults, planItem)")
+    render_block = js[render_start: render_start + 1800]
+
+    assert "weeklyGoalComplete" in render_block
+    assert "summary.completedCount" in render_block
+    assert "summary.weeklyTargetSessions" in render_block
+    assert 'tr("weekplan.weekly_goal_complete_guidance")' in render_block
+    assert render_block.index("weeklyGoalComplete") < render_block.index("summary.nextTraining")
+
+
+def test_backend_completed_today_uses_weekly_goal_complete_guidance():
+    backend = (ROOT / "app" / "backend" / "app.py").read_text(encoding="utf-8")
+
+    assert "def is_weekly_goal_complete_from_item(item):" in backend
+    assert "def build_weekly_goal_complete_guidance():" in backend
+    assert '"kind": "weekly_goal_complete"' in backend
+    assert '"message": "Ugemålet er nået. Restituer frem til næste planlagte træningsdag."' in backend
+
+    completed_start = backend.index("if completed_today:")
+    completed_block = backend[completed_start: completed_start + 500]
+    assert "is_weekly_goal_complete_from_item(item)" in completed_block
+    assert "return build_weekly_goal_complete_guidance()" in completed_block
+    assert completed_block.index("is_weekly_goal_complete_from_item(item)") < completed_block.index("if next_date:")


### PR DESCRIPTION
Summary:
- Completes the weekly-goal-complete guidance fix across the remaining next-session paths.
- Updates the frontend weekly rhythm card so `4 / 4` no longer shows another same-week next likely session such as Sunday mobility.
- Adds backend `weekly_goal_complete` next guidance for `completed_today` when the weekly target is already reached.
- Extends the weekly-goal-complete contract test to cover the weekly rhythm card and backend completed-today guidance.

Why:
PR #770 fixed one overview path, but screenshots showed two remaining paths still nudging the user toward another session after weekly target completion:

- `Næste planlagte træning: Mobilitet · søndag 3. maj`
- `Mest sandsynligt næste træning · Mobilitet · søndag 3. maj`

When a user has completed `4 / 4`, the primary guidance should be recovery, not a bonus chore wearing a mobility costume.

Expected Danish guidance:

`Ugemålet er nået. Restituer frem til næste planlagte træningsdag.`

Scope:
- Frontend weekly rhythm / next-session display
- Backend completed-today next guidance metadata
- Test coverage
- No workout logging changes
- No Today Plan selection changes
- No program selection changes

Validation:
- `python3 -m py_compile app/backend/app.py`
- `node --check app/frontend/app.js`
- `python3 -m json.tool app/frontend/i18n/da.json >/dev/null`
- `python3 -m json.tool app/frontend/i18n/en.json >/dev/null`
- `.venv/bin/python -m pytest tests/test_weekly_goal_complete_guidance_contract.py -q`
- Result: `5 passed in 0.07s`

Risk:
- Low. This only changes guidance text/metadata when the weekly goal is complete.