### PR TITLE
Preserve cardio review metrics for running alias

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -1020,7 +1020,7 @@ def create_session_result(user_id, payload):
 
     if not clean_results:
         # cardio-sessioner kan være gyldige uden sets
-        if session_type in ("løb", "cardio", "run"):
+        if session_type in ("løb", "cardio", "run", "running"):
             clean_results.append({
                 "exercise_id": "cardio_session",
                 "completed": True,
@@ -1087,7 +1087,7 @@ def create_session_result(user_id, payload):
     if completed:
         if session_type_normalized in ("styrke", "strength"):
             counts_toward_weekly_goal = has_meaningful_results
-        elif session_type_normalized in ("løb", "run", "cardio"):
+        elif session_type_normalized in ("løb", "run", "running", "cardio"):
             dist_ok = False
             dur_ok = False
             try:
@@ -1119,11 +1119,11 @@ def create_session_result(user_id, payload):
         "selected_endurance_program_id": selected_endurance_program_id or None,
         "counts_toward_weekly_goal": counts_toward_weekly_goal,
         "notes": notes,
-        "cardio_kind": cardio_kind if session_type in ("løb", "cardio", "run") else "",
-        "avg_rpe": avg_rpe if session_type in ("løb", "cardio", "run") else None,
-        "distance_km": distance_km if session_type in ("løb", "cardio", "run") else None,
-        "duration_total_sec": duration_total_sec if session_type in ("løb", "cardio", "run") else None,
-        "pace_sec_per_km": pace_sec_per_km if session_type in ("løb", "cardio", "run") else None,
+        "cardio_kind": cardio_kind if session_type in ("løb", "cardio", "run", "running") else "",
+        "avg_rpe": avg_rpe if session_type in ("løb", "cardio", "run", "running") else None,
+        "distance_km": distance_km if session_type in ("løb", "cardio", "run", "running") else None,
+        "duration_total_sec": duration_total_sec if session_type in ("løb", "cardio", "run", "running") else None,
+        "pace_sec_per_km": pace_sec_per_km if session_type in ("løb", "cardio", "run", "running") else None,
         "results": clean_results,
         "created_at": datetime.now(timezone.utc).isoformat()
     }
@@ -1239,7 +1239,7 @@ def build_session_result_item(user_id, payload, existing_item=None):
     if completed:
         if session_type_normalized in ("styrke", "strength"):
             counts_toward_weekly_goal = has_meaningful_results
-        elif session_type_normalized in ("løb", "run", "cardio"):
+        elif session_type_normalized in ("løb", "run", "running", "cardio"):
             dist_ok = False
             dur_ok = False
             try:
@@ -1271,11 +1271,11 @@ def build_session_result_item(user_id, payload, existing_item=None):
         "selected_endurance_program_id": selected_endurance_program_id or None,
         "counts_toward_weekly_goal": counts_toward_weekly_goal,
         "notes": notes,
-        "cardio_kind": cardio_kind if session_type in ("løb", "cardio", "run") else "",
-        "avg_rpe": avg_rpe if session_type in ("løb", "cardio", "run") else None,
-        "distance_km": distance_km if session_type in ("løb", "cardio", "run") else None,
-        "duration_total_sec": duration_total_sec if session_type in ("løb", "cardio", "run") else None,
-        "pace_sec_per_km": pace_sec_per_km if session_type in ("løb", "cardio", "run") else None,
+        "cardio_kind": cardio_kind if session_type in ("løb", "cardio", "run", "running") else "",
+        "avg_rpe": avg_rpe if session_type in ("løb", "cardio", "run", "running") else None,
+        "distance_km": distance_km if session_type in ("løb", "cardio", "run", "running") else None,
+        "duration_total_sec": duration_total_sec if session_type in ("løb", "cardio", "run", "running") else None,
+        "pace_sec_per_km": pace_sec_per_km if session_type in ("løb", "cardio", "run", "running") else None,
         "results": clean_results,
         "created_at": existing_item.get("created_at") or datetime.now(timezone.utc).isoformat()
     }

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4581,7 +4581,7 @@ function toggleCardioReviewFields(item){
   if (!wrap) return;
 
   const sessionType = String(item?.session_type || "").trim().toLowerCase();
-  const isCardio = sessionType === "løb" || sessionType === "cardio" || sessionType === "run";
+  const isCardio = sessionType === "løb" || sessionType === "cardio" || sessionType === "run" || sessionType === "running";
 
   wrap.style.display = isCardio ? "block" : "none";
 
@@ -8688,7 +8688,7 @@ function getSessionResultProgramIdForPlan(plan){
   if (sessionType === "styrke" || sessionType === "strength"){
     return String(plan?.selected_strength_program_id || "").trim();
   }
-  if (sessionType === "løb" || sessionType === "run" || sessionType === "cardio"){
+  if (sessionType === "løb" || sessionType === "run" || sessionType === "running" || sessionType === "cardio"){
     return String(plan?.selected_endurance_program_id || "").trim();
   }
   return "";

--- a/tests/test_cardio_review_save_running_alias_contract.py
+++ b/tests/test_cardio_review_save_running_alias_contract.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "frontend" / "app.js"
+BACKEND = ROOT / "app" / "backend" / "app.py"
+
+
+def test_frontend_running_alias_shows_cardio_review_fields_and_program_id():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert 'const isCardio = sessionType === "løb" || sessionType === "cardio" || sessionType === "run" || sessionType === "running";' in js
+    assert 'if (sessionType === "løb" || sessionType === "run" || sessionType === "running" || sessionType === "cardio"){' in js
+
+
+def test_backend_running_alias_counts_and_preserves_cardio_metrics():
+    py = BACKEND.read_text(encoding="utf-8")
+
+    assert 'session_type in ("løb", "cardio", "run", "running")' in py
+    assert 'session_type_normalized in ("løb", "run", "running", "cardio")' in py
+
+    for field in [
+        '"cardio_kind": cardio_kind if session_type in ("løb", "cardio", "run", "running") else ""',
+        '"avg_rpe": avg_rpe if session_type in ("løb", "cardio", "run", "running") else None',
+        '"distance_km": distance_km if session_type in ("løb", "cardio", "run", "running") else None',
+        '"duration_total_sec": duration_total_sec if session_type in ("løb", "cardio", "run", "running") else None',
+        '"pace_sec_per_km": pace_sec_per_km if session_type in ("løb", "cardio", "run", "running") else None',
+    ]:
+        assert field in py


### PR DESCRIPTION
Summary:
- Shows cardio review fields for `session_type: running`.
- Uses the endurance program id for `running` review saves.
- Preserves cardio metrics in backend create/update flows for the `running` alias.
- Adds a contract test covering frontend visibility and backend metric preservation.

Why:
Running/cardio review could not reliably save distance, duration, pace, RPE, or cardio kind when the session type was stored as `running`. The review UI did not show the cardio inputs, and backend save logic treated `running` as non-cardio when deciding whether to keep cardio metrics.

Scope:
- Frontend review form behavior
- Backend session result create/update preservation
- Test coverage
- No Today Plan decision changes
- No program selection logic changes

Validation:
- `node --check app/frontend/app.js`
- `python3 -m py_compile app/backend/app.py`
- `.venv/bin/python -m pytest tests/test_cardio_review_save_running_alias_contract.py -q`
- Result: `2 passed in 0.05s`

Expected behavior:
- Running/cardio review shows distance, duration, and RPE fields.
- Saving a `running` session preserves `cardio_kind`, `avg_rpe`, `distance_km`, `duration_total_sec`, and `pace_sec_per_km`.