### PR TITLE
Fix cardio review summary metrics

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -191,7 +191,7 @@ function buildSessionResultSummaryFromStoredItem(item){
   const progressFlags = Array.isArray(item.progress_flags) ? item.progress_flags : [];
   const fatigue = String(item.fatigue || "").trim();
 
-  if (sessionTypeKey === "løb" || sessionTypeKey === "cardio" || sessionTypeKey === "run"){
+  if (sessionTypeKey === "løb" || sessionTypeKey === "cardio" || sessionTypeKey === "run" || sessionTypeKey === "running"){
     const distanceKm = Number(item.distance_km || 0);
     const durationTotalSec = Number(item.duration_total_sec || 0);
     const paceSecPerKm = distanceKm > 0 && durationTotalSec > 0
@@ -4886,7 +4886,7 @@ function renderSessionResultSummary(summary, fallbackResults = null){
     : [];
   const progressFlags = Array.isArray(summary.progress_flags) ? summary.progress_flags : [];
 
-  if (sessionTypeKey === "løb" || sessionTypeKey === "cardio" || sessionTypeKey === "run"){
+  if (sessionTypeKey === "løb" || sessionTypeKey === "cardio" || sessionTypeKey === "run" || sessionTypeKey === "running"){
     const cardioKind = String(summary.cardio_kind || "").trim();
     const distanceKm = Number(summary.distance_km || 0);
     const durationTotalSec = Number(summary.duration_total_sec || 0);

--- a/tests/test_cardio_review_summary_contract.py
+++ b/tests/test_cardio_review_summary_contract.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "frontend" / "app.js"
+
+
+CARDIO_ALIAS_CHECK = (
+    'sessionTypeKey === "løb" || sessionTypeKey === "cardio" || '
+    'sessionTypeKey === "run" || sessionTypeKey === "running"'
+)
+
+
+def test_running_alias_uses_cardio_summary_in_stored_session_summary():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    start = js.index("function buildSessionResultSummaryFromStoredItem(item)")
+    block = js[start:start + 1400]
+
+    assert CARDIO_ALIAS_CHECK in block
+    assert "distance_km" in block
+    assert "duration_total_sec" in block
+    assert "pace_sec_per_km" in block
+    assert "total_sets" not in block.split(CARDIO_ALIAS_CHECK, 1)[1].split("return {", 2)[1]
+
+
+def test_running_alias_uses_cardio_summary_in_review_renderer():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    start = js.index("function renderSessionResultSummary(summary, fallbackResults = null)")
+    block = js[start:start + 3800]
+
+    assert CARDIO_ALIAS_CHECK in block
+    assert 'tr("cardio.review.distance_label")' in block
+    assert 'tr("cardio.review.duration_label")' in block
+    assert 'tr("cardio.review.actual_pace_label")' in block
+
+    cardio_branch = block.split(CARDIO_ALIAS_CHECK, 1)[1].split("return;", 1)[0]
+    assert "review.summary_sets_label" not in cardio_branch
+    assert "review.summary_reps_label" not in cardio_branch
+    assert "review.summary_volume_label" not in cardio_branch


### PR DESCRIPTION
Summary:
- Treats `session_type: running` as a cardio/run summary in review rendering.
- Updates both stored session summary construction and review summary rendering.
- Adds a contract test so running aliases do not fall through to strength metrics.

Why:
A running/cardio session could render as a strength-style review summary with `Sæt: 0`, `Reps: 0`, and `Estimeret volumen: 0`. That is technically a summary, in the same way a shopping receipt is technically literature.

Scope:
- Frontend review summary only
- Test coverage
- No backend changes
- No logging changes
- No Today Plan or program selection changes

Validation:
- `node --check app/frontend/app.js`
- `.venv/bin/python -m pytest tests/test_cardio_review_summary_contract.py -q`
- Result: `2 passed in 0.05s`

Expected behavior:
- Running/cardio review summaries use cardio metrics: distance, duration, and pace.
- Running/cardio review summaries do not show strength metrics such as sets, reps, or estimated volume.