### PR TITLE
Fix backend deploy script for imported runtime modules

### DIFF
--- a/scripts/deploy_backend_safe.sh
+++ b/scripts/deploy_backend_safe.sh
@@ -1,34 +1,45 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SRC_FILE="app/backend/app.py"
-TARGET_FILE="/opt/sovereign-strength-api/app/backend/app.py"
+SRC_DIR="app/backend"
+TARGET_DIR="/opt/sovereign-strength-api/app/backend"
 SERVICE_NAME="sovereign-strength-api.service"
 BACKUP_TS="$(date +%Y%m%d-%H%M%S)"
-BACKUP_FILE="${TARGET_FILE}.bak.${BACKUP_TS}"
+BACKEND_MODULES=(
+  "app.py"
+  "progression_engine.py"
+  "storage.py"
+  "db.py"
+)
 
 echo "Safe backend deploy"
-echo "Source: ${SRC_FILE}"
-echo "Target: ${TARGET_FILE}"
+echo "Source dir: ${SRC_DIR}"
+echo "Target dir: ${TARGET_DIR}"
 echo "Service: ${SERVICE_NAME}"
 echo
 
-if [[ ! -f "${SRC_FILE}" ]]; then
-  echo "ERROR: Source backend file not found: ${SRC_FILE}" >&2
-  exit 1
-fi
+echo "Verifying source and target files..."
+for module in "${BACKEND_MODULES[@]}"; do
+  if [[ ! -f "${SRC_DIR}/${module}" ]]; then
+    echo "ERROR: Source backend file not found: ${SRC_DIR}/${module}" >&2
+    exit 1
+  fi
 
-if [[ ! -f "${TARGET_FILE}" ]]; then
-  echo "ERROR: Target backend file not found: ${TARGET_FILE}" >&2
-  exit 1
-fi
+  if [[ ! -f "${TARGET_DIR}/${module}" ]]; then
+    echo "ERROR: Target backend file not found: ${TARGET_DIR}/${module}" >&2
+    exit 1
+  fi
+done
 
+echo
 echo "Validating Python syntax..."
-python3 -m py_compile "${SRC_FILE}"
+for module in "${BACKEND_MODULES[@]}"; do
+  python3 -m py_compile "${SRC_DIR}/${module}"
+done
 
 echo
 echo "Verifying active systemd backend path..."
-if ! systemctl cat "${SERVICE_NAME}" --no-pager -l | grep -q "WorkingDirectory=/opt/sovereign-strength-api/app/backend"; then
+if ! systemctl cat "${SERVICE_NAME}" --no-pager -l | grep -q "WorkingDirectory=${TARGET_DIR}"; then
   echo "ERROR: Service WorkingDirectory does not match expected active backend path." >&2
   systemctl cat "${SERVICE_NAME}" --no-pager -l >&2
   exit 1
@@ -41,15 +52,51 @@ if ! systemctl cat "${SERVICE_NAME}" --no-pager -l | grep -q "app:app"; then
 fi
 
 echo
-echo "Creating backup..."
-echo "-> ${BACKUP_FILE}"
-sudo cp "${TARGET_FILE}" "${BACKUP_FILE}"
+echo "Creating backups..."
+for module in "${BACKEND_MODULES[@]}"; do
+  backup_file="${TARGET_DIR}/${module}.bak.${BACKUP_TS}"
+  echo "-> ${backup_file}"
+  sudo cp "${TARGET_DIR}/${module}" "${backup_file}"
+done
 
 echo
-echo "Deploying backend..."
-sudo cp "${SRC_FILE}" "${TARGET_FILE}"
-sudo chown jakob:jakob "${TARGET_FILE}"
-sudo chmod 644 "${TARGET_FILE}"
+echo "Deploying backend modules..."
+for module in "${BACKEND_MODULES[@]}"; do
+  sudo cp "${SRC_DIR}/${module}" "${TARGET_DIR}/${module}"
+  sudo chown jakob:jakob "${TARGET_DIR}/${module}"
+  sudo chmod 644 "${TARGET_DIR}/${module}"
+done
+
+echo
+echo "Post-copy verification..."
+if ! grep -q "def get_today_plan" "${TARGET_DIR}/app.py"; then
+  echo "ERROR: Deployed app.py does not look like the expected Flask app." >&2
+  exit 1
+fi
+
+for module in "${BACKEND_MODULES[@]}"; do
+  python3 -m py_compile "${TARGET_DIR}/${module}"
+done
+
+echo
+echo "Verifying runtime import map..."
+(
+  cd "${TARGET_DIR}"
+  python3 - <<'PY'
+import app
+import progression_engine
+import storage
+import db
+from pathlib import Path
+
+expected_root = Path("/opt/sovereign-strength-api/app/backend").resolve()
+for mod in (app, progression_engine, storage, db):
+    path = Path(mod.__file__).resolve()
+    print(f"{mod.__name__}: {path}")
+    if expected_root not in path.parents and path.parent != expected_root:
+        raise SystemExit(f"ERROR: {mod.__name__} imported from unexpected path: {path}")
+PY
+)
 
 echo
 echo "Restarting service..."
