### PR TITLE
Fix cardio session history metrics for running aliases

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1007,7 +1007,7 @@ function renderWorkouts(items){
 
   root.innerHTML = sorted.map(item => {
     const rawEntries = Array.isArray(item.entries) ? item.entries : [];
-    const isCardio = String(item?.session_type || "").trim().toLowerCase() === "løb";
+    const isCardio = ["løb", "cardio", "run", "running"].includes(String(item?.session_type || "").trim().toLowerCase());
     const cardioMeta = buildCardioHistoryMeta(item);
     const compactSummary = buildLatestWorkoutSummary(item);
     const totalSets = rawEntries.reduce((sum, entry) => sum + (Number(entry?.sets || 0) || 0), 0);
@@ -1099,7 +1099,7 @@ function buildLatestWorkoutSummary(item){
   const summary = item.summary && typeof item.summary === "object" ? item.summary : {};
   const sessionType = String(item.session_type || summary.session_type || "").trim().toLowerCase();
 
-  if (sessionType === "løb" || sessionType === "cardio" || sessionType === "run"){
+  if (sessionType === "løb" || sessionType === "cardio" || sessionType === "run" || sessionType === "running"){
     return buildCardioHistoryMeta({
       ...item,
       cardio_kind: item.cardio_kind || summary.cardio_kind,
@@ -1452,7 +1452,7 @@ function renderSessionHistory(items){
     const notes = String(item && item.notes || "").trim();
     const typeLabel = formatSessionType(item && item.session_type || "");
     const dateLabel = String(item && item.date || "");
-    const isCardio = String(item?.session_type || "").trim().toLowerCase() === "løb";
+    const isCardio = ["løb", "cardio", "run", "running"].includes(String(item?.session_type || "").trim().toLowerCase());
     const cardioMeta = buildCardioHistoryMeta(item);
 
     return `
@@ -2024,7 +2024,7 @@ function buildForecastLeadText(planItem){
   const firstExercise = String(firstEntry?.exercise_id || "").trim().toLowerCase();
   const targetReps = String(firstEntry?.target_reps || "").trim();
 
-  if (sessionType === "løb" || sessionType === "cardio" || sessionType === "run"){
+  if (sessionType === "løb" || sessionType === "cardio" || sessionType === "run" || sessionType === "running"){
     if (firstExercise.includes("restitution")){
       return targetReps
         ? tr("forecast.recovery_with_target", { value: targetReps })
@@ -2084,7 +2084,7 @@ function getForecastTypeLabel(planItem){
   const firstEntry = entries.length ? entries[0] : null;
   const firstExercise = String(firstEntry?.exercise_id || "").trim().toLowerCase();
 
-  if (sessionType === "løb" || sessionType === "cardio" || sessionType === "run"){
+  if (sessionType === "løb" || sessionType === "cardio" || sessionType === "run" || sessionType === "running"){
     if (firstExercise.includes("restitution")) return tr("session_type.recovery");
     if (firstExercise.includes("interval")) return tr("forecast.type.intervals");
     if (firstExercise.includes("tempo")) return tr("forecast.type.tempo");

--- a/tests/test_cardio_session_history_metrics_contract.py
+++ b/tests/test_cardio_session_history_metrics_contract.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app" / "frontend" / "app.js"
+
+CARDIO_ALIAS_ARRAY = '["løb", "cardio", "run", "running"].includes(String(item?.session_type || "").trim().toLowerCase())'
+CARDIO_FORECAST_CHECK = 'sessionType === "løb" || sessionType === "cardio" || sessionType === "run" || sessionType === "running"'
+
+
+def test_session_history_uses_cardio_meta_for_running_aliases():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    history_start = js.index("function renderSessionHistory(items)")
+    history_block = js[history_start:history_start + 2600]
+
+    assert CARDIO_ALIAS_ARRAY in history_block
+    assert "buildCardioHistoryMeta(item)" in history_block
+    assert "history.session_totals" in history_block
+    assert history_block.index("buildCardioHistoryMeta(item)") < history_block.index("history.session_totals")
+
+
+def test_workout_history_summary_uses_cardio_meta_for_running_aliases():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    workouts_start = js.index("function renderWorkouts(items)")
+    workouts_block = js[workouts_start:workouts_start + 1800]
+
+    assert CARDIO_ALIAS_ARRAY in workouts_block
+    assert "buildCardioHistoryMeta(item)" in workouts_block
+
+
+def test_latest_summary_and_forecast_include_running_alias():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    latest_start = js.index("function buildLatestWorkoutSummary(item)")
+    latest_block = js[latest_start:latest_start + 900]
+    assert CARDIO_FORECAST_CHECK in latest_block
+
+    lead_start = js.index("function buildForecastLeadText(planItem)")
+    lead_block = js[lead_start:lead_start + 1200]
+    assert CARDIO_FORECAST_CHECK in lead_block
+
+    type_start = js.index("function getForecastTypeLabel(planItem)")
+    type_block = js[type_start:type_start + 900]
+    assert CARDIO_FORECAST_CHECK in type_block


### PR DESCRIPTION
Summary:
- Treats `løb`, `cardio`, `run`, and `running` as cardio in session history.
- Updates latest workout summary and forecast display paths to include the `running` alias.
- Adds a contract test covering session history, workout history summary, and forecast alias handling.

Why:
Running/cardio sessions could appear in history with strength totals such as sets, reps, and volume. That produced classics like `Sæt: 0 · Reps: 0 · Volumen: 0` for a run, which is technically rendered text and spiritually a cry for help.

Scope:
- Frontend display only
- Session history / workout summary / forecast labels
- Test coverage
- No backend changes
- No save-flow changes
- No Today Plan decision changes

Validation:
- `node --check app/frontend/app.js`
- `.venv/bin/python -m pytest tests/test_cardio_session_history_metrics_contract.py -q`
- Result: `3 passed in 0.06s`

Expected behavior:
- Running/cardio session history shows cardio metadata such as kind, distance, duration, pace, and RPE.
- Running/cardio history no longer falls back to strength totals.
- Forecast display treats `running` as a run/cardio session.