### PR TITLE
Use session results for weekly goal guidance

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -9936,17 +9936,40 @@ function formatIsoDateForUi(dateStr){
   return `${weekdayNames[weekdayIndex]} ${day}. ${monthNames[month - 1]}`;
 }
 
-function isWeeklyGoalComplete(planItem){
+function getWeeklyTargetSessionsFromSettings(){
+  const settings = STATE.userSettings && typeof STATE.userSettings === "object" ? STATE.userSettings : {};
+  const preferences = settings.preferences && typeof settings.preferences === "object" ? settings.preferences : {};
+  return Math.max(1, Number(preferences.weekly_target_sessions || 3) || 3);
+}
+
+function countCompletedSessionsThisWeekFromResults(sessionResults, planItem){
+  const items = Array.isArray(sessionResults) ? sessionResults : [];
+  const baseDate = String(planItem?.date || planItem?.recommended_for || "").trim();
+  const todayIso = /^\d{4}-\d{2}-\d{2}$/.test(baseDate) ? baseDate : new Date().toISOString().slice(0, 10);
+  const weekStart = getStartOfIsoWeek(todayIso);
+  if (!weekStart) return 0;
+
+  return items.filter(item => {
+    const itemDate = String(item?.date || "").slice(0, 10);
+    return itemDate && itemDate >= weekStart && itemDate <= todayIso;
+  }).length;
+}
+
+function isWeeklyGoalComplete(planItem, sessionResults){
   const weeklyStatus = planItem?.weekly_status && typeof planItem.weekly_status === "object"
     ? planItem.weekly_status
     : {};
-  const completed = Number(weeklyStatus.completed_sessions || 0) || 0;
-  const target = Number(weeklyStatus.weekly_target_sessions || weeklyStatus.target_sessions || 0) || 0;
-  return target > 0 && completed >= target;
+  const completedFromPlan = Number(weeklyStatus.completed_sessions || 0) || 0;
+  const targetFromPlan = Number(weeklyStatus.weekly_target_sessions || weeklyStatus.target_sessions || 0) || 0;
+  if (targetFromPlan > 0 && completedFromPlan >= targetFromPlan) return true;
+
+  const targetFromSettings = getWeeklyTargetSessionsFromSettings();
+  const completedFromResults = countCompletedSessionsThisWeekFromResults(sessionResults, planItem);
+  return targetFromSettings > 0 && completedFromResults >= targetFromSettings;
 }
 
-function getWeeklyGoalCompleteGuidanceText(planItem){
-  return isWeeklyGoalComplete(planItem)
+function getWeeklyGoalCompleteGuidanceText(planItem, sessionResults){
+  return isWeeklyGoalComplete(planItem, sessionResults)
     ? tr("weekplan.weekly_goal_complete_guidance")
     : "";
 }
@@ -9999,7 +10022,7 @@ function getNextPlannedSessionInfo(planItem){
 }
 
 function buildNextPlannedSessionHtml(planItem){
-  const weeklyGoalCompleteText = getWeeklyGoalCompleteGuidanceText(planItem);
+  const weeklyGoalCompleteText = getWeeklyGoalCompleteGuidanceText(planItem, STATE.sessionResults || []);
   if (weeklyGoalCompleteText){
     return `
       <div class="small" style="margin-top:10px; padding-top:10px; border-top:1px solid rgba(255,255,255,0.08)">
@@ -10036,7 +10059,7 @@ function buildNextPlannedSessionHtml(planItem){
 }
 
 function getNextPlannedSessionOverviewText(planItem){
-  const weeklyGoalCompleteText = getWeeklyGoalCompleteGuidanceText(planItem);
+  const weeklyGoalCompleteText = getWeeklyGoalCompleteGuidanceText(planItem, STATE.sessionResults || []);
   if (weeklyGoalCompleteText) return weeklyGoalCompleteText;
 
   const info = getNextPlannedSessionInfo(planItem);

--- a/tests/test_weekly_goal_complete_guidance_contract.py
+++ b/tests/test_weekly_goal_complete_guidance_contract.py
@@ -22,15 +22,15 @@ def test_weekly_goal_complete_guidance_i18n_keys_exist():
 def test_frontend_has_weekly_goal_complete_guard_before_next_session_lookup():
     js = APP_JS.read_text(encoding="utf-8")
 
-    assert "function isWeeklyGoalComplete(planItem)" in js
+    assert "function isWeeklyGoalComplete(planItem, sessionResults)" in js
     assert "completed >= target" in js
-    assert "function getWeeklyGoalCompleteGuidanceText(planItem)" in js
+    assert "function getWeeklyGoalCompleteGuidanceText(planItem, sessionResults)" in js
 
     overview_start = js.index("function getNextPlannedSessionOverviewText(planItem)")
     overview_block = js[overview_start: overview_start + 500]
-    assert "getWeeklyGoalCompleteGuidanceText(planItem)" in overview_block
+    assert "getWeeklyGoalCompleteGuidanceText(planItem, STATE.sessionResults || [])" in overview_block
     assert "if (weeklyGoalCompleteText) return weeklyGoalCompleteText;" in overview_block
-    assert overview_block.index("getWeeklyGoalCompleteGuidanceText(planItem)") < overview_block.index("getNextPlannedSessionInfo(planItem)")
+    assert overview_block.index("getWeeklyGoalCompleteGuidanceText(planItem, STATE.sessionResults || [])") < overview_block.index("getNextPlannedSessionInfo(planItem)")
 
 
 def test_after_session_html_uses_weekly_goal_complete_guidance():
@@ -38,10 +38,10 @@ def test_after_session_html_uses_weekly_goal_complete_guidance():
 
     html_start = js.index("function buildNextPlannedSessionHtml(planItem)")
     html_block = js[html_start: html_start + 900]
-    assert "getWeeklyGoalCompleteGuidanceText(planItem)" in html_block
+    assert "getWeeklyGoalCompleteGuidanceText(planItem, STATE.sessionResults || [])" in html_block
     assert "weeklyGoalCompleteText" in html_block
     assert "review.saved_next_label" in html_block
-    assert html_block.index("getWeeklyGoalCompleteGuidanceText(planItem)") < html_block.index("getNextPlannedSessionInfo(planItem)")
+    assert html_block.index("getWeeklyGoalCompleteGuidanceText(planItem, STATE.sessionResults || [])") < html_block.index("getNextPlannedSessionInfo(planItem)")
 
 
 def test_weekly_rhythm_card_uses_goal_complete_guidance_before_next_training():
@@ -70,3 +70,19 @@ def test_backend_completed_today_uses_weekly_goal_complete_guidance():
     assert "is_weekly_goal_complete_from_item(item)" in completed_block
     assert "return build_weekly_goal_complete_guidance()" in completed_block
     assert completed_block.index("is_weekly_goal_complete_from_item(item)") < completed_block.index("if next_date:")
+
+
+def test_frontend_weekly_goal_complete_uses_session_results_fallback():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert "function countCompletedSessionsThisWeekFromResults(sessionResults, planItem)" in js
+    assert "function getWeeklyTargetSessionsFromSettings()" in js
+    assert "completedFromResults >= targetFromSettings" in js
+
+    overview_start = js.index("function getNextPlannedSessionOverviewText(planItem)")
+    overview_block = js[overview_start: overview_start + 700]
+    assert "getWeeklyGoalCompleteGuidanceText(planItem, STATE.sessionResults || [])" in overview_block
+
+    html_start = js.index("function buildNextPlannedSessionHtml(planItem)")
+    html_block = js[html_start: html_start + 900]
+    assert "getWeeklyGoalCompleteGuidanceText(planItem, STATE.sessionResults || [])" in html_block


### PR DESCRIPTION
Summary:
- Updates weekly-goal-complete frontend guidance to use `STATE.sessionResults` as a fallback when `planItem.weekly_status` is stale.
- Adds helpers to derive weekly target from user settings and count completed sessions in the current ISO week from actual session results.
- Updates overview and after-session next guidance calls to pass `STATE.sessionResults`.
- Extends the contract test to cover the stale-plan-status case.

Why:
Live data showed the actual bug: after the fourth session was saved, `planItem.weekly_status` still said `3 / 4`, while session history showed `4 / 4`. The UI therefore kept showing:

- `Næste planlagte træning: Mobilitet · søndag 3. maj`
- `Mest sandsynligt næste træning · Mobilitet · søndag 3. maj`

Post-session guidance must trust actual session history when the plan object is stale.

Expected Danish guidance when session results show weekly goal complete:

`Ugemålet er nået. Restituer frem til næste planlagte træningsdag.`

Scope:
- Frontend guidance reconciliation only
- Test coverage
- No backend changes in this PR
- No workout logging changes
- No Today Plan selection changes
- No program selection changes

Validation:
- `node --check app/frontend/app.js`
- `.venv/bin/python -m pytest tests/test_weekly_goal_complete_guidance_contract.py -q`
- Result: `6 passed in 0.07s`

Risk:
- Low. This only changes weekly-goal-complete guidance when session results indicate the weekly goal has been reached, especially when `planItem.weekly_status` is stale.