### PR TITLE
Remove profile editor newline artifact

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -503,7 +503,8 @@
         <div class="stat-line"><strong data-i18n="button.edit_profile_equipment">Redigér profil og udstyr</strong></div>
       </div>
 
-<div id="profileEquipmentEditorSection" class="wizard-step-hidden" style="display:none; margin-top:12px">\n        <form id="equipmentSettingsForm" style="margin-top:12px">
+<div id="profileEquipmentEditorSection" class="wizard-step-hidden" style="display:none; margin-top:12px">
+        <form id="equipmentSettingsForm" style="margin-top:12px">
             <div id="firstRunSetupIntro" class="small wizard-step-hidden" style="margin-bottom:12px; display:none"></div>
 
             <div class="first-run-setup-section" data-first-run-step="basic_profile">

--- a/tests/test_first_run_onboarding_copy_contract.py
+++ b/tests/test_first_run_onboarding_copy_contract.py
@@ -52,3 +52,13 @@ def test_first_run_setup_ctas_open_profile_setup_not_overview_scroll_detour():
     assert 'showWizardStep("profile");' in onboarding_block
     assert 'showWizardStep("overview");' not in onboarding_block
     assert "scrollIntoView" not in onboarding_block
+
+def test_profile_editor_html_does_not_render_literal_newline_artifact():
+    html = (ROOT / "app" / "frontend" / "index.html").read_text(encoding="utf-8")
+
+    editor_start = html.index('id="profileEquipmentEditorSection"')
+    editor_block = html[editor_start:editor_start + 300]
+
+    assert "\\n" not in editor_block
+    assert '<form id="equipmentSettingsForm"' in editor_block
+


### PR DESCRIPTION
Summary:
- Removes a literal newline artifact from the profile equipment editor HTML.
- Extends the first-run onboarding contract test to prevent the artifact from returning.

Why:
The profile setup UI rendered a visible backslash-n under the profile edit heading. That should be an actual line break in the source, not text shown to users.

Scope:
- Frontend HTML only
- Existing first-run onboarding contract test only
- No backend changes
- No data model changes
- No deploy changes

Validation:
- node --check app/frontend/app.js
- python3 -m json.tool app/frontend/i18n/da.json >/dev/null
- python3 -m json.tool app/frontend/i18n/en.json >/dev/null
- .venv/bin/python -m pytest tests/test_first_run_onboarding_copy_contract.py -q
- Result: 4 passed

Follow-up to #785 and #786.