### PR TITLE
Preserve cardio edit duration on update

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -1169,6 +1169,8 @@ def build_session_result_item(user_id, payload, existing_item=None):
     avg_rpe = payload.get("avg_rpe")
     distance_km = payload.get("distance_km")
     duration_total_sec = payload.get("duration_total_sec")
+    duration_min = payload.get("duration_min", None)
+    duration_sec = payload.get("duration_sec", None)
     pace_sec_per_km = payload.get("pace_sec_per_km")
     results = payload.get("results", [])
 
@@ -1200,12 +1202,28 @@ def build_session_result_item(user_id, payload, existing_item=None):
             return None, {"ok": False, "error": "ugyldig distance_km", "field": "distance_km"}, 400
 
     if duration_total_sec in (None, ""):
-        duration_total_sec = None
+        duration_min = _parse_optional_int(duration_min, 0)
+        duration_sec = _parse_optional_int(duration_sec, 0)
+        if duration_min < 0:
+            duration_min = 0
+        if duration_sec < 0:
+            duration_sec = 0
+        if duration_sec > 59:
+            duration_sec = 59
+        duration_total_sec = (duration_min * 60) + duration_sec
+        if duration_total_sec <= 0:
+            duration_total_sec = None
     else:
         try:
             duration_total_sec = int(float(duration_total_sec))
         except Exception:
             return None, {"ok": False, "error": "ugyldig duration_total_sec", "field": "duration_total_sec"}, 400
+
+    if pace_sec_per_km in (None, "") and distance_km and duration_total_sec:
+        try:
+            pace_sec_per_km = round(float(duration_total_sec) / float(distance_km), 2)
+        except Exception:
+            pace_sec_per_km = None
 
     if pace_sec_per_km in (None, ""):
         pace_sec_per_km = None

--- a/tests/test_cardio_edit_duration_contract.py
+++ b/tests/test_cardio_edit_duration_contract.py
@@ -1,0 +1,66 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND_PATH = ROOT / "app" / "backend"
+APP_PATH = BACKEND_PATH / "app.py"
+
+
+def load_app():
+    sys.path.insert(0, str(BACKEND_PATH))
+    spec = importlib.util.spec_from_file_location("backend_app", APP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_update_session_result_accepts_duration_min_sec_for_running_alias():
+    app = load_app()
+
+    payload = {
+        "date": "2026-05-03",
+        "session_type": "running",
+        "completed": True,
+        "distance_km": "1",
+        "duration_min": "20",
+        "duration_sec": "0",
+        "cardio_kind": "restitution",
+        "avg_rpe": "3",
+        "results": [
+            {
+                "exercise_id": "cardio_session",
+                "completed": True,
+                "sets": [],
+            }
+        ],
+    }
+
+    item, err, status = app.build_session_result_item("5", payload)
+
+    assert err is None
+    assert status is None
+    assert item["duration_total_sec"] == 1200
+    assert item["distance_km"] == 1.0
+    assert item["pace_sec_per_km"] == 1200.0
+    assert item["counts_toward_weekly_goal"] is True
+
+
+def test_update_session_result_clamps_duration_seconds():
+    app = load_app()
+
+    payload = {
+        "date": "2026-05-03",
+        "session_type": "running",
+        "completed": True,
+        "distance_km": "1",
+        "duration_min": "19",
+        "duration_sec": "99",
+        "results": [{"exercise_id": "cardio_session", "completed": True, "sets": []}],
+    }
+
+    item, err, status = app.build_session_result_item("5", payload)
+
+    assert err is None
+    assert status is None
+    assert item["duration_total_sec"] == 1199


### PR DESCRIPTION
Summary:
- Allows session result update flow to accept `duration_min` and `duration_sec` when `duration_total_sec` is not provided.
- Computes `duration_total_sec` from minute/second fields during PUT/update.
- Computes `pace_sec_per_km` from distance and duration when pace is missing.
- Adds backend contract tests for running/cardio edit duration preservation and second clamping.

Why:
The frontend review form sends cardio duration as `duration_min` and `duration_sec`. The create flow understood that, but the update flow only looked for `duration_total_sec`. Editing an existing cardio session could therefore turn a real duration into `null`, because apparently one endpoint spoke normal time and the other spoke bureaucratic silence.

Scope:
- Backend session result update helper
- Test coverage
- No frontend changes
- No Today Plan changes
- No recommendation logic changes

Validation:
- `python3 -m py_compile app/backend/app.py`
- `.venv/bin/python -m pytest tests/test_cardio_edit_duration_contract.py -q`
- Result: `2 passed in 0.46s`

Expected behavior:
- PUT/update with `duration_min: 20`, `duration_sec: 0`, `distance_km: 1`, and `session_type: running` saves `duration_total_sec: 1200`.
- Pace is calculated when distance and duration are present.
- Seconds are clamped to 59 consistently with create flow.