### PR TITLE
Fix time-based progression analysis for hold seconds

### DIFF
--- a/app/backend/progression_engine.py
+++ b/app/backend/progression_engine.py
@@ -88,8 +88,14 @@ def parse_top_rep(rep_range):
 
 
 def parse_seconds_value(value):
-    txt = str(value or "").strip().lower().replace("sek", "").replace("sec", "").strip()
-    if not txt:
+    txt = str(value or "").strip().lower()
+    has_time_suffix = False
+    for suffix in ("seconds", "second", "sekunder", "sekund", "secs", "sec", "sek", "s"):
+        if txt.endswith(suffix):
+            txt = txt[: -len(suffix)].strip()
+            has_time_suffix = True
+            break
+    if not has_time_suffix or not txt:
         return None
     try:
         return int(float(txt.replace(",", ".")))
@@ -209,16 +215,21 @@ def analyze_session_result_for_progression(result):
 
     if isinstance(raw_sets, list) and raw_sets:
         clean_sets = []
+        total_time_under_tension_sec = 0
         for x in raw_sets:
             if not isinstance(x, dict):
                 continue
             reps_raw = str(x.get("reps", "")).strip()
             load_raw = x.get("load", "")
-            reps_num = None
-            try:
-                reps_num = int(reps_raw) if reps_raw != "" else None
-            except Exception:
-                reps_num = None
+            seconds_num = parse_seconds_value(reps_raw)
+            reps_num = seconds_num
+            if reps_num is None:
+                try:
+                    reps_num = int(reps_raw) if reps_raw != "" else None
+                except Exception:
+                    reps_num = None
+            if seconds_num is not None:
+                total_time_under_tension_sec += seconds_num
             load_num = parse_number_from_load(load_raw)
             clean_sets.append({
                 "reps": reps_num,
@@ -248,6 +259,7 @@ def analyze_session_result_for_progression(result):
             "min_reps": min_reps,
             "hit_failure": hit_failure,
             "load_drop_detected": load_drop_detected,
+            "total_time_under_tension_sec": total_time_under_tension_sec,
         }
 
     fallback_load = parse_number_from_load(result.get("load", ""))

--- a/tests/test_time_based_progression_analysis.py
+++ b/tests/test_time_based_progression_analysis.py
@@ -1,0 +1,66 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND_PATH = ROOT / "app" / "backend"
+ENGINE_PATH = BACKEND_PATH / "progression_engine.py"
+
+
+def load_engine():
+    sys.path.insert(0, str(BACKEND_PATH))
+    spec = importlib.util.spec_from_file_location("progression_engine", ENGINE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_seconds_value_requires_time_suffix():
+    engine = load_engine()
+
+    assert engine.parse_seconds_value("20 sec") == 20
+    assert engine.parse_seconds_value("20s") == 20
+    assert engine.parse_seconds_value("20 sek") == 20
+    assert engine.parse_seconds_value("20 seconds") == 20
+    assert engine.parse_seconds_value("20") is None
+
+
+def test_time_based_sets_are_summed_for_progression_analysis():
+    engine = load_engine()
+
+    result = {
+        "exercise_id": "plank",
+        "sets": [
+            {"reps": "20 sec", "load": ""},
+            {"reps": "25s", "load": ""},
+            {"reps": "30 sek", "load": ""},
+        ],
+        "hit_failure": False,
+    }
+
+    analysis = engine.analyze_session_result_for_progression(result)
+
+    assert analysis["source"] == "session_result"
+    assert analysis["has_sets"] is True
+    assert analysis["first_set_reps"] == 20
+    assert analysis["min_reps"] == 20
+    assert analysis["total_time_under_tension_sec"] == 75
+
+
+def test_plain_rep_sets_do_not_count_as_time_under_tension():
+    engine = load_engine()
+
+    result = {
+        "exercise_id": "squat",
+        "sets": [
+            {"reps": "8", "load": "50 kg"},
+            {"reps": "7", "load": "50 kg"},
+        ],
+        "hit_failure": False,
+    }
+
+    analysis = engine.analyze_session_result_for_progression(result)
+
+    assert analysis["first_set_reps"] == 8
+    assert analysis["min_reps"] == 7
+    assert analysis["total_time_under_tension_sec"] == 0


### PR DESCRIPTION
Summary:
- Parses explicit time-based set values such as `20 sec`, `20s`, `20 sek`, and `20 seconds`.
- Requires an explicit time suffix so plain rep values like `20` are not treated as time.
- Sums all time-based sets into `total_time_under_tension_sec`.
- Adds contract tests for time parsing, summed hold seconds, and normal rep sets.

Why:
Time-based strength results such as plank holds were ignored by progression analysis because `int("20 sec")` fails. PR #738 correctly identified this area, but its implementation used the last set to detect time and returned `min_reps` as total time. This version keeps the good bug report and removes the future fire drill.

Scope:
- Backend progression analysis only
- No frontend changes
- No cardio/running changes
- No Today Plan changes
- No recommendation policy changes

Validation:
- `python3 -m py_compile app/backend/progression_engine.py`
- `.venv/bin/python -m pytest tests/test_time_based_progression_analysis.py -q`
- Result: `3 passed in 0.05s`

Expected behavior:
- `20 sec + 25s + 30 sek` gives `total_time_under_tension_sec = 75`.
- Plain reps such as `8` and `7` remain reps and do not count as time under tension.