### PR TITLE
Fix load increment precedence for equipment settings

### DIFF
--- a/app/backend/progression_engine.py
+++ b/app/backend/progression_engine.py
@@ -6,15 +6,6 @@ def get_effective_load_increment(exercise, user_settings):
     if not isinstance(user_settings, dict):
         user_settings = {}
 
-    load_increment = exercise.get("load_increment", None)
-    try:
-        if load_increment is not None:
-            load_increment = float(load_increment)
-            if load_increment >= 0:
-                return load_increment
-    except Exception:
-        pass
-
     equipment_type = str(exercise.get("equipment_type", "")).strip()
     increments = user_settings.get("equipment_increments", {})
     if equipment_type and isinstance(increments, dict):
@@ -26,6 +17,15 @@ def get_effective_load_increment(exercise, user_settings):
                     return val
         except Exception:
             pass
+
+    load_increment = exercise.get("load_increment", None)
+    try:
+        if load_increment is not None:
+            load_increment = float(load_increment)
+            if load_increment >= 0:
+                return load_increment
+    except Exception:
+        pass
 
     try:
         step = exercise.get("progression_step", 0)

--- a/tests/test_effective_load_increment_contract.py
+++ b/tests/test_effective_load_increment_contract.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "app/backend"))
+
+from progression_engine import get_effective_load_increment
+
+
+def test_equipment_increment_overrides_exercise_default_increment():
+    exercise = {
+        "id": "squat",
+        "equipment_type": "barbell",
+        "load_increment": 10,
+        "progression_step": 10,
+    }
+    user_settings = {
+        "equipment_increments": {
+            "barbell": 2.5,
+        }
+    }
+
+    assert get_effective_load_increment(exercise, user_settings) == 2.5
+
+
+def test_exercise_default_increment_is_used_when_user_equipment_increment_is_missing():
+    exercise = {
+        "id": "squat",
+        "equipment_type": "barbell",
+        "load_increment": 10,
+        "progression_step": 10,
+    }
+    user_settings = {
+        "equipment_increments": {},
+    }
+
+    assert get_effective_load_increment(exercise, user_settings) == 10.0
+
+
+def test_progression_step_is_used_when_no_equipment_or_exercise_increment_exists():
+    exercise = {
+        "id": "custom_bodyweight",
+        "progression_step": 3,
+    }
+    user_settings = {
+        "equipment_increments": {},
+    }
+
+    assert get_effective_load_increment(exercise, user_settings) == 3.0


### PR DESCRIPTION
Summary:
- Changes load increment resolution so user equipment increments override exercise defaults.
- Keeps exercise load_increment as fallback when no user equipment increment exists.
- Keeps progression_step as final fallback.
- Adds regression coverage for issue 798.

Scope:
- Backend progression increment resolution only.
- Regression test only.
- No frontend changes.
- No data model changes.
- No proxy changes.

Validation:
- python3 -m py_compile app/backend/progression_engine.py app/backend/app.py
- .venv/bin/python -m pytest tests/test_effective_load_increment_contract.py tests/test_progression_equipment_constraints.py tests/test_local_protection_scenarios.py tests/test_strength_plan_bodyweight_visible_load_contract.py tests/test_strength_plan_equipment_filter_contract.py -q
- Result: 14 passed

Fixes #798.