### PR TITLE
Hide local protection during first-run setup

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -3396,6 +3396,7 @@ function renderFirstRunSetupEditorState(){
   const resetExercisesBtn = document.getElementById("resetExercisesCatalogFromSeedBtn");
   const resetCatalogBtn = document.getElementById("resetCatalogFromSeedBtn");
   const finishText = document.getElementById("firstRunSetupFinishText");
+  const localProtectionSection = document.getElementById("localProtectionHoldsSection");
   const sections = Array.from(document.querySelectorAll(".first-run-setup-section[data-first-run-step]"));
 
   const firstRunActive = isFirstRunSetupFlowActive();
@@ -3420,6 +3421,10 @@ function renderFirstRunSetupEditorState(){
       intro.style.display = "none";
       intro.textContent = "";
     }
+  }
+
+  if (localProtectionSection){
+    localProtectionSection.style.display = firstRunActive ? "none" : "";
   }
 
   if (nav){

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -609,7 +609,8 @@
             </label>
             </div>
 
-            <div style="margin:18px 0 6px; font-weight:700" data-i18n="profile.local_protection_holds_title">Lokal beskyttelse</div>
+            <div id="localProtectionHoldsSection">
+              <div style="margin:18px 0 6px; font-weight:700" data-i18n="profile.local_protection_holds_title">Lokal beskyttelse</div>
             <div class="small" style="margin-bottom:10px" data-i18n="profile.local_protection_holds_help">Hold et område i forsigtig eller beskyttet tilstand, hvis det stadig skal skånes på tværs af flere planlægningsdage.</div>
 
             <div style="display:grid; grid-template-columns:1fr; gap:10px; margin-bottom:16px">
@@ -669,6 +670,7 @@
                   <option value="protect" data-i18n="local_protection.hold.protect">Beskyt</option>
                 </select>
               </label>
+            </div>
             </div>
 
             <div class="first-run-setup-section" data-first-run-step="equipment">

--- a/tests/test_first_run_onboarding_copy_contract.py
+++ b/tests/test_first_run_onboarding_copy_contract.py
@@ -62,3 +62,17 @@ def test_profile_editor_html_does_not_render_literal_newline_artifact():
     assert "\\n" not in editor_block
     assert '<form id="equipmentSettingsForm"' in editor_block
 
+def test_local_protection_is_hidden_during_first_run_setup():
+    html = (ROOT / "app" / "frontend" / "index.html").read_text(encoding="utf-8")
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert 'id="localProtectionHoldsSection"' in html
+    assert 'profile.local_protection_holds_title' in html
+
+    local_protection_idx = html.index('id="localProtectionHoldsSection"')
+    equipment_step_idx = html.index('data-first-run-step="equipment"')
+    assert local_protection_idx < equipment_step_idx
+
+    assert 'const localProtectionSection = document.getElementById("localProtectionHoldsSection");' in js
+    assert 'localProtectionSection.style.display = firstRunActive ? "none" : "";' in js
+


### PR DESCRIPTION
Summary:
- Wraps the local protection controls in a dedicated frontend section.
- Hides local protection while the first-run setup wizard is active.
- Keeps local protection available outside first-run setup.
- Extends the first-run onboarding contract test.

Why:
Local protection is useful, but it is too advanced for the first-run setup path. New users should not meet ankle, knee, hip, back, shoulder, elbow, and wrist protection controls while they are still doing basic setup. Let the user enter the building before handing them the anatomy checklist, what a radical concept.

Scope:
- Frontend only
- First-run/profile setup visibility only
- No backend changes
- No data model changes
- No new global state
- No event listener changes

Validation:
- node --check app/frontend/app.js
- .venv/bin/python -m pytest tests/test_first_run_onboarding_copy_contract.py -q
- Result: 5 passed

Closes #788.