### PR TITLE
Fix Danish cardio target translations

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -4147,13 +4147,30 @@ function formatTarget(value){
     "30 min roligt løb i snakketempo": tr("cardio.target.base_30_talk"),
     "30 min easy run at conversational pace": tr("cardio.target.base_30_talk"),
     "20 min rolig gang eller meget let jog": tr("cardio.target.easy_walk_or_jog_20"),
-    "20 min easy walk or very light jog": tr("cardio.target.easy_walk_or_jog_20")
+    "20 min easy walk or very light jog": tr("cardio.target.easy_walk_or_jog_20"),
+    "10 min warm-up + 2 x 8 min controlled hard tempo + 2 min easy between + 5 min cool-down": tr("cardio.target.tempo_2x8"),
+    "10 min opvarmning + 2 x 8 min kontrolleret hårdt tempo + 2 min roligt imellem + 5 min nedkøling": tr("cardio.target.tempo_2x8")
   };
   if (mappedTargets[v]) return mappedTargets[v];
 
   const easyRunMatch = v.match(/^(\d+)\s*min\s*roligt løb i snakketempo$/i);
   if (easyRunMatch){
     return tr("cardio.target.base_talk_variable", { minutes: easyRunMatch[1] });
+  }
+
+  const easyRunEnglishMatch = v.match(/^(\d+)\s*min\s*easy run at conversational pace$/i);
+  if (easyRunEnglishMatch){
+    return tr("cardio.target.base_talk_variable", { minutes: easyRunEnglishMatch[1] });
+  }
+
+  const intervalRunEnglishMatch = v.match(/^10\s*min\s*warm-up\s*\+\s*(\d+)x\(1\s*min\s*fast\s*\/\s*1\s*min\s*easy\)\s*\+\s*5\s*min\s*cool-down$/i);
+  if (intervalRunEnglishMatch){
+    return tr("cardio.target.intervals_1min_blocks", { blocks: intervalRunEnglishMatch[1] });
+  }
+
+  const intervalRunDanishMatch = v.match(/^10\s*min\s*opvarmning\s*\+\s*(\d+)x\(1\s*min\s*hurtigt\s*\/\s*1\s*min\s*roligt\)\s*\+\s*5\s*min\s*nedkøling$/i);
+  if (intervalRunDanishMatch){
+    return tr("cardio.target.intervals_1min_blocks", { blocks: intervalRunDanishMatch[1] });
   }
 
   const easyWalkMatch = v.match(/^(\d+)\s*min\s*rolig gang eller meget let jog$/i);

--- a/app/frontend/i18n/da.json
+++ b/app/frontend/i18n/da.json
@@ -340,6 +340,8 @@
   "review.rpe_help_long": "RPE = hvor hårdt passet føltes fra 1 til 10. 1-3 meget let, 4-5 roligt, 6-7 hårdt, 8-9 meget hårdt, 10 maks.",
   "cardio.target.base_30_talk": "30 min roligt løb i snakketempo",
   "cardio.target.easy_walk_or_jog_20": "20 min rolig gang eller meget let jog",
+  "cardio.target.tempo_2x8": "10 min opvarmning + 2 x 8 min kontrolleret hårdt tempo + 2 min roligt imellem + 5 min nedkøling",
+  "cardio.target.intervals_1min_blocks": "10 min opvarmning + {blocks} x (1 min hurtigt / 1 min roligt) + 5 min nedkøling",
   "recovery.explanation.good_sleep": "god søvn",
   "recovery.explanation.good_energy": "god energi",
   "recovery.explanation.low_soreness": "lav ømhed",

--- a/app/frontend/i18n/en.json
+++ b/app/frontend/i18n/en.json
@@ -327,6 +327,8 @@
   "review.rpe_help_long": "RPE = how hard the session felt from 1 to 10. 1-3 very easy, 4-5 easy, 6-7 hard, 8-9 very hard, 10 max.",
   "cardio.target.base_30_talk": "30 min easy run at conversational pace",
   "cardio.target.easy_walk_or_jog_20": "20 min easy walk or very light jog",
+  "cardio.target.tempo_2x8": "10 min warm-up + 2 x 8 min controlled hard tempo + 2 min easy between + 5 min cool-down",
+  "cardio.target.intervals_1min_blocks": "10 min warm-up + {blocks} x (1 min fast / 1 min easy) + 5 min cool-down",
   "recovery.explanation.good_sleep": "good sleep",
   "recovery.explanation.good_energy": "good energy",
   "recovery.explanation.low_soreness": "low soreness",

--- a/tests/test_cardio_target_i18n_contract.py
+++ b/tests/test_cardio_target_i18n_contract.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = ROOT / "app/frontend/app.js"
+DA = ROOT / "app/frontend/i18n/da.json"
+EN = ROOT / "app/frontend/i18n/en.json"
+
+
+def test_format_target_translates_backend_cardio_targets():
+    js = APP_JS.read_text(encoding="utf-8")
+
+    assert "10 min warm-up + 2 x 8 min controlled hard tempo + 2 min easy between + 5 min cool-down" in js
+    assert 'tr("cardio.target.tempo_2x8")' in js
+    assert "easyRunEnglishMatch" in js
+    assert "intervalRunEnglishMatch" in js
+    assert 'tr("cardio.target.intervals_1min_blocks", { blocks: intervalRunEnglishMatch[1] })' in js
+
+
+def test_cardio_target_i18n_keys_exist_in_da_and_en():
+    da = DA.read_text(encoding="utf-8")
+    en = EN.read_text(encoding="utf-8")
+
+    assert '"cardio.target.tempo_2x8"' in da
+    assert '"cardio.target.tempo_2x8"' in en
+    assert '"cardio.target.intervals_1min_blocks"' in da
+    assert '"cardio.target.intervals_1min_blocks"' in en
+    assert "kontrolleret hårdt tempo" in da
+    assert "controlled hard tempo" in en
+    assert "{blocks} x (1 min hurtigt / 1 min roligt)" in da
+    assert "{blocks} x (1 min fast / 1 min easy)" in en


### PR DESCRIPTION
Summary:
- Translates backend cardio target strings in Today Plan.
- Adds Danish and English i18n keys for tempo and interval targets.
- Adds regression coverage for issue 792.

Scope:
- Frontend target formatting only.
- i18n only.
- Regression test only.
- No backend changes.
- No data model changes.
- No proxy changes.

Validation:
- node --check app/frontend/app.js
- python3 -m json.tool app/frontend/i18n/da.json
- python3 -m json.tool app/frontend/i18n/en.json
- .venv/bin/python -m pytest tests/test_cardio_target_i18n_contract.py -q
- Result: 2 passed

Fixes #792.