@@ -60,14 +107,5 @@ echo "Checking service status..."
 sudo systemctl status "${SERVICE_NAME}" --no-pager -l
 
 echo
-echo "Post-deploy verification..."
-if ! grep -q "def get_today_plan" "${TARGET_FILE}"; then
-  echo "ERROR: Deployed backend file does not look like the expected Flask app." >&2
-  exit 1
-fi
-
-python3 -m py_compile "${TARGET_FILE}"
-
-echo
 echo "Backend deploy completed safely."
-echo "Backup: ${BACKUP_FILE}"
+echo "Backup timestamp: ${BACKUP_TS}"

--- a/tests/test_safe_backend_deploy_script_contract.py
+++ b/tests/test_safe_backend_deploy_script_contract.py
@@ -4,27 +4,42 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "deploy_backend_safe.sh"
 
 
-def test_safe_backend_deploy_script_targets_active_backend_path():
+def test_safe_backend_deploy_script_targets_active_backend_runtime_dir():
     text = SCRIPT.read_text(encoding="utf-8")
 
-    assert 'SRC_FILE="app/backend/app.py"' in text
-    assert 'TARGET_FILE="/opt/sovereign-strength-api/app/backend/app.py"' in text
+    assert 'SRC_DIR="app/backend"' in text
+    assert 'TARGET_DIR="/opt/sovereign-strength-api/app/backend"' in text
     assert 'SERVICE_NAME="sovereign-strength-api.service"' in text
+    assert '"app.py"' in text
+    assert '"progression_engine.py"' in text
+    assert '"storage.py"' in text
+    assert '"db.py"' in text
 
 
-def test_safe_backend_deploy_script_validates_before_deploy_and_restarts_service():
+def test_safe_backend_deploy_script_validates_all_runtime_modules_before_deploy():
     text = SCRIPT.read_text(encoding="utf-8")
 
-    assert 'python3 -m py_compile "${SRC_FILE}"' in text
-    assert 'WorkingDirectory=/opt/sovereign-strength-api/app/backend' in text
-    assert 'sudo cp "${TARGET_FILE}" "${BACKUP_FILE}"' in text
-    assert 'sudo cp "${SRC_FILE}" "${TARGET_FILE}"' in text
+    assert 'for module in "${BACKEND_MODULES[@]}"' in text
+    assert 'python3 -m py_compile "${SRC_DIR}/${module}"' in text
+    assert 'WorkingDirectory=${TARGET_DIR}' in text
+    assert 'app:app' in text
+
+
+def test_safe_backend_deploy_script_backs_up_and_deploys_all_runtime_modules():
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'sudo cp "${TARGET_DIR}/${module}" "${backup_file}"' in text
+    assert 'sudo cp "${SRC_DIR}/${module}" "${TARGET_DIR}/${module}"' in text
+    assert 'sudo chown jakob:jakob "${TARGET_DIR}/${module}"' in text
+    assert 'sudo chmod 644 "${TARGET_DIR}/${module}"' in text
+
+
+def test_safe_backend_deploy_script_verifies_runtime_import_map_and_restarts_service():
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'grep -q "def get_today_plan" "${TARGET_DIR}/app.py"' in text
+    assert 'python3 -m py_compile "${TARGET_DIR}/${module}"' in text
+    assert "import progression_engine" in text
+    assert 'expected_root = Path("/opt/sovereign-strength-api/app/backend").resolve()' in text
     assert 'sudo systemctl restart "${SERVICE_NAME}"' in text
     assert 'sudo systemctl status "${SERVICE_NAME}" --no-pager -l' in text
-
-
-def test_safe_backend_deploy_script_verifies_deployed_file():
-    text = SCRIPT.read_text(encoding="utf-8")
-
-    assert 'grep -q "def get_today_plan" "${TARGET_FILE}"' in text
-    assert 'python3 -m py_compile "${TARGET_FILE}"' in text


### PR DESCRIPTION
Summary:
- Deploys all runtime backend modules instead of only `app.py`.
- Covers `app.py`, `progression_engine.py`, `storage.py`, and `db.py`.
- Backs up each runtime module before copy.
- Validates Python syntax for all source and target modules.
- Verifies the runtime import map from the actual systemd WorkingDirectory.
- Updates the deploy script contract test accordingly.

Why:
Backend deploy previously copied only `app/backend/app.py`. The running service imports additional modules from `/opt/sovereign-strength-api/app/backend`, including `progression_engine.py`. That meant a backend deploy could restart successfully while leaving imported modules stale. PR #779 exposed this when the progression fix was merged and deployed, but the actual runtime `progression_engine.py` stayed old. A deploy script that only deploys part of the backend is not a deploy script; it is theatre with sudo.

Scope:
- Backend deploy script only
- Deploy contract test only
- No application logic changes
- No frontend changes
- No data changes

Validation:
- `bash -n scripts/deploy_backend_safe.sh`
- `.venv/bin/python -m pytest tests/test_safe_backend_deploy_script_contract.py -q`
- Result: `4 passed in 0.08s`

Expected behavior:
- Future backend deploys copy every runtime module used by the service.
- Deploy fails if any expected source or target module is missing.
- Deploy verifies imports resolve from `/opt/sovereign-strength-api/app/backend`.