### PR TITLE
Fix cardio restitution labels

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -2006,7 +2006,7 @@ function formatSessionType(value){
   if (x === "styrke" || x === "strength") return tr("workout.type.strength");
   if (x === "cardio") return tr("session_type.cardio");
   if (x === "restitution" || x === "recovery" || x === "rest") return tr("session_type.recovery");
-  if (x === "løb" || x === "run") return tr("session_type.run");
+  if (x === "løb" || x === "run" || x === "running") return tr("session_type.run");
   if (x === "mobilitet" || x === "mobility") return tr("session_type.mobility");
   return x || tr("plan.none");
 }
@@ -3871,6 +3871,7 @@ function formatExerciseName(exerciseId){
     restitution_walk: tr("exercise.recovery_walk"),
     mobility: tr("session_type.mobility"),
     cardio_easy: tr("exercise.cardio_easy"),
+    cardio_restitution: tr("exercise.cardio_restitution"),
     cardio_intervals: tr("exercise.cardio_intervals"),
     cardio_session: tr("session_type.cardio"),
     cardio_base: tr("exercise.cardio_base"),
@@ -4210,8 +4211,22 @@ function buildReviewValueSelect(name, options, selectedValue, placeholder){
     `;
 }
 
+function getCardioExerciseMetaFallback(exerciseId){
+  const id = String(exerciseId || "").trim().toLowerCase();
+  if (!id.startsWith("cardio_") && id !== "cardio_session") return null;
+
+  return {
+    id,
+    name: formatExerciseName(id),
+    name_en: formatExerciseName(id),
+    category: "cardio",
+    input_kind: "cardio_time",
+    load_optional: true,
+  };
+}
+
 function getReviewExerciseMeta(exerciseId){
-  return getExerciseMeta(exerciseId) || {};
+  return getExerciseMeta(exerciseId) || getCardioExerciseMetaFallback(exerciseId) || {};
 }
 
 function buildWorkoutRepChoiceButtons(name, choices, selectedValue){

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -946,5 +946,6 @@
   "plan.weekplan_adjusted_to_today": "Ugeplanen foreslog {planned}, men dagens plan er justeret til {actual}.",
   "today_plan.local_protection_adjusted": "Dagens plan er justeret for at beskytte {regions}.",
   "history.exercise_count_compact": "{count} øvelse(r)",
-  "weekplan.weekly_goal_complete_guidance": "Ugemålet er nået. Restituer frem til næste planlagte træningsdag."
+  "weekplan.weekly_goal_complete_guidance": "Ugemålet er nået. Restituer frem til næste planlagte træningsdag.",
+  "exercise.cardio_restitution": "Cardio-restitution"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -930,5 +930,6 @@
   "plan.weekplan_adjusted_to_today": "The weekly plan suggested {planned}, but today's plan was adjusted to {actual}.",
   "today_plan.local_protection_adjusted": "Today's plan was adjusted to protect {regions}.",
   "history.exercise_count_compact": "{count} exercise(s)",
-  "weekplan.weekly_goal_complete_guidance": "Weekly goal reached. Recover until your next planned training day."
+  "weekplan.weekly_goal_complete_guidance": "Weekly goal reached. Recover until your next planned training day.",
+  "exercise.cardio_restitution": "Cardio recovery"
 }

--- a/tests/test_cardio_restitution_display_contract.py
+++ b/tests/test_cardio_restitution_display_contract.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "frontend" / "app.js"
+DA_JSON = ROOT / "app" / "frontend" / "i18n" / "da.json"
+EN_JSON = ROOT / "app" / "frontend" / "i18n" / "en.json"
+
+
+def test_running_alias_is_localized_as_run_session_type():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert 'if (x === "løb" || x === "run" || x === "running") return tr("session_type.run");' in js
+
+
+def test_cardio_restitution_has_display_name_mapping():
+    js = APP_JS.read_text(encoding="utf-8")
+    da = json.loads(DA_JSON.read_text(encoding="utf-8"))
+    en = json.loads(EN_JSON.read_text(encoding="utf-8"))
+
+    assert 'cardio_restitution: tr("exercise.cardio_restitution")' in js
+    assert da["exercise.cardio_restitution"] == "Cardio-restitution"
+    assert en["exercise.cardio_restitution"] == "Cardio recovery"
+
+
+def test_cardio_entries_have_review_meta_fallback():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert "function getCardioExerciseMetaFallback(exerciseId)" in js
+    assert 'id.startsWith("cardio_")' in js
+    assert 'input_kind: "cardio_time"' in js
+    assert "getExerciseMeta(exerciseId) || getCardioExerciseMetaFallback(exerciseId) || {}" in js


### PR DESCRIPTION
Summary:
- Localizes the `running` alias through `formatSessionType`.
- Adds a display label for `cardio_restitution`.
- Adds cardio metadata fallback for `cardio_*` review entries.
- Adds a contract test for these display rules.

Scope:
- Frontend display formatting
- i18n labels
- Review/cardio metadata fallback
- Test coverage

No Today Plan decision changes, backend changes, or workout logging changes.

Validation:
- `node --check app/frontend/app.js`
- `python3 -m json.tool app/frontend/i18n/da.json >/dev/null`
- `python3 -m json.tool app/frontend/i18n/en.json >/dev/null`
- `.venv/bin/python -m pytest tests/test_cardio_restitution_display_contract.py -q`
- Result: `3 passed in 0.06s`

Expected behavior:
- Raw `running` is displayed as the localized run label.
- `cardio_restitution` is displayed as a readable cardio recovery label.
- Cardio fallback entries render as cardio/time entries instead of unknown exercises.