### PR TITLE
Fix bodyweight progression display because visible load should be hidden

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -1590,6 +1590,19 @@ def is_plan_equipment_available(equipment_type, available_equipment):
     return bool(available_equipment.get(equipment_key, False))
 
 
+def should_hide_visible_load_progression(exercise_meta):
+    meta = exercise_meta if isinstance(exercise_meta, dict) else {}
+    equipment_type = str(meta.get("equipment_type", "")).strip().lower()
+    input_kind = str(meta.get("input_kind", "")).strip().lower()
+    if equipment_type == "bodyweight":
+        return True
+    if input_kind in ("bodyweight_reps", "time"):
+        return True
+    if bool(meta.get("supports_bodyweight", False)) and bool(meta.get("load_optional", False)):
+        return True
+    return False
+
+
 def choose_best_substitute(original_exercise_id, candidate_ids, exercise_map, available_equipment, local_state=None, exercises=None):
     original_meta = exercise_map.get(original_exercise_id, {}) or {}
     original_pattern = str(original_meta.get("movement_pattern", "")).strip()
@@ -3819,18 +3832,22 @@ def build_strength_plan(programs, exercises, latest_strength, time_budget_min, f
                 else f"history anchored to {progression_history_exercise_id}"
             )
 
+        hide_visible_load_progression = should_hide_visible_load_progression(meta)
         result_entry = {
             "exercise_id": exercise_id,
             "sets": sets,
             "target_reps": reps,
-            "target_load": target_load,
+            "target_load": None if hide_visible_load_progression else target_load,
             "progression_decision": progression.get("progression_decision", "hold"),
             "progression_reason": progression_reason,
-            "equipment_constraint": progression.get("equipment_constraint", False),
-            "recommended_next_load": progression.get("recommended_next_load"),
-            "actual_possible_next_load": progression.get("actual_possible_next_load"),
+            "equipment_constraint": False if hide_visible_load_progression else progression.get("equipment_constraint", False),
+            "recommended_next_load": None if hide_visible_load_progression else progression.get("recommended_next_load"),
+            "actual_possible_next_load": None if hide_visible_load_progression else progression.get("actual_possible_next_load"),
             "next_target_reps": progression.get("next_target_reps"),
-            "secondary_constraints": progression.get("secondary_constraints", []),
+            "secondary_constraints": [
+                item for item in (progression.get("secondary_constraints", []) or [])
+                if not hide_visible_load_progression or item != "equipment_constraint"
+            ],
             "substituted_from": substituted_from,
             "progression_history_exercise_id": progression_history_exercise_id,
             "local_regression_reason": ex.get("_local_regression_reason"),

--- a/tests/test_strength_plan_bodyweight_visible_load_contract.py
+++ b/tests/test_strength_plan_bodyweight_visible_load_contract.py
@@ -1,0 +1,100 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "app/backend"))
+
+import app
+
+
+def test_bodyweight_substitute_hides_visible_load_progression_from_loaded_history(monkeypatch):
+    programs = [
+        {
+            "id": "test_substitution_strength",
+            "kind": "strength",
+            "days": [
+                {
+                    "label": "Dag A",
+                    "exercises": [
+                        {"exercise_id": "squat", "sets": 3, "reps": "6-8"},
+                    ],
+                }
+            ],
+        }
+    ]
+
+    exercises = [
+        {
+            "id": "squat",
+            "equipment_type": "barbell",
+            "supports_bodyweight": False,
+            "input_kind": "load_reps",
+            "default_unit": "kg",
+            "start_weight": 50,
+            "movement_pattern": "squat",
+        },
+        {
+            "id": "split_squat",
+            "equipment_type": "bodyweight",
+            "supports_bodyweight": True,
+            "input_kind": "bodyweight_reps",
+            "default_unit": "reps",
+            "start_weight": 0,
+            "movement_pattern": "squat",
+        },
+    ]
+
+    def fake_substitutes(*args, **kwargs):
+        return {"candidate_ids": ["split_squat"]}
+
+    def fake_progression(*args, **kwargs):
+        return {
+            "next_load": 60,
+            "progression_decision": "increase",
+            "progression_reason": "loaded history",
+            "equipment_constraint": True,
+            "recommended_next_load": 52.5,
+            "actual_possible_next_load": 60.0,
+            "next_target_reps": None,
+            "secondary_constraints": ["equipment_constraint"],
+        }
+
+    monkeypatch.setattr(app, "get_local_substitute_candidates", fake_substitutes)
+    monkeypatch.setattr(app, "compute_progression_for_exercise", fake_progression)
+
+    result = app.build_strength_plan(
+        programs=programs,
+        exercises=exercises,
+        latest_strength={},
+        time_budget_min=30,
+        fatigue_score=0,
+        user_settings={"available_equipment": {}},
+        user_id=None,
+        selected_program_id="test_substitution_strength",
+    )
+
+    entries = result["plan_entries"]
+    assert len(entries) == 1, result
+
+    entry = entries[0]
+    assert entry["exercise_id"] == "split_squat", entry
+    assert entry["substituted_from"] == "squat", entry
+    assert entry["target_load"] is None, entry
+    assert entry["recommended_next_load"] is None, entry
+    assert entry["actual_possible_next_load"] is None, entry
+    assert entry["equipment_constraint"] is False, entry
+    assert "equipment_constraint" not in entry["secondary_constraints"], entry
+
+
+def test_visible_load_progression_hidden_for_bodyweight_like_metadata():
+    assert app.should_hide_visible_load_progression({"equipment_type": "bodyweight"}) is True
+    assert app.should_hide_visible_load_progression({"input_kind": "bodyweight_reps"}) is True
+    assert app.should_hide_visible_load_progression({"input_kind": "time"}) is True
+    assert app.should_hide_visible_load_progression({
+        "supports_bodyweight": True,
+        "load_optional": True,
+    }) is True
+    assert app.should_hide_visible_load_progression({
+        "equipment_type": "barbell",
+        "input_kind": "load_reps",
+    }) is False


### PR DESCRIPTION
## Summary

- Hides visible load progression fields for bodyweight-like strength entries.
- Keeps loaded progression internal while preventing Today Plan from showing kg recommendations for bodyweight substitutes.
- Removes visible equipment constraint state for bodyweight-like entries.
- Adds regression coverage for issue #794.

## Scope

- Backend Today Plan strength payload only
- Regression test only
- No frontend changes
- No data model changes
- No proxy changes

## Validation

- `python3 -m py_compile app/backend/app.py`
- `.venv/bin/python -m pytest tests/test_strength_plan_bodyweight_visible_load_contract.py tests/test_strength_plan_equipment_filter_contract.py tests/test_progression_equipment_constraints.py tests/test_local_protection_scenarios.py -q`

Result:

- `11 passed`

Fixes #794.