### PR TITLE
Fix equipment filtering for missing loaded equipment

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -1579,6 +1579,17 @@ def get_local_substitute_candidates(exercise_id, local_state=None):
 
 
 
+def is_plan_equipment_available(equipment_type, available_equipment):
+    equipment_key = str(equipment_type or "").strip().lower()
+    if not equipment_key:
+        return True
+    if equipment_key == "bodyweight":
+        return True
+    if not isinstance(available_equipment, dict):
+        return False
+    return bool(available_equipment.get(equipment_key, False))
+
+
 def choose_best_substitute(original_exercise_id, candidate_ids, exercise_map, available_equipment, local_state=None, exercises=None):
     original_meta = exercise_map.get(original_exercise_id, {}) or {}
     original_pattern = str(original_meta.get("movement_pattern", "")).strip()
@@ -1596,7 +1607,7 @@ def choose_best_substitute(original_exercise_id, candidate_ids, exercise_map, av
             continue
 
         equipment_type = str(candidate_meta.get("equipment_type", "")).strip()
-        allowed = (not equipment_type) or bool(available_equipment.get(equipment_type, True))
+        allowed = is_plan_equipment_available(equipment_type, available_equipment)
         if not allowed:
             continue
 
@@ -3646,7 +3657,7 @@ def build_strength_plan(programs, exercises, latest_strength, time_budget_min, f
             filtered_exercises.append(ex)
             continue
 
-        allowed = bool(available_equipment.get(equipment_type, True)) if equipment_type else True
+        allowed = is_plan_equipment_available(equipment_type, available_equipment)
         if allowed and not local_blocked:
             filtered_exercises.append(ex)
             continue
@@ -7754,7 +7765,7 @@ def is_candidate_allowed_for_local_adjustment(candidate_id, exercise_map, availa
         return False, [], []
 
     equipment_type = str(candidate_meta.get("equipment_type", "")).strip()
-    allowed = (not equipment_type) or bool(available_equipment.get(equipment_type, True))
+    allowed = is_plan_equipment_available(equipment_type, available_equipment)
     if not allowed:
         return False, [], []
 

--- a/tests/test_strength_plan_equipment_filter_contract.py
+++ b/tests/test_strength_plan_equipment_filter_contract.py
@@ -1,0 +1,101 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "app/backend"))
+
+import app
+
+
+def test_strength_plan_does_not_allow_loaded_exercises_when_equipment_is_missing():
+    programs = [
+        {
+            "id": "test_minimal_home_strength",
+            "kind": "strength",
+            "days": [
+                {
+                    "label": "Dag A",
+                    "exercises": [
+                        {"exercise_id": "squat", "sets": 3, "reps": "6-8"},
+                        {"exercise_id": "incline_push_ups", "sets": 3, "reps": "6-10"},
+                        {"exercise_id": "dumbbell_row", "sets": 3, "reps": "8-12"},
+                    ],
+                }
+            ],
+        }
+    ]
+
+    exercises = [
+        {
+            "id": "squat",
+            "equipment_type": "barbell",
+            "supports_bodyweight": False,
+            "input_kind": "load_reps",
+            "default_unit": "kg",
+            "start_weight": 50,
+            "movement_pattern": "squat",
+        },
+        {
+            "id": "incline_push_ups",
+            "equipment_type": "bodyweight",
+            "supports_bodyweight": True,
+            "input_kind": "bodyweight_reps",
+            "default_unit": "reps",
+            "start_weight": 0,
+            "movement_pattern": "push",
+        },
+        {
+            "id": "dumbbell_row",
+            "equipment_type": "dumbbell",
+            "supports_bodyweight": False,
+            "input_kind": "load_reps",
+            "default_unit": "kg",
+            "start_weight": 10,
+            "movement_pattern": "pull",
+        },
+    ]
+
+    user_settings = {
+        "available_equipment": {},
+        "preferences": {
+            "training_types": {
+                "bodyweight": True,
+                "strength_weights": False,
+                "running": False,
+                "mobility": False,
+            }
+        },
+    }
+
+    result = app.build_strength_plan(
+        programs=programs,
+        exercises=exercises,
+        latest_strength={},
+        time_budget_min=30,
+        fatigue_score=0,
+        user_settings=user_settings,
+        user_id=None,
+        selected_program_id="test_minimal_home_strength",
+    )
+
+    entries = result["plan_entries"]
+    assert [entry["exercise_id"] for entry in entries] == ["incline_push_ups"], result
+
+    bodyweight_entry = entries[0]
+    assert bodyweight_entry["target_load"] is None, bodyweight_entry
+    assert bodyweight_entry["recommended_next_load"] is None, bodyweight_entry
+    assert bodyweight_entry["actual_possible_next_load"] is None, bodyweight_entry
+    assert bodyweight_entry["equipment_constraint"] is False, bodyweight_entry
+
+    excluded_types = {
+        item["equipment_type"]
+        for item in result["excluded_due_to_equipment"]
+    }
+    assert excluded_types == {"barbell", "dumbbell"}, result
+
+
+def test_bodyweight_equipment_is_allowed_even_without_equipment_map():
+    assert app.is_plan_equipment_available("bodyweight", {}) is True
+    assert app.is_plan_equipment_available("", {}) is True
+    assert app.is_plan_equipment_available("barbell", {}) is False
+    assert app.is_plan_equipment_available("dumbbell", {"dumbbell": True}) is True


### PR DESCRIPTION
Summary:
- Adds a shared backend helper for Today Plan equipment availability.
- Treats missing loaded equipment as unavailable instead of allowed.
- Keeps bodyweight exercises available without an equipment map.
- Adds regression coverage for issue 794.

Scope:
- Backend Today Plan equipment filtering only.
- Regression test only.
- No frontend changes.
- No data model changes.
- No proxy changes.

Validation:
- python3 -m py_compile app/backend/app.py
- .venv/bin/python -m pytest tests/test_strength_plan_equipment_filter_contract.py tests/test_progression_equipment_constraints.py tests/test_local_protection_scenarios.py -q
- Result: 9 passed

Closes #794.