### PR TITLE
Preserve review notes for single cardio entries

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4733,7 +4733,7 @@ function renderSessionReview(item){
             ${tr("common.type_label")}: ${tr("session_type.run")}
           </div>
           <label>
-            ${esc(tr("after_training.session_note_label"))}
+            ${esc(tr("after_training.cardio_note_label"))}
             <input type="text" name="review_notes_${idx}" value="${esc(String(entry?._existing_result?.notes || ""))}" placeholder="${esc(tr("after_training.short_note_placeholder_cardio"))}">
           </label>
         </li>
@@ -7150,7 +7150,7 @@ function renderActiveWorkoutCard(item){
   if (isCardioEntry){
     loggingHtml = `
       <label style="display:block; margin-top:12px">
-        ${esc(tr("after_training.session_note_label"))}
+        ${esc(tr("after_training.cardio_note_label"))}
         <input type="text" name="review_notes_${idx}" value="${esc(String(entry?._existing_result?.notes || ""))}" placeholder="${esc(tr("after_training.short_note_placeholder_cardio"))}">
       </label>
     `;
@@ -8715,6 +8715,13 @@ async function handleSessionResultSubmit(ev){
   const cardioDurationSec = form.cardio_duration_sec?.value?.trim() || "";
   const planTemplateId = String(plan.template_id || "").trim();
 
+  const reviewEntryNotes = Array.isArray(plan.entries)
+    ? plan.entries
+        .map((entry, idx) => form[`review_notes_${idx}`]?.value?.trim() || "")
+        .filter(Boolean)
+    : [];
+  const sessionNotes = form.session_notes.value.trim() || (reviewEntryNotes.length === 1 ? reviewEntryNotes[0] : "");
+
   const payload = {
     date: plan.date || new Date().toISOString().slice(0,10),
     program_id: getSessionResultProgramIdForPlan(plan),
@@ -8733,7 +8740,7 @@ session_type:
     source: getSessionResultSourceForPlan(plan),
     manual_override_workout_id: String(plan.manual_override_workout_id || "").trim(),
     completed: String(form.session_completed.value) === "true",
-    notes: form.session_notes.value.trim(),
+    notes: sessionNotes,
     cardio_kind: form.cardio_kind?.value?.trim() || "",
     avg_rpe: form.avg_rpe?.value?.trim() || "",
     distance_km: cardioDistanceKm === "0" ? "" : cardioDistanceKm,

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -947,5 +947,6 @@
   "today_plan.local_protection_adjusted": "Dagens plan er justeret for at beskytte {regions}.",
   "history.exercise_count_compact": "{count} øvelse(r)",
   "weekplan.weekly_goal_complete_guidance": "Ugemålet er nået. Restituer frem til næste planlagte træningsdag.",
-  "exercise.cardio_restitution": "Cardio-restitution"
+  "exercise.cardio_restitution": "Cardio-restitution",
+  "after_training.cardio_note_label": "Note til cardio-passet"
 }

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -931,5 +931,6 @@
   "today_plan.local_protection_adjusted": "Today's plan was adjusted to protect {regions}.",
   "history.exercise_count_compact": "{count} exercise(s)",
   "weekplan.weekly_goal_complete_guidance": "Weekly goal reached. Recover until your next planned training day.",
-  "exercise.cardio_restitution": "Cardio recovery"
+  "exercise.cardio_restitution": "Cardio recovery",
+  "after_training.cardio_note_label": "Cardio session note"
 }

--- a/tests/test_review_notes_preserved_contract.py
+++ b/tests/test_review_notes_preserved_contract.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "frontend" / "app.js"
+DA_JSON = ROOT / "app" / "frontend" / "i18n" / "da.json"
+EN_JSON = ROOT / "app" / "frontend" / "i18n" / "en.json"
+
+
+def test_single_review_entry_note_falls_back_to_session_notes():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert "const reviewEntryNotes = Array.isArray(plan.entries)" in js
+    assert '.map((entry, idx) => form[`review_notes_${idx}`]?.value?.trim() || "")' in js
+    assert 'const sessionNotes = form.session_notes.value.trim() || (reviewEntryNotes.length === 1 ? reviewEntryNotes[0] : "");' in js
+    assert "notes: sessionNotes," in js
+
+
+def test_cardio_note_label_is_distinct_from_general_session_note():
+    js = APP_JS.read_text(encoding="utf-8")
+    da = json.loads(DA_JSON.read_text(encoding="utf-8"))
+    en = json.loads(EN_JSON.read_text(encoding="utf-8"))
+
+    assert 'tr("after_training.cardio_note_label")' in js
+    assert da["after_training.cardio_note_label"] == "Note til cardio-passet"
+    assert en["after_training.cardio_note_label"] == "Cardio session note"


### PR DESCRIPTION
Summary:
- Uses a single review entry note as fallback for top-level session notes.
- Adds a distinct cardio note label in Danish and English.
- Adds a contract test covering note fallback and label keys.

Why:
For cardio sessions with one entry, the visible note field was an entry-level field, while the saved session-level `notes` field stayed empty. The UI said session note, but the payload treated it like an entry note. Naturally, the note then vanished from the place humans would check first, because apparently notes needed a hiding spot.

Scope:
- Frontend review payload mapping
- Frontend i18n label
- Test coverage
- No backend changes
- No cardio metrics changes
- No Today Plan or program selection changes

Validation:
- `node --check app/frontend/app.js`
- `python3 -m json.tool app/frontend/i18n/da.json >/dev/null`
- `python3 -m json.tool app/frontend/i18n/en.json >/dev/null`
- `.venv/bin/python -m pytest tests/test_review_notes_preserved_contract.py -q`
- Result: `2 passed in 0.05s`

Expected behavior:
- If a cardio review has exactly one entry note and no separate session note, the entry note is saved as `payload.notes` too.
- Cardio note fields are labelled as cardio session notes instead of the generic session note label.